### PR TITLE
Protect role switcher with nonces

### DIFF
--- a/visi-bloc-jlg/includes/role-switcher.php
+++ b/visi-bloc-jlg/includes/role-switcher.php
@@ -9,7 +9,11 @@ function visibloc_jlg_handle_role_switching() {
     if ( ! $real_user || ! in_array( 'administrator', (array) $real_user->roles ) ) { return; }
     $cookie_name = 'visibloc_preview_role';
     if ( isset( $_GET['preview_role'] ) ) {
-        $role_to_preview = sanitize_key( $_GET['preview_role'] );
+        $role_to_preview = sanitize_key( wp_unslash( $_GET['preview_role'] ) );
+        $nonce = isset( $_GET['_wpnonce'] ) ? sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ) : '';
+        if ( ! $role_to_preview || ! $nonce || ! wp_verify_nonce( $nonce, 'visibloc_switch_role_' . $role_to_preview ) ) {
+            return;
+        }
         setcookie( $cookie_name, $role_to_preview, [
             'expires'  => time() + 3600,
             'path'     => COOKIEPATH,
@@ -18,10 +22,14 @@ function visibloc_jlg_handle_role_switching() {
             'httponly' => true,
             'samesite' => 'Lax',
         ] );
-        wp_redirect( remove_query_arg( 'preview_role' ) );
+        wp_redirect( remove_query_arg( [ 'preview_role', '_wpnonce' ] ) );
         exit;
     }
     if ( isset( $_GET['stop_preview_role'] ) ) {
+        $nonce = isset( $_GET['_wpnonce'] ) ? sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ) : '';
+        if ( ! $nonce || ! wp_verify_nonce( $nonce, 'visibloc_switch_role_stop' ) ) {
+            return;
+        }
         setcookie( $cookie_name, '', [
             'expires'  => time() - 3600,
             'path'     => COOKIEPATH,
@@ -30,7 +38,7 @@ function visibloc_jlg_handle_role_switching() {
             'httponly' => true,
             'samesite' => 'Lax',
         ] );
-        wp_redirect( remove_query_arg( 'stop_preview_role' ) );
+        wp_redirect( remove_query_arg( [ 'stop_preview_role', '_wpnonce' ] ) );
         exit;
     }
 }
@@ -44,16 +52,23 @@ function visibloc_jlg_add_role_switcher_menu( $wp_admin_bar ) {
     if ( ! function_exists( 'get_editable_roles' ) ) { require_once ABSPATH . 'wp-admin/includes/user.php'; }
     $cookie_name = 'visibloc_preview_role';
     $current_preview_role = isset( $_COOKIE[$cookie_name] ) ? sanitize_key( $_COOKIE[$cookie_name] ) : null;
+    $base_url = remove_query_arg( [ 'preview_role', 'stop_preview_role', '_wpnonce' ] );
     if ( $current_preview_role ) {
         $role_names = wp_roles()->get_names();
         $display_name = $current_preview_role === 'guest' ? 'Visiteur (Déconnecté)' : ($role_names[$current_preview_role] ?? ucfirst($current_preview_role));
         $wp_admin_bar->add_node(['id' => 'visibloc-alert', 'title' => '⚠️ Aperçu : ' . esc_html( $display_name ), 'href' => '#', 'meta' => ['style' => 'background-color: #d54e21 !important;']]);
-        $wp_admin_bar->add_node(['id' => 'visibloc-stop-preview', 'title' => '✅ Retour à ma vue', 'href' => add_query_arg( 'stop_preview_role', 'true' ), 'parent' => 'top-secondary']);
+        $stop_preview_url = add_query_arg( 'stop_preview_role', 'true', $base_url );
+        $stop_preview_url = wp_nonce_url( $stop_preview_url, 'visibloc_switch_role_stop' );
+        $wp_admin_bar->add_node(['id' => 'visibloc-stop-preview', 'title' => '✅ Retour à ma vue', 'href' => $stop_preview_url, 'parent' => 'top-secondary']);
     }
     $wp_admin_bar->add_node(['id' => 'visibloc-role-switcher', 'title' => '<span class="ab-icon dashicons-groups"></span>Aperçu en tant que', 'href' => '#']);
-    $wp_admin_bar->add_node(['id' => 'visibloc-role-guest', 'title' => 'Visiteur (Déconnecté)', 'href' => add_query_arg( 'preview_role', 'guest' ), 'parent' => 'visibloc-role-switcher']);
+    $guest_preview_url = add_query_arg( 'preview_role', 'guest', $base_url );
+    $guest_preview_url = wp_nonce_url( $guest_preview_url, 'visibloc_switch_role_guest' );
+    $wp_admin_bar->add_node(['id' => 'visibloc-role-guest', 'title' => 'Visiteur (Déconnecté)', 'href' => $guest_preview_url, 'parent' => 'visibloc-role-switcher']);
     foreach ( get_editable_roles() as $slug => $details ) {
-        $wp_admin_bar->add_node(['id' => 'visibloc-role-' . $slug, 'title' => $details['name'], 'href' => add_query_arg( 'preview_role', $slug ), 'parent' => 'visibloc-role-switcher']);
+        $preview_url = add_query_arg( 'preview_role', $slug, $base_url );
+        $preview_url = wp_nonce_url( $preview_url, 'visibloc_switch_role_' . $slug );
+        $wp_admin_bar->add_node(['id' => 'visibloc-role-' . $slug, 'title' => $details['name'], 'href' => $preview_url, 'parent' => 'visibloc-role-switcher']);
     }
 }
 


### PR DESCRIPTION
## Summary
- wrap role switcher menu URLs with wp_nonce_url to add a nonce parameter
- verify the nonce before setting or clearing the preview role cookie during role switching

## Testing
- php -l visi-bloc-jlg/includes/role-switcher.php

------
https://chatgpt.com/codex/tasks/task_e_68c8483d8a08832e873ead2faa4253f7