### PR TITLE
Secure role preview capability checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ npm run build
 
 ## Manual testing
 
-- Connect as a `subscriber`, set the `visibloc_preview_role=administrator` cookie manually, and verify that `current_user_can( 'manage_options' )` remains `false` (including when calling through XML-RPC if applicable).
+1. Sign in as a `subscriber`.
+2. Manually add the cookie `visibloc_preview_role=administrator` (for example through the browser developer tools).
+3. Confirm that `current_user_can( 'manage_options' )` still returns `false`, including when the check is performed through XML-RPC if your stack exposes it.
 
 ## Performance considerations
 


### PR DESCRIPTION
## Summary
- keep the real user identifier while preview cookies are active, even after the guest impersonation switch
- centralize and reuse preview-role allowance checks to ensure only permitted roles can use cookies
- document the manual regression test that covers forged administrator cookies

## Testing
- php -l visi-bloc-jlg/includes/role-switcher.php

------
https://chatgpt.com/codex/tasks/task_e_68cc50a09be8832eb47f96194e290710