### PR TITLE
Sanitize status query value before rendering admin page

### DIFF
--- a/visi-bloc-jlg/includes/admin-settings.php
+++ b/visi-bloc-jlg/includes/admin-settings.php
@@ -71,7 +71,7 @@ function visibloc_jlg_render_help_page_content() {
     $scheduled_posts = visibloc_jlg_get_scheduled_posts();
     $hidden_posts    = visibloc_jlg_get_hidden_posts();
     $device_posts    = visibloc_jlg_get_device_specific_posts();
-    $status          = isset( $_GET['status'] ) ? sanitize_key( $_GET['status'] ) : '';
+    $status          = isset( $_GET['status'] ) ? sanitize_key( wp_unslash( $_GET['status'] ) ) : '';
 
     ?>
     <div class="wrap">


### PR DESCRIPTION
## Summary
- unwrap the status query parameter before sanitizing it in the admin help page renderer

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c9670011cc832e8a60e01ff2777654