### PR TITLE
Sanitize query args before using sanitize_key

### DIFF
--- a/visi-bloc-jlg/includes/admin-settings.php
+++ b/visi-bloc-jlg/includes/admin-settings.php
@@ -128,7 +128,7 @@ function visibloc_jlg_render_help_page_content() {
     $scheduled_posts = visibloc_jlg_get_scheduled_posts();
     $hidden_posts    = visibloc_jlg_get_hidden_posts();
     $device_posts    = visibloc_jlg_get_device_specific_posts();
-    $status          = isset( $_GET['status'] ) ? sanitize_key( wp_unslash( $_GET['status'] ) ) : '';
+    $status          = visibloc_jlg_get_sanitized_query_arg( 'status' );
 
     ?>
     <div class="wrap">

--- a/visi-bloc-jlg/includes/role-switcher.php
+++ b/visi-bloc-jlg/includes/role-switcher.php
@@ -86,7 +86,7 @@ function visibloc_jlg_is_admin_or_technical_request() {
             return true;
         }
 
-        $context = isset( $_GET['context'] ) ? sanitize_key( wp_unslash( $_GET['context'] ) ) : '';
+        $context = visibloc_jlg_get_sanitized_query_arg( 'context' );
 
         if ( 'edit' === $context ) {
             return true;
@@ -381,7 +381,12 @@ function visibloc_jlg_handle_role_switching() {
 
     $cookie_name = 'visibloc_preview_role';
     if ( isset( $_GET['preview_role'] ) ) {
-        $role_to_preview = sanitize_key( wp_unslash( $_GET['preview_role'] ) );
+        $role_to_preview = visibloc_jlg_get_sanitized_query_arg( 'preview_role' );
+
+        if ( '' === $role_to_preview ) {
+            return;
+        }
+
         if ( ! in_array( $role_to_preview, $previewable_roles, true ) ) {
             error_log( sprintf( 'Visibloc role switcher: invalid preview role requested (%s).', $role_to_preview ) );
             return;

--- a/visi-bloc-jlg/visi-bloc-jlg.php
+++ b/visi-bloc-jlg/visi-bloc-jlg.php
@@ -10,6 +10,31 @@
 
 if ( ! defined( 'WPINC' ) ) { exit; }
 
+if ( ! function_exists( 'visibloc_jlg_get_sanitized_query_arg' ) ) {
+    /**
+     * Retrieve a sanitized value from the $_GET superglobal using sanitize_key.
+     *
+     * Only string values are accepted to avoid unexpected sanitization results
+     * or PHP notices when arrays/objects are provided.
+     *
+     * @param string $key Query arg key to read from $_GET.
+     * @return string Sanitized string or an empty string when unavailable/invalid.
+     */
+    function visibloc_jlg_get_sanitized_query_arg( $key ) {
+        if ( ! isset( $_GET[ $key ] ) ) {
+            return '';
+        }
+
+        $value = $_GET[ $key ];
+
+        if ( ! is_string( $value ) ) {
+            return '';
+        }
+
+        return sanitize_key( wp_unslash( $value ) );
+    }
+}
+
 // Charge les différents modules du plugin
 require_once __DIR__ . '/includes/datetime-utils.php';
 require_once __DIR__ . '/includes/admin-settings.php';


### PR DESCRIPTION
## Summary
- add a shared helper to safely sanitize string query args before calling sanitize_key
- use the helper for REST context, preview role switching, and admin status flashes

## Testing
- php -l visi-bloc-jlg.php
- php -l includes/role-switcher.php
- php -l includes/admin-settings.php

------
https://chatgpt.com/codex/tasks/task_e_68d2d4dcada8832eb5c21305331b3ae1