### PR TITLE
Secure preview role capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ npm install
 npm run build
 ```
 
+## Manual testing
+
+- Connect as a `subscriber`, set the `visibloc_preview_role=administrator` cookie manually, and verify that `current_user_can( 'manage_options' )` remains `false` (including when calling through XML-RPC if applicable).
+
 ## Performance considerations
 
 The "Visi-Bloc - JLG" administration screen paginates the internal queries in batches of 100 post IDs and caches the compiled


### PR DESCRIPTION
## Summary
- store the real user ID whenever a preview role cookie is active so we can validate permissions across preview modes
- block capability overrides unless the stored/current user has an allowed preview role and purge unauthorized preview cookies
- document a manual regression test covering forged administrator preview cookies

## Testing
- php -l visi-bloc-jlg/includes/role-switcher.php

------
https://chatgpt.com/codex/tasks/task_e_68cc4b0c91e4832ea0ecb13b8fa15a20