### PR TITLE
Cast visibloc preview roles option to array

### DIFF
--- a/visi-bloc-jlg/visi-bloc-jlg.php
+++ b/visi-bloc-jlg/visi-bloc-jlg.php
@@ -25,8 +25,8 @@ function visibloc_jlg_can_user_preview() {
     }
 
     // Récupère les rôles autorisés depuis les options, avec 'administrator' comme valeur par défaut sécurisée.
-    $allowed_roles = get_option( 'visibloc_preview_roles', ['administrator'] );
-    
+    $allowed_roles = (array) get_option( 'visibloc_preview_roles', ['administrator'] );
+
     // Si pour une raison quelconque l'option est vide, on sécurise en autorisant uniquement l'admin.
     if ( empty( $allowed_roles ) ) {
         $allowed_roles = ['administrator'];


### PR DESCRIPTION
## Summary
- cast the stored preview roles option to an array before use so user roles are compared consistently
- maintain the administrator fallback when the retrieved roles array is empty

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c878d2c0c0832ebba866b0a0a77ee7