### PR TITLE
Improve guest preview handling and cache metadata incrementally

### DIFF
--- a/visi-bloc-jlg/includes/visibility-logic.php
+++ b/visi-bloc-jlg/includes/visibility-logic.php
@@ -17,6 +17,7 @@ function visibloc_jlg_render_block_filter( $block_content, $block ) {
     $can_preview_hidden_blocks = $effective_user_id && function_exists( 'visibloc_jlg_is_user_allowed_to_preview' )
         ? visibloc_jlg_is_user_allowed_to_preview( $effective_user_id )
         : false;
+    $had_preview_permission = $can_preview_hidden_blocks;
 
     if ( function_exists( 'visibloc_jlg_get_allowed_preview_roles' ) ) {
         $allowed_preview_roles = visibloc_jlg_get_allowed_preview_roles();
@@ -48,7 +49,7 @@ function visibloc_jlg_render_block_filter( $block_content, $block ) {
     if ( ! $is_preview_role_neutralized && '' !== $preview_role ) {
         if ( 'guest' === $preview_role ) {
             $can_preview_hidden_blocks = false;
-            $should_apply_preview_role = $can_impersonate;
+            $should_apply_preview_role = ( $had_preview_permission || $can_impersonate );
         } else {
             if ( ! in_array( $preview_role, $allowed_preview_roles, true ) ) {
                 $can_preview_hidden_blocks = false;

--- a/visi-bloc-jlg/tests/phpunit/integration/VisibilityLogicTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/VisibilityLogicTest.php
@@ -90,4 +90,41 @@ class VisibilityLogicTest extends TestCase {
             'The logged-out marker should work when passed as a scalar value.'
         );
     }
+
+    public function test_guest_preview_forces_logged_out_state_without_impersonation(): void {
+        global $visibloc_test_state;
+
+        $visibloc_test_state['effective_user_id']             = 3;
+        $visibloc_test_state['can_preview_users'][3]          = true;
+        $visibloc_test_state['can_impersonate_users'][3]      = false;
+        $visibloc_test_state['allowed_preview_roles']         = [ 'administrator' ];
+        $visibloc_test_state['preview_role']                  = 'guest';
+        $visibloc_test_state['current_user']                  = new Visibloc_Test_User( 3, [ 'editor' ] );
+
+        $logged_in_block = [
+            'blockName' => 'core/group',
+            'attrs'     => [
+                'visibilityRoles' => [ 'logged-in' ],
+            ],
+        ];
+
+        $this->assertSame(
+            '',
+            visibloc_jlg_render_block_filter( '<p>Members content</p>', $logged_in_block ),
+            'Previewing as a guest should hide blocks reserved for logged-in users even without impersonation rights.'
+        );
+
+        $logged_out_block = [
+            'blockName' => 'core/group',
+            'attrs'     => [
+                'visibilityRoles' => [ 'logged-out' ],
+            ],
+        ];
+
+        $this->assertSame(
+            '<p>Guest view</p>',
+            visibloc_jlg_render_block_filter( '<p>Guest view</p>', $logged_out_block ),
+            'Previewing as a guest should expose content intended for visitors.'
+        );
+    }
 }

--- a/visi-bloc-jlg/uninstall.php
+++ b/visi-bloc-jlg/uninstall.php
@@ -6,6 +6,7 @@ delete_option( 'visibloc_debug_mode' );
 delete_option( 'visibloc_breakpoint_mobile' );
 delete_option( 'visibloc_breakpoint_tablet' );
 delete_option( 'visibloc_preview_roles' );
+delete_option( 'visibloc_group_block_summary' );
 
 // Supprime les transients de cache du plugin
 delete_transient( 'visibloc_hidden_posts' );


### PR DESCRIPTION
## Summary
- ensure guest preview mode applies logged-out state even without impersonation rights
- replace expensive admin scans with per-post group block summaries cached in an option
- clean up stored summaries on uninstall and cover guest preview regression with tests

## Testing
- ./vendor/bin/phpunit -c phpunit.xml.dist

------
https://chatgpt.com/codex/tasks/task_e_68d3dabe2d84832ebc9d814d228c8fcb