### PR TITLE
Harden option saving and preview role handling

### DIFF
--- a/visi-bloc-jlg/includes/admin-settings.php
+++ b/visi-bloc-jlg/includes/admin-settings.php
@@ -4,6 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 add_action( 'admin_init', 'visibloc_jlg_handle_options_save' );
 function visibloc_jlg_handle_options_save() {
     if ( ! current_user_can( 'manage_options' ) ) return;
+
+    $request_method = isset( $_SERVER['REQUEST_METHOD'] ) ? strtoupper( wp_unslash( $_SERVER['REQUEST_METHOD'] ) ) : '';
+    if ( 'POST' !== $request_method ) return;
+
     if ( ! isset( $_POST['visibloc_nonce'] ) ) return;
 
     $nonce = isset( $_POST['visibloc_nonce'] ) ? wp_unslash( $_POST['visibloc_nonce'] ) : '';


### PR DESCRIPTION
## Summary
- guard the admin options save handler to only process POST submissions before checking the nonce
- cache the current user snapshot when evaluating visibility roles and reuse role lookups while double-checking preview-role permissions
- ensure impersonated roles outside the allowed preview list lose hidden-block privileges without breaking editor previews

## Testing
- ./vendor/bin/phpunit -c phpunit.xml.dist

------
https://chatgpt.com/codex/tasks/task_e_68d44c24dac8832e8a38d943072938e3