### PR TITLE
Add script translations for editor bundle

### DIFF
--- a/visi-bloc-jlg/includes/assets.php
+++ b/visi-bloc-jlg/includes/assets.php
@@ -16,6 +16,7 @@ function visibloc_jlg_enqueue_editor_assets() {
     if ( ! file_exists( $asset_file_path ) ) { return; }
     $asset_file = include( $asset_file_path );
     wp_enqueue_script( 'visibloc-jlg-editor-script', plugins_url( 'build/index.js', $plugin_main_file ), $asset_file['dependencies'], $asset_file['version'], true );
+    wp_set_script_translations( 'visibloc-jlg-editor-script', 'visi-bloc-jlg', plugin_dir_path( __DIR__ ) . 'languages' );
     wp_enqueue_style( 'visibloc-jlg-editor-style', plugins_url( 'build/index.css', $plugin_main_file ), [], $asset_file['version'] );
     wp_localize_script('visibloc-jlg-editor-script', 'VisiBlocData', ['roles' => wp_roles()->get_names()]);
 }


### PR DESCRIPTION
## Summary
- register the block editor script for translations by pointing to the plugin languages directory

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cf38e3ab08832eaaefcec2c81484fc