### PR TITLE
Add guard for non-group blocks in visibility filter

### DIFF
--- a/visi-bloc-jlg/includes/visibility-logic.php
+++ b/visi-bloc-jlg/includes/visibility-logic.php
@@ -3,6 +3,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 
 add_filter( 'render_block', 'visibloc_jlg_render_block_filter', 10, 2 );
 function visibloc_jlg_render_block_filter( $block_content, $block ) {
+    if ( empty( $block['blockName'] ) || 'core/group' !== $block['blockName'] ) { return $block_content; }
     if ( empty( $block['attrs'] ) ) { return $block_content; }
     $attrs = $block['attrs'];
     $can_preview = visibloc_jlg_can_user_preview();


### PR DESCRIPTION
## Summary
- skip custom visibility logic unless the rendered block is a core/group block

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cda8ca8ffc832ea50278f8fba2b0ac