### PR TITLE
Fix nonce handling for admin and role switching

### DIFF
--- a/visi-bloc-jlg/includes/admin-settings.php
+++ b/visi-bloc-jlg/includes/admin-settings.php
@@ -6,8 +6,9 @@ function visibloc_jlg_handle_options_save() {
     if ( ! current_user_can( 'manage_options' ) ) return;
     if ( ! isset( $_POST['visibloc_nonce'] ) ) return;
 
-    $nonce = sanitize_text_field( wp_unslash( $_POST['visibloc_nonce'] ) );
-    if ( '' === $nonce ) return;
+    $nonce = isset( $_POST['visibloc_nonce'] ) ? wp_unslash( $_POST['visibloc_nonce'] ) : '';
+
+    if ( ! is_string( $nonce ) || '' === $nonce ) return;
 
     $mobile_breakpoint          = null;
     $mobile_breakpoint_invalid  = false;

--- a/visi-bloc-jlg/includes/role-switcher.php
+++ b/visi-bloc-jlg/includes/role-switcher.php
@@ -530,11 +530,21 @@ function visibloc_jlg_handle_role_switching() {
         return;
     }
 
-    $cookie_name = 'visibloc_preview_role';
     if ( isset( $_GET['preview_role'] ) ) {
-        $role_to_preview = visibloc_jlg_get_sanitized_query_arg( 'preview_role' );
+        $requested_role = wp_unslash( $_GET['preview_role'] );
+
+        if ( ! is_string( $requested_role ) || '' === $requested_role ) {
+            return;
+        }
+
+        $role_to_preview = sanitize_key( $requested_role );
 
         if ( '' === $role_to_preview ) {
+            return;
+        }
+
+        $nonce = isset( $_GET['_wpnonce'] ) ? wp_unslash( $_GET['_wpnonce'] ) : '';
+        if ( ! is_string( $nonce ) || '' === $nonce || ! wp_verify_nonce( $nonce, 'visibloc_switch_role_' . $role_to_preview ) ) {
             return;
         }
 
@@ -545,10 +555,6 @@ function visibloc_jlg_handle_role_switching() {
 
             visibloc_jlg_set_preview_cookie( '', time() - 3600 );
 
-            return;
-        }
-        $nonce = isset( $_GET['_wpnonce'] ) ? sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ) : '';
-        if ( ! $role_to_preview || ! $nonce || ! wp_verify_nonce( $nonce, 'visibloc_switch_role_' . $role_to_preview ) ) {
             return;
         }
 
@@ -568,8 +574,8 @@ function visibloc_jlg_handle_role_switching() {
         exit;
     }
     if ( isset( $_GET['stop_preview_role'] ) ) {
-        $nonce = isset( $_GET['_wpnonce'] ) ? sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ) : '';
-        if ( ! $nonce || ! wp_verify_nonce( $nonce, 'visibloc_switch_role_stop' ) ) {
+        $nonce = isset( $_GET['_wpnonce'] ) ? wp_unslash( $_GET['_wpnonce'] ) : '';
+        if ( ! is_string( $nonce ) || '' === $nonce || ! wp_verify_nonce( $nonce, 'visibloc_switch_role_stop' ) ) {
             return;
         }
         visibloc_jlg_set_preview_cookie( '', time() - 3600 );


### PR DESCRIPTION
## Summary
- stop sanitizing nonces when processing admin settings submissions
- validate role-switching requests with unslashed nonce values and drop an unused variable

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d4361de0ac832eb2aa0de7ff57f44d