### PR TITLE
Harden preview role cookie handling

### DIFF
--- a/visi-bloc-jlg/includes/role-switcher.php
+++ b/visi-bloc-jlg/includes/role-switcher.php
@@ -13,7 +13,13 @@ function visibloc_jlg_get_preview_role_from_cookie() {
         return null;
     }
 
-    return sanitize_key( wp_unslash( $_COOKIE[ $cookie_name ] ) );
+    $cookie_value = $_COOKIE[ $cookie_name ];
+
+    if ( ! is_string( $cookie_value ) ) {
+        return '';
+    }
+
+    return sanitize_key( wp_unslash( $cookie_value ) );
 }
 
 function visibloc_jlg_store_real_user_id( $user_id ) {

--- a/visi-bloc-jlg/visi-bloc-jlg.php
+++ b/visi-bloc-jlg/visi-bloc-jlg.php
@@ -70,7 +70,11 @@ function visibloc_jlg_can_user_preview() {
     if ( function_exists( 'visibloc_jlg_get_preview_role_from_cookie' ) ) {
         $preview_role_cookie = visibloc_jlg_get_preview_role_from_cookie();
     } else {
-        $preview_role_cookie = isset( $_COOKIE['visibloc_preview_role'] ) ? sanitize_key( wp_unslash( $_COOKIE['visibloc_preview_role'] ) ) : '';
+        if ( isset( $_COOKIE['visibloc_preview_role'] ) && is_string( $_COOKIE['visibloc_preview_role'] ) ) {
+            $preview_role_cookie = sanitize_key( wp_unslash( $_COOKIE['visibloc_preview_role'] ) );
+        } else {
+            $preview_role_cookie = '';
+        }
     }
 
     if ( 'guest' === $preview_role_cookie ) {


### PR DESCRIPTION
## Summary
- guard the preview role cookie helper against non-string values before sanitizing
- mirror the stricter cookie validation in the public fallback path to avoid notices

## Testing
- ./vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68d3a60af17c832e897db3895c413964