### PR TITLE
Allow preview wrapper when role check hides hidden block

### DIFF
--- a/visi-bloc-jlg/includes/visibility-logic.php
+++ b/visi-bloc-jlg/includes/visibility-logic.php
@@ -39,6 +39,16 @@ function visibloc_jlg_render_block_filter( $block_content, $block ) {
         ];
 
     $can_preview_hidden_blocks = ! empty( $preview_context['can_preview_hidden_blocks'] );
+    $should_show_hidden_preview = $has_hidden_flag && $can_preview_hidden_blocks;
+    $hidden_preview_markup = null;
+
+    if ( $should_show_hidden_preview ) {
+        $hidden_preview_markup = sprintf(
+            '<div class="bloc-cache-apercu" data-visibloc-label="%s">%s</div>',
+            esc_attr__( 'Hidden block', 'visi-bloc-jlg' ),
+            $block_content
+        );
+    }
 
     if ( $has_schedule_enabled ) {
         $current_time = current_time( 'timestamp' );
@@ -127,18 +137,13 @@ function visibloc_jlg_render_block_filter( $block_content, $block ) {
         if ( in_array( 'logged-out', $visibility_roles, true ) && ! $is_logged_in ) $is_visible = true;
         if ( ! $is_visible && in_array( 'logged-in', $visibility_roles, true ) && $is_logged_in ) $is_visible = true;
         if ( ! $is_visible && ! empty( $user_roles ) && count( array_intersect( $user_roles, $visibility_roles ) ) > 0 ) { $is_visible = true; }
-        if ( ! $is_visible ) return '';
-    }
-    
-    if ( $has_hidden_flag ) {
-        if ( $can_preview_hidden_blocks ) {
-            return sprintf(
-                '<div class="bloc-cache-apercu" data-visibloc-label="%s">%s</div>',
-                esc_attr__( 'Hidden block', 'visi-bloc-jlg' ),
-                $block_content
-            );
+        if ( ! $is_visible ) {
+            return $should_show_hidden_preview ? $hidden_preview_markup : '';
         }
-        return '';
+    }
+
+    if ( $has_hidden_flag ) {
+        return $should_show_hidden_preview ? $hidden_preview_markup : '';
     }
 
     return $block_content;

--- a/visi-bloc-jlg/tests/phpunit/integration/VisibilityLogicTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/VisibilityLogicTest.php
@@ -59,6 +59,30 @@ class VisibilityLogicTest extends TestCase {
         );
     }
 
+    public function test_hidden_block_placeholder_visible_for_authorized_previewers_with_role_mismatch(): void {
+        global $visibloc_test_state;
+
+        $visibloc_test_state['effective_user_id']       = 42;
+        $visibloc_test_state['current_user']            = new Visibloc_Test_User( 42, [ 'administrator' ] );
+        $visibloc_test_state['can_preview_users'][42]   = true;
+        $visibloc_test_state['can_impersonate_users'][42] = true;
+        $visibloc_test_state['allowed_preview_roles']   = [ 'administrator', 'editor' ];
+        $visibloc_test_state['preview_role']            = 'editor';
+
+        $block = [
+            'blockName' => 'core/group',
+            'attrs'     => [
+                'isHidden'         => true,
+                'visibilityRoles'  => [ 'administrator' ],
+            ],
+        ];
+
+        $output = visibloc_jlg_render_block_filter( '<p>Hidden admin content</p>', $block );
+
+        $this->assertStringContainsString( 'bloc-cache-apercu', $output );
+        $this->assertStringContainsString( '<p>Hidden admin content</p>', $output );
+    }
+
     public function test_visibility_roles_accepts_string_role_values(): void {
         global $visibloc_test_state;
 


### PR DESCRIPTION
## Summary
- ensure preview wrappers are computed before short-circuiting invisible blocks
- reuse the same preview markup for hidden blocks after role filtering
- cover preview-role mismatch scenario with a new integration test

## Testing
- ./vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68d50aa9ea58832e8547b02197c31b65