### PR TITLE
Normalize scheduled block timestamps

### DIFF
--- a/visi-bloc-jlg/includes/admin-settings.php
+++ b/visi-bloc-jlg/includes/admin-settings.php
@@ -178,11 +178,17 @@ function visibloc_jlg_render_scheduled_blocks_section( $scheduled_posts ) {
                         </tr>
                     </thead>
                     <tbody>
-                        <?php foreach ( $scheduled_posts as $post_data ) : ?>
+                        <?php foreach ( $scheduled_posts as $post_data ) :
+                            $start_timestamp = visibloc_jlg_parse_schedule_datetime( $post_data['start'] ?? null );
+                            $end_timestamp   = visibloc_jlg_parse_schedule_datetime( $post_data['end'] ?? null );
+
+                            $start_display = null !== $start_timestamp ? wp_date( 'd/m/Y H:i', $start_timestamp ) : '–';
+                            $end_display   = null !== $end_timestamp ? wp_date( 'd/m/Y H:i', $end_timestamp ) : '–';
+                            ?>
                             <tr>
                                 <td><a href="<?php echo esc_url( $post_data['link'] ); ?>"><?php echo esc_html( $post_data['title'] ); ?></a></td>
-                                <td><?php echo $post_data['start'] ? esc_html( wp_date( 'd/m/Y H:i', strtotime( $post_data['start'] ) ) ) : '–'; ?></td>
-                                <td><?php echo $post_data['end'] ? esc_html( wp_date( 'd/m/Y H:i', strtotime( $post_data['end'] ) ) ) : '–'; ?></td>
+                                <td><?php echo esc_html( $start_display ); ?></td>
+                                <td><?php echo esc_html( $end_display ); ?></td>
                             </tr>
                         <?php endforeach; ?>
                     </tbody>

--- a/visi-bloc-jlg/includes/datetime-utils.php
+++ b/visi-bloc-jlg/includes/datetime-utils.php
@@ -1,0 +1,24 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+/**
+ * Parse a Gutenberg schedule datetime attribute into a site-local timestamp.
+ *
+ * @param string|null $value Raw attribute value.
+ *
+ * @return int|null Timestamp on success, null otherwise.
+ */
+function visibloc_jlg_parse_schedule_datetime( $value ) {
+    if ( empty( $value ) || ! is_string( $value ) ) {
+        return null;
+    }
+
+    $timezone = wp_timezone();
+    $datetime = date_create_immutable( $value, $timezone );
+
+    if ( false === $datetime ) {
+        return null;
+    }
+
+    return $datetime->getTimestamp();
+}

--- a/visi-bloc-jlg/includes/visibility-logic.php
+++ b/visi-bloc-jlg/includes/visibility-logic.php
@@ -13,23 +13,9 @@ function visibloc_jlg_render_block_filter( $block_content, $block ) {
 
     if ( ! empty( $attrs['isSchedulingEnabled'] ) ) {
         $current_time = current_time( 'timestamp', true );
-        $timezone     = wp_timezone();
 
-        $start_time = null;
-        if ( ! empty( $attrs['publishStartDate'] ) ) {
-            $start_datetime = date_create_immutable( $attrs['publishStartDate'], $timezone );
-            if ( false !== $start_datetime ) {
-                $start_time = $start_datetime->getTimestamp();
-            }
-        }
-
-        $end_time = null;
-        if ( ! empty( $attrs['publishEndDate'] ) ) {
-            $end_datetime = date_create_immutable( $attrs['publishEndDate'], $timezone );
-            if ( false !== $end_datetime ) {
-                $end_time = $end_datetime->getTimestamp();
-            }
-        }
+        $start_time = visibloc_jlg_parse_schedule_datetime( $attrs['publishStartDate'] ?? null );
+        $end_time   = visibloc_jlg_parse_schedule_datetime( $attrs['publishEndDate'] ?? null );
 
         $is_before_start = null !== $start_time && $current_time < $start_time;
         $is_after_end = null !== $end_time && $current_time > $end_time;

--- a/visi-bloc-jlg/visi-bloc-jlg.php
+++ b/visi-bloc-jlg/visi-bloc-jlg.php
@@ -9,6 +9,7 @@
 if ( ! defined( 'WPINC' ) ) { exit; }
 
 // Charge les différents modules du plugin
+require_once __DIR__ . '/includes/datetime-utils.php';
 require_once __DIR__ . '/includes/admin-settings.php';
 require_once __DIR__ . '/includes/assets.php';
 require_once __DIR__ . '/includes/visibility-logic.php';


### PR DESCRIPTION
## Summary
- add a helper that parses scheduled block dates with the site timezone
- reuse the helper in both the runtime filter and admin table to display consistent times

## Testing
- php -l visi-bloc-jlg/includes/datetime-utils.php
- php -l visi-bloc-jlg/includes/visibility-logic.php
- php -l visi-bloc-jlg/includes/admin-settings.php

------
https://chatgpt.com/codex/tasks/task_e_68cc6c9d3910832eab051c7393de5748