### PR TITLE
Handle scalar visibility roles safely

### DIFF
--- a/visi-bloc-jlg/includes/visibility-logic.php
+++ b/visi-bloc-jlg/includes/visibility-logic.php
@@ -92,7 +92,21 @@ function visibloc_jlg_render_block_filter( $block_content, $block ) {
         }
     }
 
-    if ( ! empty( $attrs['visibilityRoles'] ) ) {
+    $visibility_roles = [];
+
+    if ( array_key_exists( 'visibilityRoles', $attrs ) ) {
+        $raw_visibility_roles = $attrs['visibilityRoles'];
+
+        if ( is_array( $raw_visibility_roles ) ) {
+            $visibility_roles = $raw_visibility_roles;
+        } elseif ( is_string( $raw_visibility_roles ) ) {
+            $visibility_roles = '' === trim( $raw_visibility_roles ) ? [] : [ $raw_visibility_roles ];
+        } elseif ( is_scalar( $raw_visibility_roles ) ) {
+            $visibility_roles = [ $raw_visibility_roles ];
+        }
+    }
+
+    if ( ! empty( $visibility_roles ) ) {
         $user = wp_get_current_user();
         $is_logged_in = $user->exists();
         $user_roles = (array) $user->roles;
@@ -109,9 +123,9 @@ function visibloc_jlg_render_block_filter( $block_content, $block ) {
 
         $is_visible = false;
         // Manual check: without preview access the cookie must not affect visibility.
-        if ( in_array( 'logged-out', $attrs['visibilityRoles'] ) && ! $is_logged_in ) $is_visible = true;
-        if ( ! $is_visible && in_array( 'logged-in', $attrs['visibilityRoles'] ) && $is_logged_in ) $is_visible = true;
-        if ( ! $is_visible && ! empty( $user_roles ) && count( array_intersect( $user_roles, $attrs['visibilityRoles'] ) ) > 0 ) { $is_visible = true; }
+        if ( in_array( 'logged-out', $visibility_roles, true ) && ! $is_logged_in ) $is_visible = true;
+        if ( ! $is_visible && in_array( 'logged-in', $visibility_roles, true ) && $is_logged_in ) $is_visible = true;
+        if ( ! $is_visible && ! empty( $user_roles ) && count( array_intersect( $user_roles, $visibility_roles ) ) > 0 ) { $is_visible = true; }
         if ( ! $is_visible ) return '';
     }
     

--- a/visi-bloc-jlg/tests/phpunit/integration/VisibilityLogicTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/VisibilityLogicTest.php
@@ -56,4 +56,38 @@ class VisibilityLogicTest extends TestCase {
             'Hidden blocks should not appear without preview permission for the simulated role.'
         );
     }
+
+    public function test_visibility_roles_accepts_string_role_values(): void {
+        global $visibloc_test_state;
+
+        $visibloc_test_state['current_user'] = new Visibloc_Test_User( 2, [ 'editor' ] );
+
+        $block = [
+            'blockName' => 'core/group',
+            'attrs'     => [
+                'visibilityRoles' => 'editor',
+            ],
+        ];
+
+        $this->assertSame(
+            '<p>Visible content</p>',
+            visibloc_jlg_render_block_filter( '<p>Visible content</p>', $block ),
+            'A scalar string value should be treated as a single role entry.'
+        );
+    }
+
+    public function test_visibility_roles_accepts_logged_out_string_marker(): void {
+        $block = [
+            'blockName' => 'core/group',
+            'attrs'     => [
+                'visibilityRoles' => 'logged-out',
+            ],
+        ];
+
+        $this->assertSame(
+            '<p>Guest content</p>',
+            visibloc_jlg_render_block_filter( '<p>Guest content</p>', $block ),
+            'The logged-out marker should work when passed as a scalar value.'
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- normalize the `visibilityRoles` attribute so scalar values don't trigger warnings during rendering
- tighten visibility checks to rely on the normalized list
- cover scalar role inputs with new integration tests

## Testing
- ./vendor/bin/phpunit -c phpunit.xml.dist

------
https://chatgpt.com/codex/tasks/task_e_68d3be45cb48832eaa2e80afa16ae860