### PR TITLE
Ignore preview cookie when preview is not allowed

### DIFF
--- a/visi-bloc-jlg/includes/visibility-logic.php
+++ b/visi-bloc-jlg/includes/visibility-logic.php
@@ -50,7 +50,7 @@ function visibloc_jlg_render_block_filter( $block_content, $block ) {
         $is_logged_in = $user->exists();
         $user_roles = (array) $user->roles;
 
-        if ( isset( $_COOKIE['visibloc_preview_role'] ) ) {
+        if ( $can_preview && isset( $_COOKIE['visibloc_preview_role'] ) ) {
             $preview_role = sanitize_key( wp_unslash( $_COOKIE['visibloc_preview_role'] ) );
 
             if ( 'guest' === $preview_role ) {
@@ -63,6 +63,7 @@ function visibloc_jlg_render_block_filter( $block_content, $block ) {
         }
 
         $is_visible = false;
+        // Manual check: without preview access the cookie must not affect visibility.
         if ( in_array( 'logged-out', $attrs['visibilityRoles'] ) && ! $is_logged_in ) $is_visible = true;
         if ( ! $is_visible && in_array( 'logged-in', $attrs['visibilityRoles'] ) && $is_logged_in ) $is_visible = true;
         if ( ! $is_visible && ! empty( $user_roles ) && count( array_intersect( $user_roles, $attrs['visibilityRoles'] ) ) > 0 ) { $is_visible = true; }


### PR DESCRIPTION
## Summary
- ignore the visibloc preview cookie unless the visitor can preview content
- document via a manual check comment that the cookie must not override roles without preview access

## Testing
- php -l visi-bloc-jlg/includes/visibility-logic.php

------
https://chatgpt.com/codex/tasks/task_e_68cb1637ef70832e94de5539aef1188b