### PR TITLE
Fix scheduled post end date attribute usage

### DIFF
--- a/visi-bloc-jlg/includes/admin-settings.php
+++ b/visi-bloc-jlg/includes/admin-settings.php
@@ -155,7 +155,7 @@ function visibloc_jlg_get_device_specific_posts() {
 
 function visibloc_jlg_get_scheduled_posts() {
     $posts = visibloc_jlg_get_posts_with_condition( function( $block ) {
-        return ( isset($block['blockName']) && $block['blockName'] === 'core/group' && ! empty( $block['attrs']['isSchedulingEnabled'] ) && ( ! empty( $block['attrs']['publishStartDate'] ) || ! empty( $attrs['publishEndDate'] ) ) );
+        return ( isset($block['blockName']) && $block['blockName'] === 'core/group' && ! empty( $block['attrs']['isSchedulingEnabled'] ) && ( ! empty( $block['attrs']['publishStartDate'] ) || ! empty( $block['attrs']['publishEndDate'] ) ) );
     });
     $formatted_posts = [];
     foreach($posts as $post) {


### PR DESCRIPTION
## Summary
- Fix scheduled post detection by referencing publishEndDate in block attributes

## Testing
- `php -l includes/admin-settings.php`


------
https://chatgpt.com/codex/tasks/task_e_68c80e343cc8832ebcdcf7f70c65d234