### PR TITLE
Delete visibloc_preview_roles option on uninstall

### DIFF
--- a/visi-bloc-jlg/uninstall.php
+++ b/visi-bloc-jlg/uninstall.php
@@ -5,3 +5,4 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) { exit; }
 delete_option( 'visibloc_debug_mode' );
 delete_option( 'visibloc_breakpoint_mobile' );
 delete_option( 'visibloc_breakpoint_tablet' );
+delete_option( 'visibloc_preview_roles' );


### PR DESCRIPTION
## Summary
- ensure `visibloc_preview_roles` option is deleted during plugin uninstall

## Testing
- `php -l visi-bloc-jlg/uninstall.php`
- `php -r "define('WP_UNINSTALL_PLUGIN', true); $options=['visibloc_debug_mode'=>1,'visibloc_breakpoint_mobile'=>1,'visibloc_breakpoint_tablet'=>1,'visibloc_preview_roles'=>1]; function delete_option($name){global $options; unset($options[$name]);} include 'visi-bloc-jlg/uninstall.php'; var_export($options);"`


------
https://chatgpt.com/codex/tasks/task_e_68c7c593e6a8832ea1c60fa760fd330a