### PR TITLE
Update asset URLs to use the plugin main file

### DIFF
--- a/visi-bloc-jlg/includes/assets.php
+++ b/visi-bloc-jlg/includes/assets.php
@@ -3,18 +3,20 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 
 add_action( 'wp_enqueue_scripts', 'visibloc_jlg_enqueue_public_styles' );
 function visibloc_jlg_enqueue_public_styles() {
+    $plugin_main_file = __DIR__ . '/../visi-bloc-jlg.php';
     if ( visibloc_jlg_can_user_preview() ) {
-        wp_enqueue_style( 'visibloc-jlg-public-styles', plugin_dir_url( dirname( __DIR__ ) ) . 'admin-styles.css' );
+        wp_enqueue_style( 'visibloc-jlg-public-styles', plugins_url( 'admin-styles.css', $plugin_main_file ) );
     }
 }
 
 add_action( 'enqueue_block_editor_assets', 'visibloc_jlg_enqueue_editor_assets' );
 function visibloc_jlg_enqueue_editor_assets() {
+    $plugin_main_file = __DIR__ . '/../visi-bloc-jlg.php';
     $asset_file_path = plugin_dir_path( __DIR__ ) . 'build/index.asset.php';
     if ( ! file_exists( $asset_file_path ) ) { return; }
     $asset_file = include( $asset_file_path );
-    wp_enqueue_script( 'visibloc-jlg-editor-script', plugin_dir_url( dirname( __DIR__ ) ) . 'build/index.js', $asset_file['dependencies'], $asset_file['version'], true );
-    wp_enqueue_style( 'visibloc-jlg-editor-style', plugin_dir_url( dirname( __DIR__ ) ) . 'build/index.css', [], $asset_file['version'] );
+    wp_enqueue_script( 'visibloc-jlg-editor-script', plugins_url( 'build/index.js', $plugin_main_file ), $asset_file['dependencies'], $asset_file['version'], true );
+    wp_enqueue_style( 'visibloc-jlg-editor-style', plugins_url( 'build/index.css', $plugin_main_file ), [], $asset_file['version'] );
     wp_localize_script('visibloc-jlg-editor-script', 'VisiBlocData', ['roles' => wp_roles()->get_names()]);
 }
 


### PR DESCRIPTION
## Summary
- adjust public style enqueue to resolve admin-styles.css via the plugin main file
- update block editor script and style URLs to rely on plugins_url with the main plugin file

## Testing
- php -l visi-bloc-jlg/includes/assets.php

------
https://chatgpt.com/codex/tasks/task_e_68c9cf95fb20832ebaacc428a644f8d6