### PR TITLE
Ensure guest preview keeps admin toolbar visible

### DIFF
--- a/visi-bloc-jlg/includes/role-switcher.php
+++ b/visi-bloc-jlg/includes/role-switcher.php
@@ -52,6 +52,22 @@ function visibloc_jlg_handle_role_switching() {
     }
 }
 
+add_filter( 'show_admin_bar', 'visibloc_jlg_force_admin_bar_during_guest_preview', 20 );
+function visibloc_jlg_force_admin_bar_during_guest_preview( $show ) {
+    if ( is_admin() || wp_doing_ajax() || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
+        return $show;
+    }
+
+    $cookie_name = 'visibloc_preview_role';
+    $current_preview_role = isset( $_COOKIE[ $cookie_name ] ) ? sanitize_key( wp_unslash( $_COOKIE[ $cookie_name ] ) ) : null;
+
+    if ( $current_preview_role === 'guest' && get_current_user_id() ) {
+        return true;
+    }
+
+    return $show;
+}
+
 add_action( 'admin_bar_menu', 'visibloc_jlg_add_role_switcher_menu', 999 );
 function visibloc_jlg_add_role_switcher_menu( $wp_admin_bar ) {
     $user_id = get_current_user_id();
@@ -59,7 +75,10 @@ function visibloc_jlg_add_role_switcher_menu( $wp_admin_bar ) {
     $current_preview_role = isset( $_COOKIE[$cookie_name] ) ? sanitize_key( wp_unslash( $_COOKIE[$cookie_name] ) ) : null;
     $force_admin_bar = ( $current_preview_role === 'guest' );
 
-    if ( ! $user_id || ( ! $force_admin_bar && ! is_admin_bar_showing() ) ) { return; }
+    if ( ! $user_id ) { return; }
+
+    $should_display_admin_bar = is_admin_bar_showing() || $force_admin_bar;
+    if ( ! $should_display_admin_bar ) { return; }
     $real_user = get_userdata( $user_id );
     if ( ! $real_user || ! in_array( 'administrator', (array) $real_user->roles ) ) { return; }
     if ( ! function_exists( 'get_editable_roles' ) ) { require_once ABSPATH . 'wp-admin/includes/user.php'; }
@@ -119,11 +138,17 @@ function visibloc_jlg_filter_user_capabilities( $allcaps, $caps, $args, $user ) 
     if ( isset( $_COOKIE[$cookie_name] ) && is_object( $user ) && $user->ID === get_current_user_id() ) {
         $preview_role = sanitize_key( wp_unslash( $_COOKIE[$cookie_name] ) );
         if ( $preview_role === 'guest' ) {
-            return [
+            $guest_caps = [
                 'exist'   => true,
                 'read'    => true,
                 'level_0' => true,
             ];
+
+            if ( isset( $allcaps['do_not_allow'] ) ) {
+                $guest_caps['do_not_allow'] = $allcaps['do_not_allow'];
+            }
+
+            return $guest_caps;
         }
         $role_object = get_role( $preview_role );
         if ( $role_object ) { return $role_object->capabilities; }


### PR DESCRIPTION
## Summary
- force the WordPress admin bar to stay visible when the guest preview is active so the return link is reachable
- keep minimal guest capabilities (exist/read/level_0) while preserving do_not_allow when impersonating visitors
- adjust the role switcher guard to allow injecting the return menu whenever the guest preview forces the toolbar

## Testing
- not run (no local WordPress runtime available)


------
https://chatgpt.com/codex/tasks/task_e_68cac45c1b74832ea73d373e698db675