### PR TITLE
Sanitize admin settings POST data

### DIFF
--- a/visi-bloc-jlg/includes/admin-settings.php
+++ b/visi-bloc-jlg/includes/admin-settings.php
@@ -4,23 +4,25 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 add_action( 'admin_init', 'visibloc_jlg_handle_options_save' );
 function visibloc_jlg_handle_options_save() {
     if ( ! isset( $_POST['visibloc_nonce'] ) || ! current_user_can( 'manage_options' ) ) return;
-    
-    if ( wp_verify_nonce( $_POST['visibloc_nonce'], 'visibloc_toggle_debug' ) ) {
+
+    $nonce = sanitize_text_field( wp_unslash( $_POST['visibloc_nonce'] ) );
+
+    if ( wp_verify_nonce( $nonce, 'visibloc_toggle_debug' ) ) {
         $current_status = get_option( 'visibloc_debug_mode', 'off' );
         update_option( 'visibloc_debug_mode', ( $current_status === 'on' ) ? 'off' : 'on' );
         wp_redirect( admin_url( 'admin.php?page=visi-bloc-jlg-help&status=updated' ) );
         exit;
     }
-    
-    if ( wp_verify_nonce( $_POST['visibloc_nonce'], 'visibloc_save_breakpoints' ) ) {
-        if ( isset( $_POST['visibloc_breakpoint_mobile'] ) ) update_option( 'visibloc_breakpoint_mobile', intval( $_POST['visibloc_breakpoint_mobile'] ) );
-        if ( isset( $_POST['visibloc_breakpoint_tablet'] ) ) update_option( 'visibloc_breakpoint_tablet', intval( $_POST['visibloc_breakpoint_tablet'] ) );
+
+    if ( wp_verify_nonce( $nonce, 'visibloc_save_breakpoints' ) ) {
+        if ( isset( $_POST['visibloc_breakpoint_mobile'] ) ) update_option( 'visibloc_breakpoint_mobile', absint( wp_unslash( $_POST['visibloc_breakpoint_mobile'] ) ) );
+        if ( isset( $_POST['visibloc_breakpoint_tablet'] ) ) update_option( 'visibloc_breakpoint_tablet', absint( wp_unslash( $_POST['visibloc_breakpoint_tablet'] ) ) );
         wp_redirect( admin_url( 'admin.php?page=visi-bloc-jlg-help&status=updated' ) );
         exit;
     }
 
-    if ( wp_verify_nonce( $_POST['visibloc_nonce'], 'visibloc_save_permissions' ) ) {
-        $submitted_roles = $_POST['visibloc_preview_roles'] ?? [];
+    if ( wp_verify_nonce( $nonce, 'visibloc_save_permissions' ) ) {
+        $submitted_roles = isset( $_POST['visibloc_preview_roles'] ) ? wp_unslash( $_POST['visibloc_preview_roles'] ) : [];
         $sanitized_roles = array_map( 'sanitize_key', (array) $submitted_roles );
         // On s'assure que l'administrateur est toujours inclus
         if ( ! in_array( 'administrator', $sanitized_roles ) ) {


### PR DESCRIPTION
## Summary
- sanitize the visibloc nonce via wp_unslash and sanitize_text_field before verifying
- unslash and sanitize breakpoint inputs and preview roles before saving options

## Testing
- php -l visi-bloc-jlg/includes/admin-settings.php

------
https://chatgpt.com/codex/tasks/task_e_68c85ce75b4c832eb30881a78b908e19