### PR TITLE
Optimize admin queries for large sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,9 @@ No additional build step is required for normal installation. To modify the sour
 npm install
 npm run build
 ```
+
+## Performance considerations
+
+The "Visi-Bloc - JLG" administration screen paginates the internal queries in batches of 100 post IDs and caches the compiled
+results for an hour. This keeps memory usage low, but on very large sites the first load after the cache expires may still take a
+little longer while the plugin analyses the content library.


### PR DESCRIPTION
## Summary
- limit the admin scan queries to fetch only post IDs and skip unnecessary caches to reduce memory usage
- reuse the paginated loop to parse only posts that contain Gutenberg blocks before collecting visibility data
- document the performance characteristics of the admin dashboard on very large sites

## Testing
- php -l visi-bloc-jlg/includes/admin-settings.php

------
https://chatgpt.com/codex/tasks/task_e_68c848435954832e853f24e6730d4f74