### PR TITLE
Use UTC reference for block scheduling

### DIFF
--- a/visi-bloc-jlg/includes/visibility-logic.php
+++ b/visi-bloc-jlg/includes/visibility-logic.php
@@ -8,7 +8,7 @@ function visibloc_jlg_render_block_filter( $block_content, $block ) {
     $can_preview = visibloc_jlg_can_user_preview();
 
     if ( ! empty( $attrs['isSchedulingEnabled'] ) ) {
-        $current_time = current_time( 'timestamp' );
+        $current_time = current_time( 'timestamp', true );
         $timezone     = wp_timezone();
 
         $start_time = null;


### PR DESCRIPTION
## Summary
- ensure the scheduling checks use a UTC timestamp so they match the stored start and end dates

## Testing
- php -l visi-bloc-jlg/includes/visibility-logic.php

------
https://chatgpt.com/codex/tasks/task_e_68cb0188b004832eaa182294726bf9ee