### PR TITLE
Validate breakpoints and guard tablet styles

### DIFF
--- a/visi-bloc-jlg/includes/admin-settings.php
+++ b/visi-bloc-jlg/includes/admin-settings.php
@@ -33,8 +33,30 @@ function visibloc_jlg_handle_options_save() {
     }
 
     if ( wp_verify_nonce( $nonce, 'visibloc_save_breakpoints' ) ) {
-        if ( null !== $mobile_breakpoint ) update_option( 'visibloc_breakpoint_mobile', $mobile_breakpoint );
-        if ( null !== $tablet_breakpoint ) update_option( 'visibloc_breakpoint_tablet', $tablet_breakpoint );
+        $current_mobile_bp = get_option( 'visibloc_breakpoint_mobile', 781 );
+        $current_tablet_bp = get_option( 'visibloc_breakpoint_tablet', 1024 );
+
+        $new_mobile_bp = ( null !== $mobile_breakpoint ) ? $mobile_breakpoint : $current_mobile_bp;
+        $new_tablet_bp = ( null !== $tablet_breakpoint ) ? $tablet_breakpoint : $current_tablet_bp;
+
+        if ( $new_tablet_bp <= $new_mobile_bp ) {
+            $redirect_url = add_query_arg(
+                'status',
+                'invalid_breakpoints',
+                admin_url( 'admin.php?page=visi-bloc-jlg-help' )
+            );
+            wp_safe_redirect( $redirect_url );
+            exit;
+        }
+
+        if ( null !== $mobile_breakpoint && $mobile_breakpoint !== $current_mobile_bp ) {
+            update_option( 'visibloc_breakpoint_mobile', $mobile_breakpoint );
+        }
+
+        if ( null !== $tablet_breakpoint && $tablet_breakpoint !== $current_tablet_bp ) {
+            update_option( 'visibloc_breakpoint_tablet', $tablet_breakpoint );
+        }
+
         visibloc_jlg_clear_caches();
         wp_safe_redirect( admin_url( 'admin.php?page=visi-bloc-jlg-help&status=updated' ) );
         exit;
@@ -81,6 +103,8 @@ function visibloc_jlg_render_help_page_content() {
         <h1><?php esc_html_e( 'Visi-Bloc - JLG - Aide et Réglages', 'visi-bloc-jlg' ); ?></h1>
         <?php if ( 'updated' === $status ) : ?>
             <div id="message" class="updated notice is-dismissible"><p><?php esc_html_e( 'Réglages mis à jour.', 'visi-bloc-jlg' ); ?></p></div>
+        <?php elseif ( 'invalid_breakpoints' === $status ) : ?>
+            <div id="message" class="notice notice-error is-dismissible"><p><?php esc_html_e( 'La valeur de la tablette doit être supérieure à celle du mobile. Les réglages n’ont pas été enregistrés.', 'visi-bloc-jlg' ); ?></p></div>
         <?php endif; ?>
         <div id="poststuff">
             <?php

--- a/visi-bloc-jlg/includes/assets.php
+++ b/visi-bloc-jlg/includes/assets.php
@@ -26,13 +26,17 @@ function visibloc_jlg_add_device_visibility_styles() {
     $mobile_bp = get_option( 'visibloc_breakpoint_mobile', 781 );
     $tablet_bp = get_option( 'visibloc_breakpoint_tablet', 1024 );
     $tablet_min_bp = $mobile_bp + 1;
-    $desktop_min_bp = $tablet_bp + 1;
+    $has_valid_tablet_bp = ( $tablet_bp > $mobile_bp );
+    $desktop_reference_bp = $has_valid_tablet_bp ? $tablet_bp : $mobile_bp;
+    $desktop_min_bp = $desktop_reference_bp + 1;
     ?>
     <style id="visibloc-jlg-styles">
         <?php if ( ! $can_preview ) : ?>
         .vb-desktop-only, .vb-tablet-only, .vb-mobile-only { display: none; }
         @media (max-width: <?php echo intval( $mobile_bp ); ?>px) { .vb-hide-on-mobile { display: none !important; } .vb-mobile-only { display: block !important; } }
+        <?php if ( $has_valid_tablet_bp ) : ?>
         @media (min-width: <?php echo intval( $tablet_min_bp ); ?>px) and (max-width: <?php echo intval( $tablet_bp ); ?>px) { .vb-hide-on-tablet { display: none !important; } .vb-tablet-only { display: block !important; } }
+        <?php endif; ?>
         @media (min-width: <?php echo intval( $desktop_min_bp ); ?>px) { .vb-hide-on-desktop { display: none !important; } .vb-desktop-only { display: block !important; } }
         <?php else: ?>
         .vb-desktop-only, .vb-tablet-only, .vb-mobile-only, .vb-hide-on-desktop, .vb-hide-on-tablet, .vb-hide-on-mobile { position: relative; outline: 2px dashed #0073aa; outline-offset: 2px; }


### PR DESCRIPTION
## Summary
- reject invalid breakpoint combinations when saving settings and display an error notice
- prevent tablet media queries from being output when breakpoints are inconsistent

## Testing
- php -l includes/admin-settings.php
- php -l includes/assets.php

------
https://chatgpt.com/codex/tasks/task_e_68cd759812ec832e9c57f75175b446a5