### PR TITLE
Respect preview restrictions when simulating roles

### DIFF
--- a/visi-bloc-jlg/visi-bloc-jlg.php
+++ b/visi-bloc-jlg/visi-bloc-jlg.php
@@ -33,6 +33,14 @@ function visibloc_jlg_can_user_preview() {
         $allowed_roles = ['administrator'];
     }
 
+    // Vérifie si un rôle simulé est appliqué via le switcher.
+    $preview_role_cookie = isset( $_COOKIE['visibloc_preview_role'] ) ? sanitize_key( wp_unslash( $_COOKIE['visibloc_preview_role'] ) ) : '';
+    if ( $preview_role_cookie ) {
+        if ( 'guest' === $preview_role_cookie || ! in_array( $preview_role_cookie, $allowed_roles, true ) ) {
+            return false;
+        }
+    }
+
     $user = wp_get_current_user();
     $user_roles = (array) $user->roles;
 


### PR DESCRIPTION
## Summary
- block preview eligibility now honours the simulated role stored in the visibloc_preview_role cookie
- automatically disable hidden-block preview when impersonating guest or any role that is not explicitly allowed

## Testing
- php -l visi-bloc-jlg/visi-bloc-jlg.php

------
https://chatgpt.com/codex/tasks/task_e_68c9cfcc5898832eb33705ce7c4d049a