### PR TITLE
Ensure absolute preview redirects and clear caches

### DIFF
--- a/visi-bloc-jlg/uninstall.php
+++ b/visi-bloc-jlg/uninstall.php
@@ -11,3 +11,4 @@ delete_option( 'visibloc_preview_roles' );
 delete_transient( 'visibloc_hidden_posts' );
 delete_transient( 'visibloc_device_posts' );
 delete_transient( 'visibloc_scheduled_posts' );
+delete_transient( 'visibloc_group_block_metadata' );


### PR DESCRIPTION
## Summary
- add helpers that build an absolute base URL before creating role preview links or redirects
- update role switcher redirects and toolbar links to use the shared absolute base URL helper
- remove the role metadata transient during plugin uninstall

## Testing
- php -l visi-bloc-jlg/includes/role-switcher.php
- php -l visi-bloc-jlg/uninstall.php

------
https://chatgpt.com/codex/tasks/task_e_68d3c516d10c832e8b1de400c1dff6eb