### PR TITLE
Restrict guest capability overrides to current request

### DIFF
--- a/visi-bloc-jlg/tests/phpunit/bootstrap.php
+++ b/visi-bloc-jlg/tests/phpunit/bootstrap.php
@@ -249,6 +249,16 @@ function wp_get_current_user() {
     return new Visibloc_Test_User();
 }
 
+function get_current_user_id() {
+    $user = wp_get_current_user();
+
+    if ( $user instanceof Visibloc_Test_User ) {
+        return (int) $user->ID;
+    }
+
+    return 0;
+}
+
 function get_role( $role ) {
     $roles = $GLOBALS['visibloc_test_state']['roles'];
 

--- a/visi-bloc-jlg/tests/phpunit/integration/RoleSwitcherCapabilitiesTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/RoleSwitcherCapabilitiesTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../../includes/role-switcher.php';
+
+class RoleSwitcherCapabilitiesTest extends TestCase {
+    protected function setUp(): void {
+        visibloc_test_reset_state();
+        visibloc_jlg_store_real_user_id( null );
+    }
+
+    public function test_guest_preview_only_applies_to_current_request_user(): void {
+        global $visibloc_test_state;
+
+        $real_user_id = 7;
+
+        $visibloc_test_state['effective_user_id']           = $real_user_id;
+        $visibloc_test_state['can_preview_users'][ $real_user_id ] = true;
+        $visibloc_test_state['allowed_preview_roles']       = [ 'administrator' ];
+        $visibloc_test_state['preview_role']                = 'guest';
+        $visibloc_test_state['current_user']                = new Visibloc_Test_User( 0, [] );
+
+        visibloc_jlg_store_real_user_id( $real_user_id );
+
+        $allcaps = [
+            'read'         => true,
+            'edit_posts'   => true,
+            'level_1'      => true,
+            'do_not_allow' => true,
+        ];
+
+        $other_user = new Visibloc_Test_User( 99, [ 'administrator' ] );
+        $this->assertSame(
+            $allcaps,
+            visibloc_jlg_filter_user_capabilities( $allcaps, [], [], $other_user ),
+            'Capabilities for unrelated users should remain unchanged during a guest preview.'
+        );
+
+        $guest_user_caps = visibloc_jlg_filter_user_capabilities( $allcaps, [], [], new Visibloc_Test_User( 0, [] ) );
+
+        $this->assertArrayHasKey( 'exist', $guest_user_caps );
+        $this->assertArrayHasKey( 'read', $guest_user_caps );
+        $this->assertArrayHasKey( 'level_0', $guest_user_caps );
+        $this->assertSame( true, $guest_user_caps['read'], 'Guest previews should keep the read capability.' );
+        $this->assertTrue( $guest_user_caps['exist'], 'Guest previews should set the exist capability.' );
+        $this->assertFalse( isset( $guest_user_caps['edit_posts'] ), 'Guest previews should not inherit privileged capabilities.' );
+        $this->assertArrayHasKey( 'do_not_allow', $guest_user_caps );
+        $this->assertTrue( $guest_user_caps['do_not_allow'], 'The do_not_allow capability should be preserved when stripping caps.' );
+    }
+}


### PR DESCRIPTION
## Summary
- wrap role switcher helpers in conditional definitions so the real implementations can load alongside test doubles
- ensure guest preview capability stripping only applies to the current request user
- add integration coverage that verifies other users retain their capabilities when a guest preview is active

## Testing
- vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68d6615634d0832eae5459d3a324cd28