### PR TITLE
Refine device visibility CSS handling

### DIFF
--- a/visi-bloc-jlg/includes/assets.php
+++ b/visi-bloc-jlg/includes/assets.php
@@ -11,10 +11,15 @@ function visibloc_jlg_enqueue_public_styles() {
     $tablet_bp        = absint( get_option( 'visibloc_breakpoint_tablet', $default_tablet ) );
     $mobile_bp        = $mobile_bp > 0 ? $mobile_bp : $default_mobile;
     $tablet_bp        = $tablet_bp > 0 ? $tablet_bp : $default_tablet;
-    $device_handle    = 'visibloc-jlg-device-visibility';
-    $device_style_src = plugins_url( 'assets/device-visibility.css', $plugin_main_file );
+    $has_custom_breakpoints = ( $mobile_bp !== $default_mobile ) || ( $tablet_bp !== $default_tablet );
+    $device_handle          = $has_custom_breakpoints ? 'visibloc-jlg-device-visibility-dynamic' : 'visibloc-jlg-device-visibility';
+    $device_style_src       = plugins_url( 'assets/device-visibility.css', $plugin_main_file );
 
-    wp_register_style( $device_handle, $device_style_src, [], '1.1' );
+    if ( $has_custom_breakpoints ) {
+        wp_register_style( $device_handle, false, [], '1.1' );
+    } else {
+        wp_register_style( $device_handle, $device_style_src, [], '1.1' );
+    }
     wp_enqueue_style( $device_handle );
 
     $device_css = visibloc_jlg_generate_device_visibility_css( $can_preview, $mobile_bp, $tablet_bp );
@@ -55,45 +60,190 @@ function visibloc_jlg_generate_device_visibility_css( $can_preview, $mobile_bp =
     $mobile_bp = $mobile_bp > 0 ? $mobile_bp : $default_mobile_bp;
     $tablet_bp = $tablet_bp > 0 ? $tablet_bp : $default_tablet_bp;
 
-    $has_custom_breakpoints = ( $mobile_bp !== $default_mobile_bp ) || ( $tablet_bp !== $default_tablet_bp );
-
     $css_lines = [];
 
-    if ( $has_custom_breakpoints ) {
-        $tablet_min_bp        = $mobile_bp + 1;
-        $has_valid_tablet_bp  = ( $tablet_bp > $mobile_bp );
-        $desktop_reference_bp = $has_valid_tablet_bp ? $tablet_bp : $mobile_bp;
-        $desktop_min_bp       = $desktop_reference_bp + 1;
+    $has_valid_tablet_bp  = ( $tablet_bp > $mobile_bp );
+    $tablet_min_bp        = $mobile_bp + 1;
+    $desktop_reference_bp = $has_valid_tablet_bp ? $tablet_bp : $mobile_bp;
+    $desktop_min_bp       = $desktop_reference_bp + 1;
 
+    $css_lines[] = sprintf(
+        '@media (max-width: %dpx) {',
+        $mobile_bp
+    );
+    $css_lines[] = '    .vb-hide-on-mobile,';
+    $css_lines[] = '    .vb-tablet-only,';
+    $css_lines[] = '    .vb-desktop-only { display: none !important; }';
+    $css_lines[] = '}';
+
+    if ( $has_valid_tablet_bp ) {
         $css_lines[] = sprintf(
-            '@media (max-width: %dpx) {',
-            $mobile_bp
+            '@media (min-width: %1$dpx) and (max-width: %2$dpx) {',
+            $tablet_min_bp,
+            $tablet_bp
         );
-        $css_lines[] = '    .vb-hide-on-mobile,';
-        $css_lines[] = '    .vb-tablet-only,';
+        $css_lines[] = '    .vb-hide-on-tablet,';
+        $css_lines[] = '    .vb-mobile-only,';
         $css_lines[] = '    .vb-desktop-only { display: none !important; }';
         $css_lines[] = '}';
+    }
 
-        if ( $has_valid_tablet_bp ) {
-            $css_lines[] = sprintf(
-                '@media (min-width: %1$dpx) and (max-width: %2$dpx) {',
-                $tablet_min_bp,
-                $tablet_bp
-            );
-            $css_lines[] = '    .vb-hide-on-tablet,';
-            $css_lines[] = '    .vb-mobile-only,';
-            $css_lines[] = '    .vb-desktop-only { display: none !important; }';
-            $css_lines[] = '}';
+    $css_lines[] = sprintf(
+        '@media (min-width: %dpx) {',
+        $desktop_min_bp
+    );
+    $css_lines[] = '    .vb-hide-on-desktop,';
+    $css_lines[] = '    .vb-mobile-only,';
+    $css_lines[] = '    .vb-tablet-only { display: none !important; }';
+    $css_lines[] = '}';
+
+    $has_custom_breakpoints = ( $mobile_bp !== $default_mobile_bp ) || ( $tablet_bp !== $default_tablet_bp );
+
+    if ( $has_custom_breakpoints ) {
+        $static_blocks = [
+            [
+                'min'       => null,
+                'max'       => $default_mobile_bp,
+                'selectors' => [
+                    '.vb-hide-on-mobile',
+                    '.vb-tablet-only',
+                    '.vb-desktop-only',
+                ],
+            ],
+            [
+                'min'       => $default_mobile_bp + 1,
+                'max'       => $default_tablet_bp,
+                'selectors' => [
+                    '.vb-hide-on-tablet',
+                    '.vb-mobile-only',
+                    '.vb-desktop-only',
+                ],
+            ],
+            [
+                'min'       => $default_tablet_bp + 1,
+                'max'       => null,
+                'selectors' => [
+                    '.vb-hide-on-desktop',
+                    '.vb-mobile-only',
+                    '.vb-tablet-only',
+                ],
+            ],
+        ];
+
+        $visible_ranges = [
+            '.vb-hide-on-mobile' => [ [ $mobile_bp + 1, null ] ],
+            '.vb-tablet-only'    => $has_valid_tablet_bp ? [ [ $tablet_min_bp, $tablet_bp ] ] : [],
+            '.vb-desktop-only'   => [ [ $desktop_min_bp, null ] ],
+            '.vb-hide-on-tablet' => $has_valid_tablet_bp ? [ [ null, $mobile_bp ], [ $tablet_bp + 1, null ] ] : [ [ null, null ] ],
+            '.vb-mobile-only'    => [ [ null, $mobile_bp ] ],
+            '.vb-hide-on-desktop'=> [ [ null, $desktop_min_bp - 1 ] ],
+        ];
+
+        $reset_blocks = [];
+
+        foreach ( $static_blocks as $block ) {
+            $static_min = isset( $block['min'] ) ? (int) $block['min'] : null;
+            $static_max = isset( $block['max'] ) ? (int) $block['max'] : null;
+
+            foreach ( $block['selectors'] as $selector ) {
+                if ( empty( $visible_ranges[ $selector ] ) ) {
+                    continue;
+                }
+
+                foreach ( $visible_ranges[ $selector ] as $visible_range ) {
+                    $range_min = isset( $visible_range[0] ) ? (int) $visible_range[0] : null;
+                    $range_max = isset( $visible_range[1] ) ? (int) $visible_range[1] : null;
+
+                    $intersection = visibloc_jlg_intersect_ranges( $static_min, $static_max, $range_min, $range_max );
+
+                    if ( null === $intersection ) {
+                        continue;
+                    }
+
+                    $key = sprintf(
+                        '%s:%s',
+                        null === $intersection['min'] ? '' : $intersection['min'],
+                        null === $intersection['max'] ? '' : $intersection['max']
+                    );
+
+                    if ( ! isset( $reset_blocks[ $key ] ) ) {
+                        $reset_blocks[ $key ] = [
+                            'min'       => $intersection['min'],
+                            'max'       => $intersection['max'],
+                            'selectors' => [],
+                        ];
+                    }
+
+                    if ( ! in_array( $selector, $reset_blocks[ $key ]['selectors'], true ) ) {
+                        $reset_blocks[ $key ]['selectors'][] = $selector;
+                    }
+                }
+            }
         }
 
-        $css_lines[] = sprintf(
-            '@media (min-width: %dpx) {',
-            $desktop_min_bp
-        );
-        $css_lines[] = '    .vb-hide-on-desktop,';
-        $css_lines[] = '    .vb-mobile-only,';
-        $css_lines[] = '    .vb-tablet-only { display: none !important; }';
-        $css_lines[] = '}';
+        if ( ! empty( $reset_blocks ) ) {
+            uasort(
+                $reset_blocks,
+                function ( $a, $b ) {
+                    $a_min = isset( $a['min'] ) ? $a['min'] : PHP_INT_MIN;
+                    $b_min = isset( $b['min'] ) ? $b['min'] : PHP_INT_MIN;
+
+                    if ( $a_min === $b_min ) {
+                        $a_max = isset( $a['max'] ) ? $a['max'] : PHP_INT_MAX;
+                        $b_max = isset( $b['max'] ) ? $b['max'] : PHP_INT_MAX;
+
+                        if ( $a_max === $b_max ) {
+                            return 0;
+                        }
+
+                        return ( $a_max < $b_max ) ? -1 : 1;
+                    }
+
+                    return ( $a_min < $b_min ) ? -1 : 1;
+                }
+            );
+
+            foreach ( $reset_blocks as $reset ) {
+                $min = $reset['min'];
+                $max = $reset['max'];
+
+                if ( isset( $min, $max ) && $min > $max ) {
+                    continue;
+                }
+
+                if ( isset( $min ) && isset( $max ) ) {
+                    $css_lines[] = sprintf(
+                        '@media (min-width: %1$dpx) and (max-width: %2$dpx) {',
+                        $min,
+                        $max
+                    );
+                } elseif ( isset( $min ) ) {
+                    $css_lines[] = sprintf(
+                        '@media (min-width: %dpx) {',
+                        $min
+                    );
+                } elseif ( isset( $max ) ) {
+                    $css_lines[] = sprintf(
+                        '@media (max-width: %dpx) {',
+                        $max
+                    );
+                } else {
+                    continue;
+                }
+
+                $selector_count = count( $reset['selectors'] );
+                foreach ( $reset['selectors'] as $index => $selector ) {
+                    $is_last = ( $index === $selector_count - 1 );
+                    $css_lines[] = sprintf(
+                        '    %s%s',
+                        $selector,
+                        $is_last ? ' { display: revert !important; }' : ','
+                    );
+                }
+
+                $css_lines[] = '}';
+            }
+        }
     }
 
     if ( $can_preview ) {
@@ -119,5 +269,31 @@ function visibloc_jlg_generate_device_visibility_css( $can_preview, $mobile_bp =
     }
 
     return implode( "\n", $css_lines );
+}
+
+function visibloc_jlg_intersect_ranges( $min_a, $max_a, $min_b, $max_b ) {
+    $range_a_min = isset( $min_a ) ? (int) $min_a : -INF;
+    $range_a_max = isset( $max_a ) ? (int) $max_a : INF;
+    $range_b_min = isset( $min_b ) ? (int) $min_b : -INF;
+    $range_b_max = isset( $max_b ) ? (int) $max_b : INF;
+
+    $intersection_min = max( $range_a_min, $range_b_min );
+    $intersection_max = min( $range_a_max, $range_b_max );
+
+    if ( $intersection_min > $intersection_max ) {
+        return null;
+    }
+
+    $resolved_min = is_infinite( $intersection_min ) ? null : (int) $intersection_min;
+    $resolved_max = is_infinite( $intersection_max ) ? null : (int) $intersection_max;
+
+    if ( isset( $resolved_min, $resolved_max ) && $resolved_min > $resolved_max ) {
+        return null;
+    }
+
+    return [
+        'min' => $resolved_min,
+        'max' => $resolved_max,
+    ];
 }
 

--- a/visi-bloc-jlg/tests/phpunit/integration/DeviceVisibilityCssTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/DeviceVisibilityCssTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../../includes/assets.php';
+
+class DeviceVisibilityCssTest extends TestCase {
+    public function test_mobile_breakpoint_lower_than_default_unhides_tablet_classes(): void {
+        $css = visibloc_jlg_generate_device_visibility_css( false, 600, 1024 );
+
+        $this->assertStringContainsString('@media (max-width: 600px)', $css);
+        $this->assertStringNotContainsString('@media (max-width: 781px)', $css);
+        $this->assertMatchesRegularExpression(
+            '/@media \\(min-width: 601px\\) and \\(max-width: 781px\\) {\\s+\\.vb-hide-on-mobile,\\s+\\.vb-tablet-only \\{ display: revert !important; \\}\\s+}/',
+            $css
+        );
+    }
+}

--- a/visi-bloc-jlg/tests/phpunit/integration/VisibilityLogicTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/VisibilityLogicTest.php
@@ -227,7 +227,24 @@ class VisibilityLogicTest extends TestCase {
 
     public function test_generate_device_visibility_css_respects_preview_context(): void {
         $css_without_preview = visibloc_jlg_generate_device_visibility_css( false, 781, 1024 );
-        $this->assertSame( '', trim( $css_without_preview ) );
+        $expected_default_css = <<<CSS
+@media (max-width: 781px) {
+    .vb-hide-on-mobile,
+    .vb-tablet-only,
+    .vb-desktop-only { display: none !important; }
+}
+@media (min-width: 782px) and (max-width: 1024px) {
+    .vb-hide-on-tablet,
+    .vb-mobile-only,
+    .vb-desktop-only { display: none !important; }
+}
+@media (min-width: 1025px) {
+    .vb-hide-on-desktop,
+    .vb-mobile-only,
+    .vb-tablet-only { display: none !important; }
+}
+CSS;
+        $this->assertSame( $expected_default_css, trim( $css_without_preview ) );
 
         $css_with_custom_breakpoints = visibloc_jlg_generate_device_visibility_css( false, 700, 900 );
         $this->assertStringContainsString( '@media (max-width: 700px)', $css_with_custom_breakpoints );


### PR DESCRIPTION
## Summary
- register a separate style handle for custom device breakpoints and always enqueue the generated CSS
- rebuild the device visibility CSS generator to emit full breakpoint rules and targeted overrides when thresholds change
- extend the PHPUnit suite with a regression test for lowered mobile breakpoints and update the preview coverage expectations

## Testing
- ./vendor/bin/phpunit --configuration phpunit.xml.dist

------
https://chatgpt.com/codex/tasks/task_e_68d5c0555e64832e8e1def94edd73a04