### PR TITLE
Refine visibility preview context and device assets

### DIFF
--- a/visi-bloc-jlg/assets/device-visibility.css
+++ b/visi-bloc-jlg/assets/device-visibility.css
@@ -1,0 +1,23 @@
+@media (max-width: 781px) {
+    .vb-hide-on-mobile,
+    .vb-tablet-only,
+    .vb-desktop-only {
+        display: none !important;
+    }
+}
+
+@media (min-width: 782px) and (max-width: 1024px) {
+    .vb-hide-on-tablet,
+    .vb-mobile-only,
+    .vb-desktop-only {
+        display: none !important;
+    }
+}
+
+@media (min-width: 1025px) {
+    .vb-hide-on-desktop,
+    .vb-mobile-only,
+    .vb-tablet-only {
+        display: none !important;
+    }
+}

--- a/visi-bloc-jlg/includes/admin-settings.php
+++ b/visi-bloc-jlg/includes/admin-settings.php
@@ -89,11 +89,20 @@ function visibloc_jlg_handle_options_save() {
     }
 
     if ( wp_verify_nonce( $nonce, 'visibloc_save_permissions' ) ) {
-        $sanitized_roles = $submitted_roles;
+        if ( ! function_exists( 'get_editable_roles' ) ) {
+            require_once ABSPATH . 'wp-admin/includes/user.php';
+        }
+
+        $editable_roles = array_keys( (array) get_editable_roles() );
+        $editable_roles = array_map( 'sanitize_key', $editable_roles );
+
+        $sanitized_roles = array_values( array_unique( array_intersect( $editable_roles, $submitted_roles ) ) );
+
         // On s'assure que l'administrateur est toujours inclus
-        if ( ! in_array( 'administrator', $sanitized_roles ) ) {
+        if ( ! in_array( 'administrator', $sanitized_roles, true ) ) {
             $sanitized_roles[] = 'administrator';
         }
+
         update_option( 'visibloc_preview_roles', $sanitized_roles );
         visibloc_jlg_clear_caches();
         wp_safe_redirect( admin_url( 'admin.php?page=visi-bloc-jlg-help&status=updated' ) );

--- a/visi-bloc-jlg/includes/assets.php
+++ b/visi-bloc-jlg/includes/assets.php
@@ -4,14 +4,22 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 add_action( 'wp_enqueue_scripts', 'visibloc_jlg_enqueue_public_styles' );
 function visibloc_jlg_enqueue_public_styles() {
     $plugin_main_file = __DIR__ . '/../visi-bloc-jlg.php';
-    $can_preview       = visibloc_jlg_can_user_preview();
-    $device_css        = visibloc_jlg_generate_device_visibility_css( $can_preview );
-    $device_handle     = 'visibloc-jlg-device-visibility';
+    $can_preview      = visibloc_jlg_can_user_preview();
+    $default_mobile   = 781;
+    $default_tablet   = 1024;
+    $mobile_bp        = absint( get_option( 'visibloc_breakpoint_mobile', $default_mobile ) );
+    $tablet_bp        = absint( get_option( 'visibloc_breakpoint_tablet', $default_tablet ) );
+    $mobile_bp        = $mobile_bp > 0 ? $mobile_bp : $default_mobile;
+    $tablet_bp        = $tablet_bp > 0 ? $tablet_bp : $default_tablet;
+    $device_handle    = 'visibloc-jlg-device-visibility';
+    $device_style_src = plugins_url( 'assets/device-visibility.css', $plugin_main_file );
 
-    wp_register_style( $device_handle, false, [], '1.1' );
+    wp_register_style( $device_handle, $device_style_src, [], '1.1' );
+    wp_enqueue_style( $device_handle );
+
+    $device_css = visibloc_jlg_generate_device_visibility_css( $can_preview, $mobile_bp, $tablet_bp );
 
     if ( '' !== $device_css ) {
-        wp_enqueue_style( $device_handle );
         wp_add_inline_style( $device_handle, $device_css );
     }
 
@@ -32,45 +40,61 @@ function visibloc_jlg_enqueue_editor_assets() {
     wp_localize_script('visibloc-jlg-editor-script', 'VisiBlocData', ['roles' => wp_roles()->get_names()]);
 }
 
-function visibloc_jlg_generate_device_visibility_css( $can_preview ) {
-    $mobile_bp            = absint( get_option( 'visibloc_breakpoint_mobile', 781 ) );
-    $tablet_bp            = absint( get_option( 'visibloc_breakpoint_tablet', 1024 ) );
-    $tablet_min_bp        = $mobile_bp + 1;
-    $has_valid_tablet_bp  = ( $tablet_bp > $mobile_bp );
-    $desktop_reference_bp = $has_valid_tablet_bp ? $tablet_bp : $mobile_bp;
-    $desktop_min_bp       = $desktop_reference_bp + 1;
+function visibloc_jlg_generate_device_visibility_css( $can_preview, $mobile_bp = null, $tablet_bp = null ) {
+    $default_mobile_bp = 781;
+    $default_tablet_bp = 1024;
+
+    if ( null === $mobile_bp ) {
+        $mobile_bp = absint( get_option( 'visibloc_breakpoint_mobile', $default_mobile_bp ) );
+    }
+
+    if ( null === $tablet_bp ) {
+        $tablet_bp = absint( get_option( 'visibloc_breakpoint_tablet', $default_tablet_bp ) );
+    }
+
+    $mobile_bp = $mobile_bp > 0 ? $mobile_bp : $default_mobile_bp;
+    $tablet_bp = $tablet_bp > 0 ? $tablet_bp : $default_tablet_bp;
+
+    $has_custom_breakpoints = ( $mobile_bp !== $default_mobile_bp ) || ( $tablet_bp !== $default_tablet_bp );
 
     $css_lines = [];
 
-    $css_lines[] = sprintf(
-        '@media (max-width: %dpx) {',
-        $mobile_bp
-    );
-    $css_lines[] = '    .vb-hide-on-mobile,';
-    $css_lines[] = '    .vb-tablet-only,';
-    $css_lines[] = '    .vb-desktop-only { display: none !important; }';
-    $css_lines[] = '}';
+    if ( $has_custom_breakpoints ) {
+        $tablet_min_bp        = $mobile_bp + 1;
+        $has_valid_tablet_bp  = ( $tablet_bp > $mobile_bp );
+        $desktop_reference_bp = $has_valid_tablet_bp ? $tablet_bp : $mobile_bp;
+        $desktop_min_bp       = $desktop_reference_bp + 1;
 
-    if ( $has_valid_tablet_bp ) {
         $css_lines[] = sprintf(
-            '@media (min-width: %1$dpx) and (max-width: %2$dpx) {',
-            $tablet_min_bp,
-            $tablet_bp
+            '@media (max-width: %dpx) {',
+            $mobile_bp
         );
-        $css_lines[] = '    .vb-hide-on-tablet,';
-        $css_lines[] = '    .vb-mobile-only,';
+        $css_lines[] = '    .vb-hide-on-mobile,';
+        $css_lines[] = '    .vb-tablet-only,';
         $css_lines[] = '    .vb-desktop-only { display: none !important; }';
         $css_lines[] = '}';
-    }
 
-    $css_lines[] = sprintf(
-        '@media (min-width: %dpx) {',
-        $desktop_min_bp
-    );
-    $css_lines[] = '    .vb-hide-on-desktop,';
-    $css_lines[] = '    .vb-mobile-only,';
-    $css_lines[] = '    .vb-tablet-only { display: none !important; }';
-    $css_lines[] = '}';
+        if ( $has_valid_tablet_bp ) {
+            $css_lines[] = sprintf(
+                '@media (min-width: %1$dpx) and (max-width: %2$dpx) {',
+                $tablet_min_bp,
+                $tablet_bp
+            );
+            $css_lines[] = '    .vb-hide-on-tablet,';
+            $css_lines[] = '    .vb-mobile-only,';
+            $css_lines[] = '    .vb-desktop-only { display: none !important; }';
+            $css_lines[] = '}';
+        }
+
+        $css_lines[] = sprintf(
+            '@media (min-width: %dpx) {',
+            $desktop_min_bp
+        );
+        $css_lines[] = '    .vb-hide-on-desktop,';
+        $css_lines[] = '    .vb-mobile-only,';
+        $css_lines[] = '    .vb-tablet-only { display: none !important; }';
+        $css_lines[] = '}';
+    }
 
     if ( $can_preview ) {
         $css_lines[] = '.vb-desktop-only, .vb-tablet-only, .vb-mobile-only, .vb-hide-on-desktop, .vb-hide-on-tablet, .vb-hide-on-mobile { position: relative; outline: 2px dashed #0073aa; outline-offset: 2px; }';

--- a/visi-bloc-jlg/includes/visibility-logic.php
+++ b/visi-bloc-jlg/includes/visibility-logic.php
@@ -1,75 +1,46 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-add_filter( 'render_block', 'visibloc_jlg_render_block_filter', 10, 2 );
+add_filter( 'render_block_core/group', 'visibloc_jlg_render_block_filter', 10, 2 );
 function visibloc_jlg_render_block_filter( $block_content, $block ) {
-    if ( empty( $block['blockName'] ) || 'core/group' !== $block['blockName'] ) { return $block_content; }
     if ( empty( $block['attrs'] ) ) { return $block_content; }
+
     $attrs = $block['attrs'];
-    $is_admin_or_technical_request = function_exists( 'visibloc_jlg_is_admin_or_technical_request' )
-        ? visibloc_jlg_is_admin_or_technical_request()
-        : false;
-    $is_preview_role_neutralized = $is_admin_or_technical_request;
-    $effective_user_id = function_exists( 'visibloc_jlg_get_effective_user_id' ) ? visibloc_jlg_get_effective_user_id() : 0;
-    $can_impersonate = $effective_user_id && function_exists( 'visibloc_jlg_is_user_allowed_to_impersonate' )
-        ? visibloc_jlg_is_user_allowed_to_impersonate( $effective_user_id )
-        : false;
-    $can_preview_hidden_blocks = $effective_user_id && function_exists( 'visibloc_jlg_is_user_allowed_to_preview' )
-        ? visibloc_jlg_is_user_allowed_to_preview( $effective_user_id )
-        : false;
-    $had_preview_permission = $can_preview_hidden_blocks;
 
-    if ( function_exists( 'visibloc_jlg_get_allowed_preview_roles' ) ) {
-        $allowed_preview_roles = visibloc_jlg_get_allowed_preview_roles();
-    } else {
-        $allowed_preview_roles = (array) get_option( 'visibloc_preview_roles', [ 'administrator' ] );
-        $allowed_preview_roles = array_map( 'sanitize_key', $allowed_preview_roles );
+    $visibility_roles = [];
 
-        if ( empty( $allowed_preview_roles ) ) {
-            $allowed_preview_roles = [ 'administrator' ];
+    if ( array_key_exists( 'visibilityRoles', $attrs ) ) {
+        $raw_visibility_roles = $attrs['visibilityRoles'];
+
+        if ( is_array( $raw_visibility_roles ) ) {
+            $visibility_roles = $raw_visibility_roles;
+        } elseif ( is_string( $raw_visibility_roles ) ) {
+            $visibility_roles = '' === trim( $raw_visibility_roles ) ? [] : [ $raw_visibility_roles ];
+        } elseif ( is_scalar( $raw_visibility_roles ) ) {
+            $visibility_roles = [ $raw_visibility_roles ];
         }
+
+        $visibility_roles = array_filter( array_map( 'sanitize_key', $visibility_roles ) );
     }
 
-    if ( $is_preview_role_neutralized ) {
-        $preview_role = '';
-    } elseif ( function_exists( 'visibloc_jlg_get_preview_role_from_cookie' ) ) {
-        $preview_role = visibloc_jlg_get_preview_role_from_cookie();
-    } else {
-        $preview_role = isset( $_COOKIE['visibloc_preview_role'] ) ? sanitize_key( wp_unslash( $_COOKIE['visibloc_preview_role'] ) ) : '';
+    $has_hidden_flag      = ! empty( $attrs['isHidden'] );
+    $has_schedule_enabled = ! empty( $attrs['isSchedulingEnabled'] );
+
+    if ( ! $has_hidden_flag && ! $has_schedule_enabled && empty( $visibility_roles ) ) {
+        return $block_content;
     }
 
-    $preview_role = is_string( $preview_role ) ? $preview_role : '';
+    $preview_context = function_exists( 'visibloc_jlg_get_preview_runtime_context' )
+        ? visibloc_jlg_get_preview_runtime_context()
+        : [
+            'can_preview_hidden_blocks'  => false,
+            'should_apply_preview_role'  => false,
+            'preview_role'               => '',
+        ];
 
-    if ( $can_preview_hidden_blocks && $is_preview_role_neutralized ) {
-        $can_preview_hidden_blocks = false;
-    }
+    $can_preview_hidden_blocks = ! empty( $preview_context['can_preview_hidden_blocks'] );
 
-    $should_apply_preview_role = false;
-
-    if ( ! $is_preview_role_neutralized && '' !== $preview_role ) {
-        if ( 'guest' === $preview_role ) {
-            $can_preview_hidden_blocks = false;
-            $should_apply_preview_role = ( $had_preview_permission || $can_impersonate );
-        } else {
-            if ( ! in_array( $preview_role, $allowed_preview_roles, true ) ) {
-                $can_preview_hidden_blocks = false;
-            }
-
-            if ( ! $can_impersonate ) {
-                $preview_role = '';
-            } elseif ( ! get_role( $preview_role ) ) {
-                $preview_role = '';
-            } else {
-                $should_apply_preview_role = true;
-            }
-        }
-    }
-
-    if ( '' === $preview_role ) {
-        $should_apply_preview_role = false;
-    }
-
-    if ( ! empty( $attrs['isSchedulingEnabled'] ) ) {
+    if ( $has_schedule_enabled ) {
         $current_time = current_time( 'timestamp', true );
 
         $start_time = visibloc_jlg_parse_schedule_datetime( $attrs['publishStartDate'] ?? null );
@@ -93,21 +64,10 @@ function visibloc_jlg_render_block_filter( $block_content, $block ) {
         }
     }
 
-    $visibility_roles = [];
-
-    if ( array_key_exists( 'visibilityRoles', $attrs ) ) {
-        $raw_visibility_roles = $attrs['visibilityRoles'];
-
-        if ( is_array( $raw_visibility_roles ) ) {
-            $visibility_roles = $raw_visibility_roles;
-        } elseif ( is_string( $raw_visibility_roles ) ) {
-            $visibility_roles = '' === trim( $raw_visibility_roles ) ? [] : [ $raw_visibility_roles ];
-        } elseif ( is_scalar( $raw_visibility_roles ) ) {
-            $visibility_roles = [ $raw_visibility_roles ];
-        }
-    }
-
     if ( ! empty( $visibility_roles ) ) {
+        $should_apply_preview_role = ! empty( $preview_context['should_apply_preview_role'] );
+        $preview_role              = is_string( $preview_context['preview_role'] ?? '' ) ? $preview_context['preview_role'] : '';
+
         $user = wp_get_current_user();
         $is_logged_in = $user->exists();
         $user_roles = (array) $user->roles;
@@ -130,7 +90,7 @@ function visibloc_jlg_render_block_filter( $block_content, $block ) {
         if ( ! $is_visible ) return '';
     }
     
-    if ( isset( $attrs['isHidden'] ) && $attrs['isHidden'] === true ) {
+    if ( $has_hidden_flag ) {
         if ( $can_preview_hidden_blocks ) {
             return sprintf(
                 '<div class="bloc-cache-apercu" data-visibloc-label="%s">%s</div>',

--- a/visi-bloc-jlg/tests/phpunit/integration/VisibilityLogicTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/VisibilityLogicTest.php
@@ -173,11 +173,15 @@ class VisibilityLogicTest extends TestCase {
     }
 
     public function test_generate_device_visibility_css_respects_preview_context(): void {
-        $css_without_preview = visibloc_jlg_generate_device_visibility_css( false );
-        $this->assertStringContainsString( '@media (max-width: 781px)', $css_without_preview );
-        $this->assertStringNotContainsString( 'outline: 2px dashed', $css_without_preview );
+        $css_without_preview = visibloc_jlg_generate_device_visibility_css( false, 781, 1024 );
+        $this->assertSame( '', trim( $css_without_preview ) );
 
-        $css_with_preview = visibloc_jlg_generate_device_visibility_css( true );
+        $css_with_custom_breakpoints = visibloc_jlg_generate_device_visibility_css( false, 700, 900 );
+        $this->assertStringContainsString( '@media (max-width: 700px)', $css_with_custom_breakpoints );
+        $this->assertStringContainsString( '@media (min-width: 901px)', $css_with_custom_breakpoints );
+        $this->assertStringNotContainsString( 'outline: 2px dashed', $css_with_custom_breakpoints );
+
+        $css_with_preview = visibloc_jlg_generate_device_visibility_css( true, 781, 1024 );
         $this->assertStringContainsString( 'outline: 2px dashed #0073aa', $css_with_preview );
         $this->assertStringContainsString( 'Visible sur Desktop Uniquement', $css_with_preview );
     }

--- a/visi-bloc-jlg/visi-bloc-jlg.php
+++ b/visi-bloc-jlg/visi-bloc-jlg.php
@@ -62,68 +62,14 @@ function visibloc_jlg_can_user_preview() {
         return $cached_can_preview;
     }
 
-    if ( function_exists( 'visibloc_jlg_get_allowed_preview_roles' ) ) {
-        $allowed_roles = visibloc_jlg_get_allowed_preview_roles();
-    } else {
-        $allowed_roles = (array) get_option( 'visibloc_preview_roles', [ 'administrator' ] );
-        $allowed_roles = array_map( 'sanitize_key', $allowed_roles );
-
-        if ( empty( $allowed_roles ) ) {
-            $allowed_roles = [ 'administrator' ];
-        }
-    }
-
-    if ( function_exists( 'visibloc_jlg_get_preview_role_from_cookie' ) ) {
-        $preview_role_cookie = visibloc_jlg_get_preview_role_from_cookie();
-    } else {
-        if ( isset( $_COOKIE['visibloc_preview_role'] ) && is_string( $_COOKIE['visibloc_preview_role'] ) ) {
-            $preview_role_cookie = sanitize_key( wp_unslash( $_COOKIE['visibloc_preview_role'] ) );
-        } else {
-            $preview_role_cookie = '';
-        }
-    }
-
-    if ( 'guest' === $preview_role_cookie ) {
-        $cached_can_preview = false;
+    if ( function_exists( 'visibloc_jlg_get_preview_runtime_context' ) ) {
+        $runtime_context = visibloc_jlg_get_preview_runtime_context();
+        $cached_can_preview = ! empty( $runtime_context['can_preview_hidden_blocks'] );
 
         return $cached_can_preview;
     }
 
-    if ( $preview_role_cookie && 'guest' !== $preview_role_cookie && ! in_array( $preview_role_cookie, $allowed_roles, true ) ) {
-        $cached_can_preview = false;
-
-        return $cached_can_preview;
-    }
-
-    if ( function_exists( 'visibloc_jlg_get_effective_user_id' ) ) {
-        $user_id = visibloc_jlg_get_effective_user_id();
-    } elseif ( function_exists( 'visibloc_jlg_get_stored_real_user_id' ) ) {
-        $user_id = visibloc_jlg_get_stored_real_user_id();
-
-        if ( ! $user_id ) {
-            $user_id = get_current_user_id();
-        }
-    } else {
-        $user_id = get_current_user_id();
-    }
-
-    $user_id = absint( $user_id );
-
-    if ( ! $user_id ) {
-        $cached_can_preview = false;
-
-        return $cached_can_preview;
-    }
-
-    $user = get_userdata( $user_id );
-
-    if ( ! $user ) {
-        $cached_can_preview = false;
-
-        return $cached_can_preview;
-    }
-
-    $cached_can_preview = count( array_intersect( (array) $user->roles, $allowed_roles ) ) > 0;
+    $cached_can_preview = false;
 
     return $cached_can_preview;
 }


### PR DESCRIPTION
## Summary
- centralize preview runtime calculations and update the core/group render filter to short-circuit early while relying on the shared context
- add a default device-visibility stylesheet and only inline breakpoint overrides alongside preview outlines when needed
- validate saved preview roles against editable roles and refresh the PHPUnit coverage to reflect the new behaviour

## Testing
- ./vendor/bin/phpunit -c phpunit.xml.dist

------
https://chatgpt.com/codex/tasks/task_e_68d42f36e868832ebb14b88595b4806f