### PR TITLE
Fix scheduled block timezone conversion in admin table

### DIFF
--- a/visi-bloc-jlg/includes/admin-settings.php
+++ b/visi-bloc-jlg/includes/admin-settings.php
@@ -179,11 +179,11 @@ function visibloc_jlg_render_scheduled_blocks_section( $scheduled_posts ) {
                     </thead>
                     <tbody>
                         <?php foreach ( $scheduled_posts as $post_data ) :
-                            $start_timestamp = visibloc_jlg_parse_schedule_datetime( $post_data['start'] ?? null );
-                            $end_timestamp   = visibloc_jlg_parse_schedule_datetime( $post_data['end'] ?? null );
+                            $start_datetime = visibloc_jlg_create_schedule_datetime( $post_data['start'] ?? null );
+                            $end_datetime   = visibloc_jlg_create_schedule_datetime( $post_data['end'] ?? null );
 
-                            $start_display = null !== $start_timestamp ? wp_date( 'd/m/Y H:i', $start_timestamp ) : '–';
-                            $end_display   = null !== $end_timestamp ? wp_date( 'd/m/Y H:i', $end_timestamp ) : '–';
+                            $start_display = null !== $start_datetime ? wp_date( 'd/m/Y H:i', $start_datetime->getTimestamp() ) : '–';
+                            $end_display   = null !== $end_datetime ? wp_date( 'd/m/Y H:i', $end_datetime->getTimestamp() ) : '–';
                             ?>
                             <tr>
                                 <td><a href="<?php echo esc_url( $post_data['link'] ); ?>"><?php echo esc_html( $post_data['title'] ); ?></a></td>

--- a/visi-bloc-jlg/includes/datetime-utils.php
+++ b/visi-bloc-jlg/includes/datetime-utils.php
@@ -2,13 +2,14 @@
 if ( ! defined( 'ABSPATH' ) ) exit;
 
 /**
- * Parse a Gutenberg schedule datetime attribute into a site-local timestamp.
+ * Convert a Gutenberg schedule datetime attribute into a DateTimeImmutable instance
+ * that respects the site's timezone.
  *
  * @param string|null $value Raw attribute value.
  *
- * @return int|null Timestamp on success, null otherwise.
+ * @return DateTimeImmutable|null Datetime object on success, null otherwise.
  */
-function visibloc_jlg_parse_schedule_datetime( $value ) {
+function visibloc_jlg_create_schedule_datetime( $value ) {
     if ( empty( $value ) || ! is_string( $value ) ) {
         return null;
     }
@@ -17,6 +18,23 @@ function visibloc_jlg_parse_schedule_datetime( $value ) {
     $datetime = date_create_immutable( $value, $timezone );
 
     if ( false === $datetime ) {
+        return null;
+    }
+
+    return $datetime;
+}
+
+/**
+ * Parse a Gutenberg schedule datetime attribute into a site-local timestamp.
+ *
+ * @param string|null $value Raw attribute value.
+ *
+ * @return int|null Timestamp on success, null otherwise.
+ */
+function visibloc_jlg_parse_schedule_datetime( $value ) {
+    $datetime = visibloc_jlg_create_schedule_datetime( $value );
+
+    if ( null === $datetime ) {
         return null;
     }
 


### PR DESCRIPTION
## Summary
- add a helper to convert schedule attributes into site-local DateTimeImmutable instances
- update the scheduled blocks admin table to rely on the helper before formatting dates for display
- keep the existing timestamp helper by building it on top of the new conversion utility

## Testing
- php -l visi-bloc-jlg/includes/datetime-utils.php
- php -l visi-bloc-jlg/includes/admin-settings.php

------
https://chatgpt.com/codex/tasks/task_e_68cc6e7bc270832e921f9679b8239afe