### PR TITLE
Fix guest preview visibility handling

### DIFF
--- a/visi-bloc-jlg/includes/visibility-logic.php
+++ b/visi-bloc-jlg/includes/visibility-logic.php
@@ -28,6 +28,10 @@ function visibloc_jlg_render_block_filter( $block_content, $block ) {
         $preview_role = isset( $_COOKIE['visibloc_preview_role'] ) ? sanitize_key( wp_unslash( $_COOKIE['visibloc_preview_role'] ) ) : '';
     }
 
+    if ( 'guest' === $preview_role ) {
+        $is_legit_preview_requester = false;
+    }
+
     if ( $preview_role && 'guest' !== $preview_role && ! in_array( $preview_role, $allowed_preview_roles, true ) ) {
         $is_legit_preview_requester = false;
     }

--- a/visi-bloc-jlg/visi-bloc-jlg.php
+++ b/visi-bloc-jlg/visi-bloc-jlg.php
@@ -48,6 +48,10 @@ function visibloc_jlg_can_user_preview() {
         $preview_role_cookie = isset( $_COOKIE['visibloc_preview_role'] ) ? sanitize_key( wp_unslash( $_COOKIE['visibloc_preview_role'] ) ) : '';
     }
 
+    if ( 'guest' === $preview_role_cookie ) {
+        return false;
+    }
+
     if ( $preview_role_cookie && 'guest' !== $preview_role_cookie && ! in_array( $preview_role_cookie, $allowed_roles, true ) ) {
         return false;
     }


### PR DESCRIPTION
## Summary
- prevent guest previews from being treated as legitimate preview requests so hidden and scheduled blocks are removed
- disable preview stylesheet injection when the guest preview cookie is active

## Testing
- php -l includes/visibility-logic.php
- php -l visi-bloc-jlg.php

------
https://chatgpt.com/codex/tasks/task_e_68d180ff8bb0832e80a40900ceed8277