### PR TITLE
Add translatable label for hidden block preview

### DIFF
--- a/visi-bloc-jlg/admin-styles.css
+++ b/visi-bloc-jlg/admin-styles.css
@@ -7,7 +7,7 @@
     box-sizing: border-box;
 }
 .bloc-cache-apercu::before {
-    content: "Bloc caché";
+    content: attr(data-visibloc-label);
     position: absolute;
     top: -12px;
     left: 10px;

--- a/visi-bloc-jlg/includes/visibility-logic.php
+++ b/visi-bloc-jlg/includes/visibility-logic.php
@@ -81,7 +81,11 @@ function visibloc_jlg_render_block_filter( $block_content, $block ) {
     
     if ( isset( $attrs['isHidden'] ) && $attrs['isHidden'] === true ) {
         if ( $is_legit_preview_requester ) {
-            return '<div class="bloc-cache-apercu">' . $block_content . '</div>';
+            return sprintf(
+                '<div class="bloc-cache-apercu" data-visibloc-label="%s">%s</div>',
+                esc_attr__( 'Hidden block', 'visi-bloc-jlg' ),
+                $block_content
+            );
         }
         return '';
     }


### PR DESCRIPTION
## Summary
- add a data-visibloc-label attribute with a translated fallback label when previewing hidden blocks
- update the admin badge CSS to read the label from the new data attribute for localization

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d07eaae604832ea270873d892f08af