### PR TITLE
Handle unauthorized preview roles in render filter

### DIFF
--- a/visi-bloc-jlg/includes/visibility-logic.php
+++ b/visi-bloc-jlg/includes/visibility-logic.php
@@ -11,6 +11,29 @@ function visibloc_jlg_render_block_filter( $block_content, $block ) {
         ? visibloc_jlg_is_user_allowed_to_preview( $effective_user_id )
         : false;
 
+    if ( function_exists( 'visibloc_jlg_get_preview_role_from_cookie' ) ) {
+        $preview_role = visibloc_jlg_get_preview_role_from_cookie();
+    } else {
+        $preview_role = isset( $_COOKIE['visibloc_preview_role'] ) ? sanitize_key( wp_unslash( $_COOKIE['visibloc_preview_role'] ) ) : null;
+    }
+
+    if ( $preview_role && 'guest' !== $preview_role ) {
+        if ( function_exists( 'visibloc_jlg_get_allowed_preview_roles' ) ) {
+            $allowed_preview_roles = visibloc_jlg_get_allowed_preview_roles();
+        } else {
+            $allowed_preview_roles = (array) get_option( 'visibloc_preview_roles', [ 'administrator' ] );
+            $allowed_preview_roles = array_map( 'sanitize_key', $allowed_preview_roles );
+
+            if ( empty( $allowed_preview_roles ) ) {
+                $allowed_preview_roles = [ 'administrator' ];
+            }
+        }
+
+        if ( ! in_array( $preview_role, $allowed_preview_roles, true ) ) {
+            $is_legit_preview_requester = false;
+        }
+    }
+
     if ( ! empty( $attrs['isSchedulingEnabled'] ) ) {
         $current_time = current_time( 'timestamp', true );
 


### PR DESCRIPTION
## Summary
- ensure the block render filter reads the simulated preview role from the cookie helper
- prevent preview markers from appearing when the simulated role is not allowed to preview blocks

## Testing
- php -l visi-bloc-jlg/includes/visibility-logic.php

------
https://chatgpt.com/codex/tasks/task_e_68cfea95b5c8832e8da3d13e7558e137