### PR TITLE
Clear cached transients on uninstall

### DIFF
--- a/visi-bloc-jlg/uninstall.php
+++ b/visi-bloc-jlg/uninstall.php
@@ -6,3 +6,8 @@ delete_option( 'visibloc_debug_mode' );
 delete_option( 'visibloc_breakpoint_mobile' );
 delete_option( 'visibloc_breakpoint_tablet' );
 delete_option( 'visibloc_preview_roles' );
+
+// Supprime les transients de cache du plugin
+delete_transient( 'visibloc_hidden_posts' );
+delete_transient( 'visibloc_device_posts' );
+delete_transient( 'visibloc_scheduled_posts' );


### PR DESCRIPTION
## Summary
- delete the plugin's cached transients when uninstalling to remove stored post data

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c86560f0f0832ea70d91937e2f4b5b