### PR TITLE
Delete all plugin options on uninstall

### DIFF
--- a/visi-bloc-jlg/uninstall.php
+++ b/visi-bloc-jlg/uninstall.php
@@ -5,3 +5,4 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) { exit; }
 delete_option( 'visibloc_debug_mode' );
 delete_option( 'visibloc_breakpoint_mobile' );
 delete_option( 'visibloc_breakpoint_tablet' );
+delete_option( 'visibloc_preview_roles' );


### PR DESCRIPTION
## Summary
- Ensure plugin cleanup by deleting `visibloc_preview_roles` option during uninstall

## Testing
- `php -l uninstall.php`


------
https://chatgpt.com/codex/tasks/task_e_68c743915b98832e94950d4ea99c0bb4