### PR TITLE
Localize admin strings

### DIFF
--- a/visi-bloc-jlg/includes/admin-settings.php
+++ b/visi-bloc-jlg/includes/admin-settings.php
@@ -52,7 +52,15 @@ function visibloc_jlg_handle_options_save() {
 
 add_action( 'admin_menu', 'visibloc_jlg_add_admin_menu' );
 function visibloc_jlg_add_admin_menu() {
-    add_menu_page( 'Aide & Réglages Visi-Bloc - JLG', 'Visi-Bloc - JLG', 'manage_options', 'visi-bloc-jlg-help', 'visibloc_jlg_render_help_page_content', 'dashicons-visibility', 25 );
+    add_menu_page(
+        __( 'Aide & Réglages Visi-Bloc - JLG', 'visi-bloc-jlg' ),
+        __( 'Visi-Bloc - JLG', 'visi-bloc-jlg' ),
+        'manage_options',
+        'visi-bloc-jlg-help',
+        'visibloc_jlg_render_help_page_content',
+        'dashicons-visibility',
+        25
+    );
 }
 
 function visibloc_jlg_render_help_page_content() {
@@ -70,14 +78,14 @@ function visibloc_jlg_render_help_page_content() {
     <div class="wrap">
         <h1><?php esc_html_e( 'Visi-Bloc - JLG - Aide et Réglages', 'visi-bloc-jlg' ); ?></h1>
         <?php if ( 'updated' === $status ) : ?>
-            <div id="message" class="updated notice is-dismissible"><p>Réglages mis à jour.</p></div>
+            <div id="message" class="updated notice is-dismissible"><p><?php esc_html_e( 'Réglages mis à jour.', 'visi-bloc-jlg' ); ?></p></div>
         <?php endif; ?>
         <div id="poststuff">
             <div class="postbox">
-                <h2 class="hndle"><span>Permissions d'Aperçu</span></h2>
+                <h2 class="hndle"><span><?php esc_html_e( "Permissions d'Aperçu", 'visi-bloc-jlg' ); ?></span></h2>
                 <div class="inside">
                     <form method="POST" action="">
-                        <p>Cochez les rôles qui peuvent voir les blocs cachés/programmés sur le site public.</p>
+                        <p><?php esc_html_e( 'Cochez les rôles qui peuvent voir les blocs cachés/programmés sur le site public.', 'visi-bloc-jlg' ); ?></p>
                         <?php
                         $editable_roles = get_editable_roles();
                         foreach ( $editable_roles as $slug => $details ) :
@@ -87,39 +95,103 @@ function visibloc_jlg_render_help_page_content() {
                             <label style="display: block; margin-bottom: 5px;">
                                 <input type="checkbox" name="visibloc_preview_roles[]" value="<?php echo esc_attr( $slug ); ?>" <?php checked( $is_checked ); ?> <?php disabled( $is_disabled ); ?> />
                                 <?php echo esc_html( $details['name'] ); ?>
-                                <?php if($is_disabled) echo " (toujours activé)"; ?>
+                                <?php if ( $is_disabled ) { printf( ' %s', esc_html__( '(toujours activé)', 'visi-bloc-jlg' ) ); } ?>
                             </label>
                         <?php endforeach; ?>
                         <?php wp_nonce_field( 'visibloc_save_permissions', 'visibloc_nonce' ); ?>
-                        <?php submit_button('Enregistrer les Permissions'); ?>
+                        <?php submit_button( __( 'Enregistrer les Permissions', 'visi-bloc-jlg' ) ); ?>
                     </form>
                 </div>
             </div>
             <div class="postbox">
-                <h2 class="hndle"><span>Tableau de Bord des Blocs Masqués (via Œil)</span></h2>
+                <h2 class="hndle"><span><?php esc_html_e( 'Tableau de bord des blocs masqués (via Œil)', 'visi-bloc-jlg' ); ?></span></h2>
                 <div class="inside">
-                     <?php if ( empty( $hidden_posts ) ) : ?><p>Aucun bloc masqué manuellement n'a été trouvé.</p><?php else : ?><ul style="list-style: disc; padding-left: 20px;"><?php foreach ( $hidden_posts as $post_data ) : ?><li><a href="<?php echo esc_url( $post_data['link'] ); ?>"><?php echo esc_html( $post_data['title'] ); ?></a></li><?php endforeach; ?></ul><?php endif; ?>
+                    <?php if ( empty( $hidden_posts ) ) : ?>
+                        <p><?php esc_html_e( "Aucun bloc masqué manuellement n'a été trouvé.", 'visi-bloc-jlg' ); ?></p>
+                    <?php else : ?>
+                        <ul style="list-style: disc; padding-left: 20px;">
+                            <?php foreach ( $hidden_posts as $post_data ) : ?>
+                                <li><a href="<?php echo esc_url( $post_data['link'] ); ?>"><?php echo esc_html( $post_data['title'] ); ?></a></li>
+                            <?php endforeach; ?>
+                        </ul>
+                    <?php endif; ?>
                 </div>
             </div>
             <div class="postbox">
-                <h2 class="hndle"><span>Tableau de Bord des Blocs avec Visibilité par Appareil</span></h2>
+                <h2 class="hndle"><span><?php esc_html_e( 'Tableau de bord des blocs avec visibilité par appareil', 'visi-bloc-jlg' ); ?></span></h2>
                 <div class="inside">
-                    <?php if ( empty( $device_posts ) ) : ?><p>Aucun bloc avec une règle de visibilité par appareil n'a été trouvé.</p><?php else : ?><ul style="list-style: disc; padding-left: 20px;"><?php foreach ( $device_posts as $post_data ) : ?><li><a href="<?php echo esc_url( $post_data['link'] ); ?>"><?php echo esc_html( $post_data['title'] ); ?></a></li><?php endforeach; ?></ul><?php endif; ?>
+                    <?php if ( empty( $device_posts ) ) : ?>
+                        <p><?php esc_html_e( "Aucun bloc avec une règle de visibilité par appareil n'a été trouvé.", 'visi-bloc-jlg' ); ?></p>
+                    <?php else : ?>
+                        <ul style="list-style: disc; padding-left: 20px;">
+                            <?php foreach ( $device_posts as $post_data ) : ?>
+                                <li><a href="<?php echo esc_url( $post_data['link'] ); ?>"><?php echo esc_html( $post_data['title'] ); ?></a></li>
+                            <?php endforeach; ?>
+                        </ul>
+                    <?php endif; ?>
                 </div>
             </div>
             <div class="postbox">
-                <h2 class="hndle"><span>Tableau de Bord des Blocs Programmés</span></h2>
+                <h2 class="hndle"><span><?php esc_html_e( 'Tableau de bord des blocs programmés', 'visi-bloc-jlg' ); ?></span></h2>
                 <div class="inside">
-                    <?php if ( empty( $scheduled_posts ) ) : ?><p>Aucun bloc programmé n'a été trouvé sur votre site.</p><?php else : ?><table class="wp-list-table widefat striped"><thead><tr><th>Titre de l'Article / Modèle</th><th>Date de Début</th><th>Date de Fin</th></tr></thead><tbody><?php foreach ( $scheduled_posts as $post_data ) : ?><tr><td><a href="<?php echo esc_url( $post_data['link'] ); ?>"><?php echo esc_html( $post_data['title'] ); ?></a></td><td><?php echo $post_data['start'] ? esc_html( wp_date( 'd/m/Y H:i', strtotime($post_data['start']) ) ) : '–'; ?></td><td><?php echo $post_data['end'] ? esc_html( wp_date( 'd/m/Y H:i', strtotime($post_data['end']) ) ) : '–'; ?></td></tr><?php endforeach; ?></tbody></table><?php endif; ?>
+                    <?php if ( empty( $scheduled_posts ) ) : ?>
+                        <p><?php esc_html_e( "Aucun bloc programmé n'a été trouvé sur votre site.", 'visi-bloc-jlg' ); ?></p>
+                    <?php else : ?>
+                        <table class="wp-list-table widefat striped">
+                            <thead>
+                                <tr>
+                                    <th><?php esc_html_e( "Titre de l'article / Modèle", 'visi-bloc-jlg' ); ?></th>
+                                    <th><?php esc_html_e( 'Date de début', 'visi-bloc-jlg' ); ?></th>
+                                    <th><?php esc_html_e( 'Date de fin', 'visi-bloc-jlg' ); ?></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <?php foreach ( $scheduled_posts as $post_data ) : ?>
+                                    <tr>
+                                        <td><a href="<?php echo esc_url( $post_data['link'] ); ?>"><?php echo esc_html( $post_data['title'] ); ?></a></td>
+                                        <td><?php echo $post_data['start'] ? esc_html( wp_date( 'd/m/Y H:i', strtotime( $post_data['start'] ) ) ) : '–'; ?></td>
+                                        <td><?php echo $post_data['end'] ? esc_html( wp_date( 'd/m/Y H:i', strtotime( $post_data['end'] ) ) ) : '–'; ?></td>
+                                    </tr>
+                                <?php endforeach; ?>
+                            </tbody>
+                        </table>
+                    <?php endif; ?>
                 </div>
             </div>
              <div class="postbox">
-                <h2 class="hndle"><span>Mode de Débogage</span></h2>
-                <div class="inside"><form method="POST" action=""><p>Statut actuel : <strong><?php echo $debug_status === 'on' ? 'ACTIVÉ' : 'DÉSACTIVÉ'; ?></strong></p><input type="hidden" name="action" value="visibloc_toggle_debug"><?php wp_nonce_field( 'visibloc_toggle_debug', 'visibloc_nonce' ); ?><button type="submit" class="button button-primary"><?php echo $debug_status === 'on' ? 'Désactiver' : 'Activer'; ?></button></form></div>
+                <h2 class="hndle"><span><?php esc_html_e( 'Mode de débogage', 'visi-bloc-jlg' ); ?></span></h2>
+                <div class="inside">
+                    <form method="POST" action="">
+                        <p>
+                            <?php esc_html_e( 'Statut actuel :', 'visi-bloc-jlg' ); ?>
+                            <strong><?php echo $debug_status === 'on' ? esc_html__( 'ACTIVÉ', 'visi-bloc-jlg' ) : esc_html__( 'DÉSACTIVÉ', 'visi-bloc-jlg' ); ?></strong>
+                        </p>
+                        <input type="hidden" name="action" value="visibloc_toggle_debug">
+                        <?php wp_nonce_field( 'visibloc_toggle_debug', 'visibloc_nonce' ); ?>
+                        <button type="submit" class="button button-primary"><?php echo $debug_status === 'on' ? esc_html__( 'Désactiver', 'visi-bloc-jlg' ) : esc_html__( 'Activer', 'visi-bloc-jlg' ); ?></button>
+                    </form>
+                </div>
             </div>
             <div class="postbox">
-                <h2 class="hndle"><span>Réglage des Points de Rupture</span></h2>
-                <div class="inside"><form method="POST" action=""><p>Alignez les largeurs d'écran avec celles de votre thème.</p><table class="form-table"><tr><th scope="row"><label for="visibloc_breakpoint_mobile">Largeur max. Mobile</label></th><td><input name="visibloc_breakpoint_mobile" type="number" id="visibloc_breakpoint_mobile" value="<?php echo esc_attr( $mobile_bp ); ?>" class="small-text"> px</td></tr><tr><th scope="row"><label for="visibloc_breakpoint_tablet">Largeur max. Tablette</label></th><td><input name="visibloc_breakpoint_tablet" type="number" id="visibloc_breakpoint_tablet" value="<?php echo esc_attr( $tablet_bp ); ?>" class="small-text"> px</td></tr></table><input type="hidden" name="action" value="visibloc_save_breakpoints"><?php wp_nonce_field( 'visibloc_save_breakpoints', 'visibloc_nonce' ); ?><?php submit_button('Enregistrer les breakpoints'); ?></form></div>
+                <h2 class="hndle"><span><?php esc_html_e( 'Réglage des points de rupture', 'visi-bloc-jlg' ); ?></span></h2>
+                <div class="inside">
+                    <form method="POST" action="">
+                        <p><?php esc_html_e( "Alignez les largeurs d'écran avec celles de votre thème.", 'visi-bloc-jlg' ); ?></p>
+                        <table class="form-table">
+                            <tr>
+                                <th scope="row"><label for="visibloc_breakpoint_mobile"><?php esc_html_e( 'Largeur max. mobile', 'visi-bloc-jlg' ); ?></label></th>
+                                <td><input name="visibloc_breakpoint_mobile" type="number" id="visibloc_breakpoint_mobile" value="<?php echo esc_attr( $mobile_bp ); ?>" class="small-text"> <?php esc_html_e( 'px', 'visi-bloc-jlg' ); ?></td>
+                            </tr>
+                            <tr>
+                                <th scope="row"><label for="visibloc_breakpoint_tablet"><?php esc_html_e( 'Largeur max. tablette', 'visi-bloc-jlg' ); ?></label></th>
+                                <td><input name="visibloc_breakpoint_tablet" type="number" id="visibloc_breakpoint_tablet" value="<?php echo esc_attr( $tablet_bp ); ?>" class="small-text"> <?php esc_html_e( 'px', 'visi-bloc-jlg' ); ?></td>
+                            </tr>
+                        </table>
+                        <input type="hidden" name="action" value="visibloc_save_breakpoints">
+                        <?php wp_nonce_field( 'visibloc_save_breakpoints', 'visibloc_nonce' ); ?>
+                        <?php submit_button( __( 'Enregistrer les breakpoints', 'visi-bloc-jlg' ) ); ?>
+                    </form>
+                </div>
             </div>
         </div>
     </div>

--- a/visi-bloc-jlg/includes/assets.php
+++ b/visi-bloc-jlg/includes/assets.php
@@ -35,8 +35,12 @@ function visibloc_jlg_add_device_visibility_styles() {
         <?php else: ?>
         .vb-desktop-only, .vb-tablet-only, .vb-mobile-only, .vb-hide-on-desktop, .vb-hide-on-tablet, .vb-hide-on-mobile { position: relative; outline: 2px dashed #0073aa; outline-offset: 2px; }
         .vb-desktop-only::before, .vb-tablet-only::before, .vb-mobile-only::before, .vb-hide-on-desktop::before, .vb-hide-on-tablet::before, .vb-hide-on-mobile::before { content: attr(data-visibloc-label); position: absolute; bottom: -2px; right: -2px; background-color: #0073aa; color: white; padding: 2px 8px; font-size: 11px; font-family: sans-serif; font-weight: bold; z-index: 99; border-radius: 3px 0 3px 0; }
-        .vb-hide-on-mobile::before { content: 'Caché sur Mobile'; } .vb-hide-on-tablet::before { content: 'Caché sur Tablette'; } .vb-hide-on-desktop::before { content: 'Caché sur Desktop'; }
-        .vb-mobile-only::before { content: 'Visible sur Mobile Uniquement'; } .vb-tablet-only::before { content: 'Visible sur Tablette Uniquement'; } .vb-desktop-only::before { content: 'Visible sur Desktop Uniquement'; }
+        .vb-hide-on-mobile::before { content: <?php echo wp_json_encode( __( 'Caché sur Mobile', 'visi-bloc-jlg' ) ); ?>; }
+        .vb-hide-on-tablet::before { content: <?php echo wp_json_encode( __( 'Caché sur Tablette', 'visi-bloc-jlg' ) ); ?>; }
+        .vb-hide-on-desktop::before { content: <?php echo wp_json_encode( __( 'Caché sur Desktop', 'visi-bloc-jlg' ) ); ?>; }
+        .vb-mobile-only::before { content: <?php echo wp_json_encode( __( 'Visible sur Mobile Uniquement', 'visi-bloc-jlg' ) ); ?>; }
+        .vb-tablet-only::before { content: <?php echo wp_json_encode( __( 'Visible sur Tablette Uniquement', 'visi-bloc-jlg' ) ); ?>; }
+        .vb-desktop-only::before { content: <?php echo wp_json_encode( __( 'Visible sur Desktop Uniquement', 'visi-bloc-jlg' ) ); ?>; }
         <?php endif; ?>
     </style>
     <?php

--- a/visi-bloc-jlg/includes/role-switcher.php
+++ b/visi-bloc-jlg/includes/role-switcher.php
@@ -64,16 +64,42 @@ function visibloc_jlg_add_role_switcher_menu( $wp_admin_bar ) {
     $base_url = remove_query_arg( [ 'preview_role', 'stop_preview_role', '_wpnonce' ] );
     if ( $current_preview_role ) {
         $role_names = wp_roles()->get_names();
-        $display_name = $current_preview_role === 'guest' ? 'Visiteur (Déconnecté)' : ($role_names[$current_preview_role] ?? ucfirst($current_preview_role));
-        $wp_admin_bar->add_node(['id' => 'visibloc-alert', 'title' => '⚠️ Aperçu : ' . esc_html( $display_name ), 'href' => '#', 'meta' => ['style' => 'background-color: #d54e21 !important;']]);
+        $display_name = $current_preview_role === 'guest' ? __( 'Visiteur (Déconnecté)', 'visi-bloc-jlg' ) : ( $role_names[ $current_preview_role ] ?? ucfirst( $current_preview_role ) );
+        $wp_admin_bar->add_node([
+            'id'    => 'visibloc-alert',
+            'title' => sprintf(
+                /* translators: %s: role name used for preview. */
+                esc_html__( '⚠️ Aperçu : %s', 'visi-bloc-jlg' ),
+                esc_html( $display_name )
+            ),
+            'href'  => '#',
+            'meta'  => [ 'style' => 'background-color: #d54e21 !important;' ],
+        ]);
         $stop_preview_url = add_query_arg( 'stop_preview_role', 'true', $base_url );
         $stop_preview_url = wp_nonce_url( $stop_preview_url, 'visibloc_switch_role_stop' );
-        $wp_admin_bar->add_node(['id' => 'visibloc-stop-preview', 'title' => '✅ Retour à ma vue', 'href' => $stop_preview_url, 'parent' => 'top-secondary']);
+        $wp_admin_bar->add_node([
+            'id'     => 'visibloc-stop-preview',
+            'title'  => esc_html__( '✅ Retour à ma vue', 'visi-bloc-jlg' ),
+            'href'   => $stop_preview_url,
+            'parent' => 'top-secondary',
+        ]);
     }
-    $wp_admin_bar->add_node(['id' => 'visibloc-role-switcher', 'title' => '<span class="ab-icon dashicons-groups"></span>Aperçu en tant que', 'href' => '#']);
+    $wp_admin_bar->add_node([
+        'id'    => 'visibloc-role-switcher',
+        'title' => sprintf(
+            '<span class="ab-icon dashicons-groups"></span>%s',
+            esc_html__( 'Aperçu en tant que', 'visi-bloc-jlg' )
+        ),
+        'href'  => '#',
+    ]);
     $guest_preview_url = add_query_arg( 'preview_role', 'guest', $base_url );
     $guest_preview_url = wp_nonce_url( $guest_preview_url, 'visibloc_switch_role_guest' );
-    $wp_admin_bar->add_node(['id' => 'visibloc-role-guest', 'title' => 'Visiteur (Déconnecté)', 'href' => $guest_preview_url, 'parent' => 'visibloc-role-switcher']);
+    $wp_admin_bar->add_node([
+        'id'     => 'visibloc-role-guest',
+        'title'  => esc_html__( 'Visiteur (Déconnecté)', 'visi-bloc-jlg' ),
+        'href'   => $guest_preview_url,
+        'parent' => 'visibloc-role-switcher',
+    ]);
     foreach ( get_editable_roles() as $slug => $details ) {
         $preview_url = add_query_arg( 'preview_role', $slug, $base_url );
         $preview_url = wp_nonce_url( $preview_url, 'visibloc_switch_role_' . $slug );

--- a/visi-bloc-jlg/includes/visibility-logic.php
+++ b/visi-bloc-jlg/includes/visibility-logic.php
@@ -15,10 +15,15 @@ function visibloc_jlg_render_block_filter( $block_content, $block ) {
         $is_after_end = $end_time && $current_time > $end_time;
         if ( $is_before_start || $is_after_end ) {
             if ( $can_preview ) {
-                $start_date_fr = $start_time ? wp_date( 'd/m/Y H:i', $start_time ) : 'N/A';
-                $end_date_fr = $end_time ? wp_date( 'd/m/Y H:i', $end_time ) : 'N/A';
-                $info = "Programmé (Début:{$start_date_fr} | Fin:{$end_date_fr})";
-                return '<div class="bloc-schedule-apercu" data-schedule-info="' . esc_attr($info) . '">' . $block_content . '</div>';
+                $start_date_fr = $start_time ? wp_date( 'd/m/Y H:i', $start_time ) : __( 'N/A', 'visi-bloc-jlg' );
+                $end_date_fr = $end_time ? wp_date( 'd/m/Y H:i', $end_time ) : __( 'N/A', 'visi-bloc-jlg' );
+                $info = sprintf(
+                    /* translators: 1: start date, 2: end date. */
+                    __( 'Programmé (Début:%1$s | Fin:%2$s)', 'visi-bloc-jlg' ),
+                    $start_date_fr,
+                    $end_date_fr
+                );
+                return '<div class="bloc-schedule-apercu" data-schedule-info="' . esc_attr( $info ) . '">' . $block_content . '</div>';
             }
             return '';
         }


### PR DESCRIPTION
## Summary
- wrap settings page menu labels, section headings, and form helper text in translation helpers for the Visi-Bloc admin UI.
- translate scheduled block preview metadata to use localized strings when revealing scheduling info to previewers.
- localize role switcher admin bar items and preview CSS badges so front-end helpers display in the site language.

## Testing
- php -l visi-bloc-jlg/includes/admin-settings.php
- php -l visi-bloc-jlg/includes/visibility-logic.php
- php -l visi-bloc-jlg/includes/role-switcher.php
- php -l visi-bloc-jlg/includes/assets.php

------
https://chatgpt.com/codex/tasks/task_e_68c91c8a240c832eba2ca31d8e52d07b