### PR TITLE
Handle XML-RPC as technical request

### DIFF
--- a/visi-bloc-jlg/includes/role-switcher.php
+++ b/visi-bloc-jlg/includes/role-switcher.php
@@ -43,6 +43,10 @@ function visibloc_jlg_is_admin_or_technical_request() {
         return true;
     }
 
+    if ( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST ) {
+        return true;
+    }
+
     if ( function_exists( 'wp_doing_cron' ) && wp_doing_cron() ) {
         return true;
     }


### PR DESCRIPTION
## Summary
- treat XML-RPC requests as technical so preview role overrides are skipped during XML-RPC calls

## Testing
- php -l includes/role-switcher.php

------
https://chatgpt.com/codex/tasks/task_e_68d14c9dc85c832eb1d40132e7f07e49