### PR TITLE
Include template parts in block scan

### DIFF
--- a/visi-bloc-jlg/includes/admin-settings.php
+++ b/visi-bloc-jlg/includes/admin-settings.php
@@ -317,7 +317,7 @@ function visibloc_jlg_find_blocks_recursive( $blocks, $callback ) {
 
 function visibloc_jlg_get_posts_with_condition( $attribute_callback ) {
     $found_posts = [];
-    $post_types  = apply_filters( 'visibloc_jlg_scanned_post_types', [ 'post', 'page', 'wp_template' ] );
+    $post_types  = apply_filters( 'visibloc_jlg_scanned_post_types', [ 'post', 'page', 'wp_template', 'wp_template_part' ] );
     $page        = 1;
 
     while ( true ) {


### PR DESCRIPTION
## Summary
- include `wp_template_part` in the default post types scanned for blocks so template part content is analysed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d14ca0fd58832e8d14687d6e472c75