### PR TITLE
Refine device visibility styles for custom breakpoints

### DIFF
--- a/visi-bloc-jlg/includes/assets.php
+++ b/visi-bloc-jlg/includes/assets.php
@@ -12,14 +12,20 @@ function visibloc_jlg_enqueue_public_styles() {
     $mobile_bp        = $mobile_bp > 0 ? $mobile_bp : $default_mobile;
     $tablet_bp        = $tablet_bp > 0 ? $tablet_bp : $default_tablet;
     $has_custom_breakpoints = ( $mobile_bp !== $default_mobile ) || ( $tablet_bp !== $default_tablet );
-    $device_handle          = $has_custom_breakpoints ? 'visibloc-jlg-device-visibility-dynamic' : 'visibloc-jlg-device-visibility';
     $device_style_src       = plugins_url( 'assets/device-visibility.css', $plugin_main_file );
+    $default_handle         = 'visibloc-jlg-device-visibility';
+    $dynamic_handle         = 'visibloc-jlg-device-visibility-dynamic';
 
     if ( $has_custom_breakpoints ) {
-        wp_register_style( $device_handle, false, [], '1.1' );
+        wp_dequeue_style( $default_handle );
+        wp_deregister_style( $default_handle );
+        wp_register_style( $dynamic_handle, false, [], '1.1' );
+        $device_handle = $dynamic_handle;
     } else {
-        wp_register_style( $device_handle, $device_style_src, [], '1.1' );
+        wp_register_style( $default_handle, $device_style_src, [], '1.1' );
+        $device_handle = $default_handle;
     }
+
     wp_enqueue_style( $device_handle );
 
     $device_css = visibloc_jlg_generate_device_visibility_css( $can_preview, $mobile_bp, $tablet_bp );
@@ -60,189 +66,25 @@ function visibloc_jlg_generate_device_visibility_css( $can_preview, $mobile_bp =
     $mobile_bp = $mobile_bp > 0 ? $mobile_bp : $default_mobile_bp;
     $tablet_bp = $tablet_bp > 0 ? $tablet_bp : $default_tablet_bp;
 
-    $css_lines = [];
+    $css_lines      = [];
+    $current_blocks = visibloc_jlg_build_visibility_blocks( $mobile_bp, $tablet_bp );
 
-    $has_valid_tablet_bp  = ( $tablet_bp > $mobile_bp );
-    $tablet_min_bp        = $mobile_bp + 1;
-    $desktop_reference_bp = $has_valid_tablet_bp ? $tablet_bp : $mobile_bp;
-    $desktop_min_bp       = $desktop_reference_bp + 1;
-
-    $css_lines[] = sprintf(
-        '@media (max-width: %dpx) {',
-        $mobile_bp
+    $css_lines = array_merge(
+        $css_lines,
+        visibloc_jlg_render_visibility_blocks( $current_blocks, 'display: none !important;' )
     );
-    $css_lines[] = '    .vb-hide-on-mobile,';
-    $css_lines[] = '    .vb-tablet-only,';
-    $css_lines[] = '    .vb-desktop-only { display: none !important; }';
-    $css_lines[] = '}';
-
-    if ( $has_valid_tablet_bp ) {
-        $css_lines[] = sprintf(
-            '@media (min-width: %1$dpx) and (max-width: %2$dpx) {',
-            $tablet_min_bp,
-            $tablet_bp
-        );
-        $css_lines[] = '    .vb-hide-on-tablet,';
-        $css_lines[] = '    .vb-mobile-only,';
-        $css_lines[] = '    .vb-desktop-only { display: none !important; }';
-        $css_lines[] = '}';
-    }
-
-    $css_lines[] = sprintf(
-        '@media (min-width: %dpx) {',
-        $desktop_min_bp
-    );
-    $css_lines[] = '    .vb-hide-on-desktop,';
-    $css_lines[] = '    .vb-mobile-only,';
-    $css_lines[] = '    .vb-tablet-only { display: none !important; }';
-    $css_lines[] = '}';
 
     $has_custom_breakpoints = ( $mobile_bp !== $default_mobile_bp ) || ( $tablet_bp !== $default_tablet_bp );
 
     if ( $has_custom_breakpoints ) {
-        $static_blocks = [
-            [
-                'min'       => null,
-                'max'       => $default_mobile_bp,
-                'selectors' => [
-                    '.vb-hide-on-mobile',
-                    '.vb-tablet-only',
-                    '.vb-desktop-only',
-                ],
-            ],
-            [
-                'min'       => $default_mobile_bp + 1,
-                'max'       => $default_tablet_bp,
-                'selectors' => [
-                    '.vb-hide-on-tablet',
-                    '.vb-mobile-only',
-                    '.vb-desktop-only',
-                ],
-            ],
-            [
-                'min'       => $default_tablet_bp + 1,
-                'max'       => null,
-                'selectors' => [
-                    '.vb-hide-on-desktop',
-                    '.vb-mobile-only',
-                    '.vb-tablet-only',
-                ],
-            ],
-        ];
-
-        $visible_ranges = [
-            '.vb-hide-on-mobile' => [ [ $mobile_bp + 1, null ] ],
-            '.vb-tablet-only'    => $has_valid_tablet_bp ? [ [ $tablet_min_bp, $tablet_bp ] ] : [],
-            '.vb-desktop-only'   => [ [ $desktop_min_bp, null ] ],
-            '.vb-hide-on-tablet' => $has_valid_tablet_bp ? [ [ null, $mobile_bp ], [ $tablet_bp + 1, null ] ] : [ [ null, null ] ],
-            '.vb-mobile-only'    => [ [ null, $mobile_bp ] ],
-            '.vb-hide-on-desktop'=> [ [ null, $desktop_min_bp - 1 ] ],
-        ];
-
-        $reset_blocks = [];
-
-        foreach ( $static_blocks as $block ) {
-            $static_min = isset( $block['min'] ) ? (int) $block['min'] : null;
-            $static_max = isset( $block['max'] ) ? (int) $block['max'] : null;
-
-            foreach ( $block['selectors'] as $selector ) {
-                if ( empty( $visible_ranges[ $selector ] ) ) {
-                    continue;
-                }
-
-                foreach ( $visible_ranges[ $selector ] as $visible_range ) {
-                    $range_min = isset( $visible_range[0] ) ? (int) $visible_range[0] : null;
-                    $range_max = isset( $visible_range[1] ) ? (int) $visible_range[1] : null;
-
-                    $intersection = visibloc_jlg_intersect_ranges( $static_min, $static_max, $range_min, $range_max );
-
-                    if ( null === $intersection ) {
-                        continue;
-                    }
-
-                    $key = sprintf(
-                        '%s:%s',
-                        null === $intersection['min'] ? '' : $intersection['min'],
-                        null === $intersection['max'] ? '' : $intersection['max']
-                    );
-
-                    if ( ! isset( $reset_blocks[ $key ] ) ) {
-                        $reset_blocks[ $key ] = [
-                            'min'       => $intersection['min'],
-                            'max'       => $intersection['max'],
-                            'selectors' => [],
-                        ];
-                    }
-
-                    if ( ! in_array( $selector, $reset_blocks[ $key ]['selectors'], true ) ) {
-                        $reset_blocks[ $key ]['selectors'][] = $selector;
-                    }
-                }
-            }
-        }
+        $default_blocks = visibloc_jlg_build_visibility_blocks( $default_mobile_bp, $default_tablet_bp );
+        $reset_blocks   = visibloc_jlg_calculate_reset_blocks( $default_blocks, $current_blocks );
 
         if ( ! empty( $reset_blocks ) ) {
-            uasort(
-                $reset_blocks,
-                function ( $a, $b ) {
-                    $a_min = isset( $a['min'] ) ? $a['min'] : PHP_INT_MIN;
-                    $b_min = isset( $b['min'] ) ? $b['min'] : PHP_INT_MIN;
-
-                    if ( $a_min === $b_min ) {
-                        $a_max = isset( $a['max'] ) ? $a['max'] : PHP_INT_MAX;
-                        $b_max = isset( $b['max'] ) ? $b['max'] : PHP_INT_MAX;
-
-                        if ( $a_max === $b_max ) {
-                            return 0;
-                        }
-
-                        return ( $a_max < $b_max ) ? -1 : 1;
-                    }
-
-                    return ( $a_min < $b_min ) ? -1 : 1;
-                }
+            $css_lines = array_merge(
+                $css_lines,
+                visibloc_jlg_render_visibility_blocks( $reset_blocks, 'display: revert !important;' )
             );
-
-            foreach ( $reset_blocks as $reset ) {
-                $min = $reset['min'];
-                $max = $reset['max'];
-
-                if ( isset( $min, $max ) && $min > $max ) {
-                    continue;
-                }
-
-                if ( isset( $min ) && isset( $max ) ) {
-                    $css_lines[] = sprintf(
-                        '@media (min-width: %1$dpx) and (max-width: %2$dpx) {',
-                        $min,
-                        $max
-                    );
-                } elseif ( isset( $min ) ) {
-                    $css_lines[] = sprintf(
-                        '@media (min-width: %dpx) {',
-                        $min
-                    );
-                } elseif ( isset( $max ) ) {
-                    $css_lines[] = sprintf(
-                        '@media (max-width: %dpx) {',
-                        $max
-                    );
-                } else {
-                    continue;
-                }
-
-                $selector_count = count( $reset['selectors'] );
-                foreach ( $reset['selectors'] as $index => $selector ) {
-                    $is_last = ( $index === $selector_count - 1 );
-                    $css_lines[] = sprintf(
-                        '    %s%s',
-                        $selector,
-                        $is_last ? ' { display: revert !important; }' : ','
-                    );
-                }
-
-                $css_lines[] = '}';
-            }
         }
     }
 
@@ -271,29 +113,272 @@ function visibloc_jlg_generate_device_visibility_css( $can_preview, $mobile_bp =
     return implode( "\n", $css_lines );
 }
 
-function visibloc_jlg_intersect_ranges( $min_a, $max_a, $min_b, $max_b ) {
-    $range_a_min = isset( $min_a ) ? (int) $min_a : -INF;
-    $range_a_max = isset( $max_a ) ? (int) $max_a : INF;
-    $range_b_min = isset( $min_b ) ? (int) $min_b : -INF;
-    $range_b_max = isset( $max_b ) ? (int) $max_b : INF;
+function visibloc_jlg_build_visibility_blocks( $mobile_bp, $tablet_bp ) {
+    $mobile_bp = (int) $mobile_bp;
+    $tablet_bp = (int) $tablet_bp;
 
-    $intersection_min = max( $range_a_min, $range_b_min );
-    $intersection_max = min( $range_a_max, $range_b_max );
-
-    if ( $intersection_min > $intersection_max ) {
-        return null;
-    }
-
-    $resolved_min = is_infinite( $intersection_min ) ? null : (int) $intersection_min;
-    $resolved_max = is_infinite( $intersection_max ) ? null : (int) $intersection_max;
-
-    if ( isset( $resolved_min, $resolved_max ) && $resolved_min > $resolved_max ) {
-        return null;
-    }
-
-    return [
-        'min' => $resolved_min,
-        'max' => $resolved_max,
+    $has_valid_tablet = $tablet_bp > $mobile_bp;
+    $blocks           = [
+        [
+            'min'       => null,
+            'max'       => $mobile_bp,
+            'selectors' => [
+                '.vb-hide-on-mobile',
+                '.vb-tablet-only',
+                '.vb-desktop-only',
+            ],
+        ],
     ];
+
+    if ( $has_valid_tablet ) {
+        $blocks[] = [
+            'min'       => $mobile_bp + 1,
+            'max'       => $tablet_bp,
+            'selectors' => [
+                '.vb-hide-on-tablet',
+                '.vb-mobile-only',
+                '.vb-desktop-only',
+            ],
+        ];
+    }
+
+    $desktop_reference = $has_valid_tablet ? $tablet_bp : $mobile_bp;
+
+    $blocks[] = [
+        'min'       => $desktop_reference + 1,
+        'max'       => null,
+        'selectors' => [
+            '.vb-hide-on-desktop',
+            '.vb-mobile-only',
+            '.vb-tablet-only',
+        ],
+    ];
+
+    return $blocks;
+}
+
+function visibloc_jlg_render_visibility_blocks( array $blocks, $declaration ) {
+    $css_lines = [];
+
+    foreach ( $blocks as $block ) {
+        if ( empty( $block['selectors'] ) ) {
+            continue;
+        }
+
+        $min = isset( $block['min'] ) ? (int) $block['min'] : null;
+        $max = isset( $block['max'] ) ? (int) $block['max'] : null;
+
+        if ( isset( $min, $max ) && $min > $max ) {
+            continue;
+        }
+
+        $media_query = visibloc_jlg_format_media_query( $min, $max );
+
+        if ( null === $media_query ) {
+            continue;
+        }
+
+        $css_lines[] = $media_query;
+
+        $selector_count = count( $block['selectors'] );
+        foreach ( $block['selectors'] as $index => $selector ) {
+            $is_last = ( $index === $selector_count - 1 );
+            $css_lines[] = sprintf(
+                '    %s%s',
+                $selector,
+                $is_last ? ' { ' . $declaration . ' }' : ','
+            );
+        }
+
+        $css_lines[] = '}';
+    }
+
+    return $css_lines;
+}
+
+function visibloc_jlg_format_media_query( $min, $max ) {
+    if ( isset( $min ) && isset( $max ) ) {
+        return sprintf( '@media (min-width: %1$dpx) and (max-width: %2$dpx) {', $min, $max );
+    }
+
+    if ( isset( $min ) ) {
+        return sprintf( '@media (min-width: %dpx) {', $min );
+    }
+
+    if ( isset( $max ) ) {
+        return sprintf( '@media (max-width: %dpx) {', $max );
+    }
+
+    return null;
+}
+
+function visibloc_jlg_calculate_reset_blocks( array $default_blocks, array $current_blocks ) {
+    $default_ranges = visibloc_jlg_collect_selector_ranges( $default_blocks );
+    $current_ranges = visibloc_jlg_collect_selector_ranges( $current_blocks );
+    $reset_blocks   = [];
+
+    foreach ( $default_ranges as $selector => $ranges ) {
+        $current = $current_ranges[ $selector ] ?? [];
+
+        foreach ( $ranges as $range ) {
+            $differences = visibloc_jlg_range_difference( $range, $current );
+
+            foreach ( $differences as $difference ) {
+                $key = sprintf(
+                    '%s:%s',
+                    isset( $difference['min'] ) ? $difference['min'] : '',
+                    isset( $difference['max'] ) ? $difference['max'] : ''
+                );
+
+                if ( ! isset( $reset_blocks[ $key ] ) ) {
+                    $reset_blocks[ $key ] = [
+                        'min'       => isset( $difference['min'] ) ? $difference['min'] : null,
+                        'max'       => isset( $difference['max'] ) ? $difference['max'] : null,
+                        'selectors' => [],
+                    ];
+                }
+
+                if ( ! in_array( $selector, $reset_blocks[ $key ]['selectors'], true ) ) {
+                    $reset_blocks[ $key ]['selectors'][] = $selector;
+                }
+            }
+        }
+    }
+
+    if ( empty( $reset_blocks ) ) {
+        return [];
+    }
+
+    $reset_blocks = array_values( $reset_blocks );
+    usort( $reset_blocks, 'visibloc_jlg_compare_blocks' );
+
+    return $reset_blocks;
+}
+
+function visibloc_jlg_collect_selector_ranges( array $blocks ) {
+    $ranges = [];
+
+    foreach ( $blocks as $block ) {
+        $range = [
+            'min' => isset( $block['min'] ) ? (int) $block['min'] : null,
+            'max' => isset( $block['max'] ) ? (int) $block['max'] : null,
+        ];
+
+        foreach ( $block['selectors'] as $selector ) {
+            if ( ! isset( $ranges[ $selector ] ) ) {
+                $ranges[ $selector ] = [];
+            }
+
+            $ranges[ $selector ][] = $range;
+        }
+    }
+
+    return $ranges;
+}
+
+function visibloc_jlg_range_difference( array $range, array $sub_ranges ) {
+    if ( empty( $sub_ranges ) ) {
+        return [ $range ];
+    }
+
+    $segments = [ $range ];
+    usort( $sub_ranges, 'visibloc_jlg_compare_ranges' );
+
+    foreach ( $sub_ranges as $sub_range ) {
+        $next_segments = [];
+
+        foreach ( $segments as $segment ) {
+            $parts = visibloc_jlg_subtract_segment( $segment, $sub_range );
+
+            foreach ( $parts as $part ) {
+                if ( ! isset( $part['min'] ) && ! isset( $part['max'] ) ) {
+                    continue;
+                }
+
+                if ( isset( $part['min'], $part['max'] ) && $part['min'] > $part['max'] ) {
+                    continue;
+                }
+
+                $next_segments[] = [
+                    'min' => isset( $part['min'] ) ? (int) $part['min'] : null,
+                    'max' => isset( $part['max'] ) ? (int) $part['max'] : null,
+                ];
+            }
+        }
+
+        $segments = $next_segments;
+
+        if ( empty( $segments ) ) {
+            break;
+        }
+    }
+
+    return $segments;
+}
+
+function visibloc_jlg_subtract_segment( array $segment, array $sub_range ) {
+    $segment_min = isset( $segment['min'] ) ? (int) $segment['min'] : PHP_INT_MIN;
+    $segment_max = isset( $segment['max'] ) ? (int) $segment['max'] : PHP_INT_MAX;
+    $sub_min     = isset( $sub_range['min'] ) ? (int) $sub_range['min'] : PHP_INT_MIN;
+    $sub_max     = isset( $sub_range['max'] ) ? (int) $sub_range['max'] : PHP_INT_MAX;
+
+    if ( $sub_max < $segment_min || $sub_min > $segment_max ) {
+        return [ $segment ];
+    }
+
+    $results = [];
+
+    if ( $sub_min > $segment_min ) {
+        $results[] = [
+            'min' => isset( $segment['min'] ) ? (int) $segment['min'] : null,
+            'max' => isset( $sub_range['min'] ) ? ( (int) $sub_range['min'] - 1 ) : null,
+        ];
+    }
+
+    if ( $sub_max < $segment_max ) {
+        $results[] = [
+            'min' => isset( $sub_range['max'] ) ? ( (int) $sub_range['max'] + 1 ) : null,
+            'max' => isset( $segment['max'] ) ? (int) $segment['max'] : null,
+        ];
+    }
+
+    return array_values(
+        array_filter(
+            $results,
+            static function ( $candidate ) {
+                if ( ! isset( $candidate['min'] ) && ! isset( $candidate['max'] ) ) {
+                    return false;
+                }
+
+                if ( isset( $candidate['min'], $candidate['max'] ) && $candidate['min'] > $candidate['max'] ) {
+                    return false;
+                }
+
+                return true;
+            }
+        )
+    );
+}
+
+function visibloc_jlg_compare_blocks( $a, $b ) {
+    return visibloc_jlg_compare_ranges( $a, $b );
+}
+
+function visibloc_jlg_compare_ranges( $a, $b ) {
+    $a_min = isset( $a['min'] ) ? (int) $a['min'] : PHP_INT_MIN;
+    $b_min = isset( $b['min'] ) ? (int) $b['min'] : PHP_INT_MIN;
+
+    if ( $a_min === $b_min ) {
+        $a_max = isset( $a['max'] ) ? (int) $a['max'] : PHP_INT_MAX;
+        $b_max = isset( $b['max'] ) ? (int) $b['max'] : PHP_INT_MAX;
+
+        if ( $a_max === $b_max ) {
+            return 0;
+        }
+
+        return ( $a_max < $b_max ) ? -1 : 1;
+    }
+
+    return ( $a_min < $b_min ) ? -1 : 1;
 }
 

--- a/visi-bloc-jlg/tests/phpunit/integration/DeviceVisibilityCssTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/DeviceVisibilityCssTest.php
@@ -10,9 +10,55 @@ class DeviceVisibilityCssTest extends TestCase {
 
         $this->assertStringContainsString('@media (max-width: 600px)', $css);
         $this->assertStringNotContainsString('@media (max-width: 781px)', $css);
-        $this->assertMatchesRegularExpression(
-            '/@media \\(min-width: 601px\\) and \\(max-width: 781px\\) {\\s+\\.vb-hide-on-mobile,\\s+\\.vb-tablet-only \\{ display: revert !important; \\}\\s+}/',
-            $css
-        );
+        $block = $this->extractMediaQueryBlock( $css, '@media (min-width: 601px) and (max-width: 781px)' );
+
+        $this->assertNotNull( $block );
+        $this->assertStringContainsString('.vb-hide-on-mobile,', $block);
+        $this->assertStringContainsString('.vb-tablet-only { display: revert !important; }', $block);
+    }
+
+    public function test_mobile_breakpoint_lower_than_default_does_not_hide_classes_above_new_threshold(): void {
+        $css   = visibloc_jlg_generate_device_visibility_css( false, 600, 1024 );
+        $block = $this->extractMediaQueryBlock( $css, '@media (min-width: 601px) and (max-width: 781px)' );
+
+        $this->assertNotNull( $block );
+        $this->assertStringContainsString('.vb-hide-on-mobile,', $block);
+        $this->assertStringContainsString('.vb-tablet-only { display: revert !important; }', $block);
+        $this->assertStringNotContainsString('display: none !important;', $block);
+    }
+
+    private function extractMediaQueryBlock( string $css, string $query ): ?string {
+        $position = strpos( $css, $query );
+
+        if ( false === $position ) {
+            return null;
+        }
+
+        $start = strpos( $css, '{', $position );
+
+        if ( false === $start ) {
+            return null;
+        }
+
+        $depth   = 0;
+        $length  = strlen( $css );
+
+        for ( $index = $start; $index < $length; $index++ ) {
+            $character = $css[ $index ];
+
+            if ( '{' === $character ) {
+                $depth++;
+            } elseif ( '}' === $character ) {
+                $depth--;
+
+                if ( 0 === $depth ) {
+                    $block = substr( $css, $start + 1, $index - $start - 1 );
+
+                    return trim( $block );
+                }
+            }
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
## Summary
- ensure the static device visibility stylesheet only loads when default breakpoints are used and register a standalone handle for dynamic CSS
- rebuild the dynamic device visibility CSS generator to always emit the full rule set and compute overrides that neutralize legacy rules when breakpoints change
- extend the device visibility integration tests with coverage for regressions when the mobile breakpoint drops below the default threshold

## Testing
- ./vendor/bin/phpunit -c phpunit.xml.dist

------
https://chatgpt.com/codex/tasks/task_e_68d651065880832e8043853b8665f888