### PR TITLE
Handle invalid preview roles option values

### DIFF
--- a/visi-bloc-jlg/includes/admin-settings.php
+++ b/visi-bloc-jlg/includes/admin-settings.php
@@ -118,7 +118,13 @@ function visibloc_jlg_render_help_page_content() {
     $debug_status   = get_option( 'visibloc_debug_mode', 'off' );
     $mobile_bp      = get_option( 'visibloc_breakpoint_mobile', 781 );
     $tablet_bp      = get_option( 'visibloc_breakpoint_tablet', 1024 );
-    $allowed_roles  = get_option( 'visibloc_preview_roles', [ 'administrator' ] );
+
+    $allowed_roles_option = get_option( 'visibloc_preview_roles', [ 'administrator' ] );
+    $allowed_roles        = array_filter( (array) $allowed_roles_option );
+
+    if ( empty( $allowed_roles ) ) {
+        $allowed_roles = [ 'administrator' ];
+    }
     $scheduled_posts = visibloc_jlg_get_scheduled_posts();
     $hidden_posts    = visibloc_jlg_get_hidden_posts();
     $device_posts    = visibloc_jlg_get_device_specific_posts();
@@ -147,6 +153,10 @@ function visibloc_jlg_render_help_page_content() {
 }
 
 function visibloc_jlg_render_permissions_section( $allowed_roles ) {
+    if ( ! is_array( $allowed_roles ) ) {
+        return;
+    }
+
     ?>
     <div class="postbox">
         <h2 class="hndle"><span><?php esc_html_e( "Permissions d'Aperçu", 'visi-bloc-jlg' ); ?></span></h2>


### PR DESCRIPTION
## Summary
- ensure the preview roles option is always treated as an array and fall back to the administrator role when empty
- guard the permissions rendering helper against unexpected non-array input

## Testing
- php -l visi-bloc-jlg/includes/admin-settings.php

------
https://chatgpt.com/codex/tasks/task_e_68cf4115621c832e8e6ccbf7e87383bc