### PR TITLE
Use sprintf for schedule summary strings

### DIFF
--- a/visi-bloc-jlg/build/index.asset.php
+++ b/visi-bloc-jlg/build/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('wp-block-editor', 'wp-blocks', 'wp-components', 'wp-compose', 'wp-data', 'wp-date', 'wp-element', 'wp-hooks', 'wp-i18n'), 'version' => '1a2b3c4d5e6f');
+<?php return array('dependencies' => array('wp-block-editor', 'wp-blocks', 'wp-components', 'wp-compose', 'wp-data', 'wp-date', 'wp-element', 'wp-hooks', 'wp-i18n'), 'version' => '1afaacc3f15d161e876f488b884f18a7');

--- a/visi-bloc-jlg/build/index.js
+++ b/visi-bloc-jlg/build/index.js
@@ -205,6 +205,7 @@ __webpack_require__.r(__webpack_exports__);
 
 
 
+const { sprintf } = _wordpress_i18n__WEBPACK_IMPORTED_MODULE_5__;
 const DEVICE_VISIBILITY_OPTIONS = [{
   label: (0,_wordpress_i18n__WEBPACK_IMPORTED_MODULE_5__.__)('Visible sur tous les appareils', 'visi-bloc-jlg'),
   value: 'all'
@@ -295,11 +296,11 @@ const withVisibilityControls = (0,_wordpress_compose__WEBPACK_IMPORTED_MODULE_2_
       const startDate = publishStartDate ? (0,_wordpress_date__WEBPACK_IMPORTED_MODULE_6__.format)('d/m/Y H:i', publishStartDate) : null;
       const endDate = publishEndDate ? (0,_wordpress_date__WEBPACK_IMPORTED_MODULE_6__.format)('d/m/Y H:i', publishEndDate) : null;
       if (startDate && endDate) {
-        scheduleSummary = `Du ${startDate} au ${endDate}.`;
+        scheduleSummary = sprintf((0,_wordpress_i18n__WEBPACK_IMPORTED_MODULE_5__.__)('Du %s au %s.', 'visi-bloc-jlg'), startDate, endDate);
       } else if (startDate) {
-        scheduleSummary = `À partir du ${startDate}.`;
+        scheduleSummary = sprintf((0,_wordpress_i18n__WEBPACK_IMPORTED_MODULE_5__.__)('À partir du %s.', 'visi-bloc-jlg'), startDate);
       } else if (endDate) {
-        scheduleSummary = `Jusqu'au ${endDate}.`;
+        scheduleSummary = sprintf((0,_wordpress_i18n__WEBPACK_IMPORTED_MODULE_5__.__)('Jusqu\'au %s.', 'visi-bloc-jlg'), endDate);
       } else {
         scheduleSummary = (0,_wordpress_i18n__WEBPACK_IMPORTED_MODULE_5__.__)('Activée, mais sans date définie.', 'visi-bloc-jlg');
       }


### PR DESCRIPTION
## Summary
- replace hard-coded schedule summary strings with `sprintf`/`__` calls so they can be localized
- expose `sprintf` from the `@wordpress/i18n` bundle and refresh the asset version hash

## Testing
- npm run build *(fails: no package.json in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68ce9bebb7e4832e88d8c7274d0e6ddc