### PR TITLE
Use wp_safe_redirect for admin option saves

### DIFF
--- a/visi-bloc-jlg/includes/admin-settings.php
+++ b/visi-bloc-jlg/includes/admin-settings.php
@@ -27,14 +27,14 @@ function visibloc_jlg_handle_options_save() {
     if ( wp_verify_nonce( $nonce, 'visibloc_toggle_debug' ) ) {
         $current_status = get_option( 'visibloc_debug_mode', 'off' );
         update_option( 'visibloc_debug_mode', ( $current_status === 'on' ) ? 'off' : 'on' );
-        wp_redirect( admin_url( 'admin.php?page=visi-bloc-jlg-help&status=updated' ) );
+        wp_safe_redirect( admin_url( 'admin.php?page=visi-bloc-jlg-help&status=updated' ) );
         exit;
     }
 
     if ( wp_verify_nonce( $nonce, 'visibloc_save_breakpoints' ) ) {
         if ( null !== $mobile_breakpoint ) update_option( 'visibloc_breakpoint_mobile', $mobile_breakpoint );
         if ( null !== $tablet_breakpoint ) update_option( 'visibloc_breakpoint_tablet', $tablet_breakpoint );
-        wp_redirect( admin_url( 'admin.php?page=visi-bloc-jlg-help&status=updated' ) );
+        wp_safe_redirect( admin_url( 'admin.php?page=visi-bloc-jlg-help&status=updated' ) );
         exit;
     }
 
@@ -45,7 +45,7 @@ function visibloc_jlg_handle_options_save() {
             $sanitized_roles[] = 'administrator';
         }
         update_option( 'visibloc_preview_roles', $sanitized_roles );
-        wp_redirect( admin_url( 'admin.php?page=visi-bloc-jlg-help&status=updated' ) );
+        wp_safe_redirect( admin_url( 'admin.php?page=visi-bloc-jlg-help&status=updated' ) );
         exit;
     }
 }


### PR DESCRIPTION
## Summary
- replace wp_redirect with wp_safe_redirect in the admin options handler to harden redirects

## Testing
- php /tmp/test_visibloc_redirect.php debug
- php /tmp/test_visibloc_redirect.php breakpoints
- php /tmp/test_visibloc_redirect.php permissions

------
https://chatgpt.com/codex/tasks/task_e_68c93093bee4832ebd55930e6df9bb3b