### PR TITLE
Fix year format for scheduled block dates

### DIFF
--- a/visi-bloc-jlg/includes/visibility-logic.php
+++ b/visi-bloc-jlg/includes/visibility-logic.php
@@ -15,8 +15,8 @@ function visibloc_jlg_render_block_filter( $block_content, $block ) {
         $is_after_end = $end_time && $current_time > $end_time;
         if ( $is_before_start || $is_after_end ) {
             if ( $can_preview ) {
-                $start_date_fr = $start_time ? wp_date( 'd/m/y H:i', $start_time ) : 'N/A';
-                $end_date_fr = $end_time ? wp_date( 'd/m/y H:i', $end_time ) : 'N/A';
+                $start_date_fr = $start_time ? wp_date( 'd/m/Y H:i', $start_time ) : 'N/A';
+                $end_date_fr = $end_time ? wp_date( 'd/m/Y H:i', $end_time ) : 'N/A';
                 $info = "Programmé (Début:{$start_date_fr} | Fin:{$end_date_fr})";
                 return '<div class="bloc-schedule-apercu" data-schedule-info="' . esc_attr($info) . '">' . $block_content . '</div>';
             }


### PR DESCRIPTION
## Summary
- update the scheduled block preview to use a four-digit year when formatting dates

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8656706dc832e8a5c5b6b9bb08fbe