### PR TITLE
Add integration coverage for role switcher request flows

### DIFF
--- a/visi-bloc-jlg/tests/phpunit/integration/RoleSwitcherCapabilitiesTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/RoleSwitcherCapabilitiesTest.php
@@ -2,7 +2,7 @@
 
 use PHPUnit\Framework\TestCase;
 
-require_once __DIR__ . '/../../../includes/role-switcher.php';
+require_once __DIR__ . '/../role-switcher-test-loader.php';
 
 class RoleSwitcherCapabilitiesTest extends TestCase {
     protected function setUp(): void {

--- a/visi-bloc-jlg/tests/phpunit/integration/RoleSwitcherRequestTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/RoleSwitcherRequestTest.php
@@ -1,0 +1,508 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'HOUR_IN_SECONDS' ) ) {
+    define( 'HOUR_IN_SECONDS', 3600 );
+}
+
+if ( ! defined( 'COOKIEPATH' ) ) {
+    define( 'COOKIEPATH', '/' );
+}
+
+if ( ! defined( 'COOKIE_DOMAIN' ) ) {
+    define( 'COOKIE_DOMAIN', '' );
+}
+
+if ( ! class_exists( 'Visibloc_Test_Redirect_Exception' ) ) {
+    class Visibloc_Test_Redirect_Exception extends Exception {}
+}
+
+global $visibloc_test_redirect_state;
+$visibloc_test_redirect_state = [];
+
+if ( ! function_exists( 'apply_filters' ) ) {
+    function apply_filters( $hook, $value ) {
+        return $value;
+    }
+}
+
+if ( ! function_exists( 'esc_html__' ) ) {
+    function esc_html__( $text ) {
+        return $text;
+    }
+}
+
+if ( ! function_exists( 'esc_html' ) ) {
+    function esc_html( $text ) {
+        return $text;
+    }
+}
+
+if ( ! function_exists( 'esc_url_raw' ) ) {
+    function esc_url_raw( $url ) {
+        return $url;
+    }
+}
+
+if ( ! function_exists( 'admin_url' ) ) {
+    function admin_url( $path = '' ) {
+        $path = ltrim( $path, '/' );
+
+        return 'https://example.test/wp-admin/' . $path;
+    }
+}
+
+if ( ! function_exists( 'home_url' ) ) {
+    function home_url( $path = '/' ) {
+        $path = '/' . ltrim( $path, '/' );
+
+        return 'https://example.test' . $path;
+    }
+}
+
+if ( ! function_exists( 'wp_parse_url' ) ) {
+    function wp_parse_url( $url ) {
+        return parse_url( $url );
+    }
+}
+
+if ( ! function_exists( 'is_ssl' ) ) {
+    function is_ssl() {
+        return false;
+    }
+}
+
+if ( ! function_exists( 'is_admin' ) ) {
+    function is_admin() {
+        return false;
+    }
+}
+
+if ( ! function_exists( 'wp_doing_ajax' ) ) {
+    function wp_doing_ajax() {
+        return false;
+    }
+}
+
+if ( ! function_exists( 'wp_doing_cron' ) ) {
+    function wp_doing_cron() {
+        return false;
+    }
+}
+
+if ( ! function_exists( 'wp_get_referer' ) ) {
+    function wp_get_referer() {
+        return '';
+    }
+}
+
+if ( ! function_exists( 'is_admin_bar_showing' ) ) {
+    function is_admin_bar_showing() {
+        return true;
+    }
+}
+
+if ( ! function_exists( 'wp_roles' ) ) {
+    class Visibloc_Test_Roles_Registry {
+        public function get_names() {
+            $names = [];
+
+            foreach ( $GLOBALS['visibloc_test_state']['roles'] as $slug => $details ) {
+                $names[ $slug ] = $details->name ?? ucfirst( $slug );
+            }
+
+            return $names;
+        }
+    }
+
+    function wp_roles() {
+        static $registry = null;
+
+        if ( null === $registry ) {
+            $registry = new Visibloc_Test_Roles_Registry();
+        }
+
+        return $registry;
+    }
+}
+
+if ( ! function_exists( 'visibloc_jlg_get_sanitized_query_arg' ) ) {
+    function visibloc_jlg_get_sanitized_query_arg( $key ) {
+        if ( ! isset( $_GET[ $key ] ) ) {
+            return '';
+        }
+
+        $value = $_GET[ $key ];
+
+        if ( ! is_string( $value ) ) {
+            return '';
+        }
+
+        return sanitize_key( wp_unslash( $value ) );
+    }
+}
+
+if ( ! function_exists( 'get_editable_roles' ) ) {
+    function get_editable_roles() {
+        $roles = [];
+
+        foreach ( $GLOBALS['visibloc_test_state']['roles'] as $slug => $details ) {
+            $roles[ $slug ] = [ 'name' => $details->name ?? ucfirst( $slug ) ];
+        }
+
+        return $roles;
+    }
+}
+
+if ( ! function_exists( 'add_query_arg' ) ) {
+    function add_query_arg( $key, $value = null, $url = '' ) {
+        if ( is_array( $key ) ) {
+            $params = $key;
+            $url    = (string) $value;
+        } else {
+            $params = [ $key => $value ];
+            $url    = (string) $url;
+        }
+
+        $fragment = '';
+        $fragment_position = strpos( $url, '#' );
+
+        if ( false !== $fragment_position ) {
+            $fragment = substr( $url, $fragment_position );
+            $url      = substr( $url, 0, $fragment_position );
+        }
+
+        $query      = '';
+        $query_pos  = strpos( $url, '?' );
+        $base       = $url;
+
+        if ( false !== $query_pos ) {
+            $query = substr( $url, $query_pos + 1 );
+            $base  = substr( $url, 0, $query_pos );
+        }
+
+        parse_str( $query, $query_args );
+
+        foreach ( $params as $param_key => $param_value ) {
+            if ( null === $param_value ) {
+                unset( $query_args[ $param_key ] );
+            } else {
+                $query_args[ $param_key ] = $param_value;
+            }
+        }
+
+        $new_query = http_build_query( $query_args );
+
+        $result = $base;
+
+        if ( '' !== $new_query ) {
+            $result .= '?' . $new_query;
+        }
+
+        return $result . $fragment;
+    }
+}
+
+if ( ! function_exists( 'remove_query_arg' ) ) {
+    function remove_query_arg( $keys, $url = '' ) {
+        $keys = (array) $keys;
+        $fragment = '';
+        $fragment_position = strpos( $url, '#' );
+
+        if ( false !== $fragment_position ) {
+            $fragment = substr( $url, $fragment_position );
+            $url      = substr( $url, 0, $fragment_position );
+        }
+
+        $query_pos = strpos( $url, '?' );
+
+        if ( false === $query_pos ) {
+            return $url . $fragment;
+        }
+
+        $base  = substr( $url, 0, $query_pos );
+        $query = substr( $url, $query_pos + 1 );
+
+        parse_str( $query, $query_args );
+
+        foreach ( $keys as $key ) {
+            unset( $query_args[ $key ] );
+        }
+
+        $new_query = http_build_query( $query_args );
+
+        if ( '' === $new_query ) {
+            return $base . $fragment;
+        }
+
+        return $base . '?' . $new_query . $fragment;
+    }
+}
+
+if ( ! function_exists( 'wp_nonce_url' ) ) {
+    function wp_nonce_url( $url, $action ) {
+        return add_query_arg( '_wpnonce', 'nonce-' . $action, $url );
+    }
+}
+
+if ( ! function_exists( 'wp_verify_nonce' ) ) {
+    function wp_verify_nonce( $nonce, $action ) {
+        return $nonce === 'nonce-' . $action;
+    }
+}
+
+if ( ! function_exists( 'wp_safe_redirect' ) ) {
+    function wp_safe_redirect( $location, $status = 302, $x_redirect_by = 'WordPress' ) {
+        global $visibloc_test_redirect_state;
+
+        $visibloc_test_redirect_state = [
+            'location'      => $location,
+            'status'        => $status,
+            'x_redirect_by' => $x_redirect_by,
+        ];
+
+        throw new Visibloc_Test_Redirect_Exception();
+    }
+}
+
+require_once __DIR__ . '/../role-switcher-test-loader.php';
+
+class Visibloc_Test_Admin_Bar {
+    /** @var array<string,array> */
+    public $nodes = [];
+
+    public function add_node( array $node ) {
+        $this->nodes[ $node['id'] ] = $node;
+    }
+}
+
+class RoleSwitcherRequestTest extends TestCase {
+    protected function setUp(): void {
+        visibloc_test_reset_state();
+        visibloc_jlg_store_real_user_id( null );
+
+        $_GET    = [];
+        $_COOKIE = [];
+        $_SERVER = [
+            'HTTP_HOST'    => 'example.test',
+            'REQUEST_URI'  => '/',
+        ];
+
+        global $visibloc_test_redirect_state;
+        $visibloc_test_redirect_state = [];
+        $GLOBALS['visibloc_test_cookie_log'] = [];
+
+        if ( function_exists( 'header_remove' ) ) {
+            header_remove();
+        }
+    }
+
+    protected function tearDown(): void {
+        if ( function_exists( 'header_remove' ) ) {
+            header_remove();
+        }
+
+        $_GET = [];
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_valid_preview_role_request_sets_cookie_and_updates_admin_bar(): void {
+        global $visibloc_test_state, $visibloc_test_redirect_state;
+
+        $user_id = 11;
+
+        $visibloc_test_state['effective_user_id']             = $user_id;
+        $visibloc_test_state['current_user']                  = new Visibloc_Test_User( $user_id, [ 'administrator' ] );
+        $visibloc_test_state['can_preview_users'][ $user_id ] = true;
+        $visibloc_test_state['can_impersonate_users'][ $user_id ] = true;
+        $visibloc_test_state['allowed_preview_roles']         = [ 'administrator', 'editor' ];
+        $visibloc_test_state['roles']['editor']               = (object) [ 'name' => 'Editor', 'capabilities' => [] ];
+
+        $_GET = [
+            'preview_role' => 'editor',
+            '_wpnonce'     => 'nonce-visibloc_switch_role_editor',
+            'foo'          => 'bar',
+        ];
+
+        $_SERVER['REQUEST_URI'] = '/page/?preview_role=editor&_wpnonce=nonce-visibloc_switch_role_editor&foo=bar';
+
+        $expected_expiration = visibloc_jlg_get_preview_cookie_expiration_time();
+
+        try {
+            visibloc_jlg_handle_role_switching();
+            $this->fail( 'Expected redirect exception was not thrown.' );
+        } catch ( Visibloc_Test_Redirect_Exception $exception ) {
+            // Expected path.
+        }
+
+        $this->assertSame( 'https://example.test/page/?foo=bar', $visibloc_test_redirect_state['location'], 'Redirect should drop control parameters.' );
+
+        $cookie = $this->getLatestCookieLog();
+
+        $this->assertNotNull( $cookie, 'Preview request should record a cookie update.' );
+        $this->assertSame( 'editor', $cookie['value'] ?? null, 'Preview cookie should store the requested role.' );
+
+        $expiration = $cookie['expires'] ?? null;
+        $this->assertIsInt( $expiration );
+        $this->assertGreaterThanOrEqual( $expected_expiration - 2, $expiration );
+        $this->assertLessThanOrEqual( $expected_expiration + 2, $expiration );
+
+        $visibloc_test_state['preview_role'] = 'editor';
+
+        $this->emulateRedirectRequest( $visibloc_test_redirect_state['location'] );
+
+        $admin_bar = new Visibloc_Test_Admin_Bar();
+        visibloc_jlg_add_role_switcher_menu( $admin_bar );
+
+        $this->assertArrayHasKey( 'visibloc-alert', $admin_bar->nodes, 'Active preview should inject alert node.' );
+        $this->assertStringContainsString( 'Aperçu : Editor', $admin_bar->nodes['visibloc-alert']['title'] );
+
+        $this->assertArrayHasKey( 'visibloc-stop-preview', $admin_bar->nodes );
+        $this->assertStringContainsString( 'stop_preview_role=true', $admin_bar->nodes['visibloc-stop-preview']['href'] );
+        $this->assertStringContainsString( '_wpnonce=nonce-visibloc_switch_role_stop', $admin_bar->nodes['visibloc-stop-preview']['href'] );
+
+        $this->assertArrayHasKey( 'visibloc-role-switcher', $admin_bar->nodes );
+        $this->assertArrayHasKey( 'visibloc-role-guest', $admin_bar->nodes, 'Guest option should be available for impersonators.' );
+        $this->assertStringContainsString( 'preview_role=guest', $admin_bar->nodes['visibloc-role-guest']['href'] );
+        $this->assertArrayHasKey( 'visibloc-role-editor', $admin_bar->nodes );
+        $this->assertStringContainsString( 'preview_role=editor', $admin_bar->nodes['visibloc-role-editor']['href'] );
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_invalid_role_request_purges_cookie_and_flags_error(): void {
+        global $visibloc_test_state, $visibloc_test_redirect_state;
+
+        $user_id = 17;
+
+        $visibloc_test_state['effective_user_id']             = $user_id;
+        $visibloc_test_state['current_user']                  = new Visibloc_Test_User( $user_id, [ 'administrator' ] );
+        $visibloc_test_state['can_preview_users'][ $user_id ] = true;
+        $visibloc_test_state['can_impersonate_users'][ $user_id ] = true;
+        $visibloc_test_state['allowed_preview_roles']         = [ 'administrator', 'editor' ];
+        $visibloc_test_state['roles']['editor']               = (object) [ 'name' => 'Editor', 'capabilities' => [] ];
+
+        $_GET = [
+            'preview_role' => 'subscriber',
+            '_wpnonce'     => 'nonce-visibloc_switch_role_subscriber',
+            'foo'          => 'bar',
+        ];
+
+        $_SERVER['REQUEST_URI'] = '/page/?preview_role=subscriber&_wpnonce=nonce-visibloc_switch_role_subscriber&foo=bar';
+
+        try {
+            visibloc_jlg_handle_role_switching();
+            $this->fail( 'Expected redirect exception was not thrown.' );
+        } catch ( Visibloc_Test_Redirect_Exception $exception ) {
+            // Expected.
+        }
+
+        $this->assertArrayHasKey( 'location', $visibloc_test_redirect_state );
+        $this->assertStringNotContainsString( 'preview_role', $visibloc_test_redirect_state['location'] );
+        $this->assertStringContainsString( 'preview_status=invalid_role', $visibloc_test_redirect_state['location'] );
+
+        $cookie = $this->getLatestCookieLog();
+        $this->assertNotNull( $cookie, 'Invalid role should trigger a purge cookie log entry.' );
+        $this->assertSame( '', $cookie['value'] ?? null, 'Purged cookie should be empty.' );
+
+        $expiration = $cookie['expires'] ?? null;
+        $this->assertIsInt( $expiration );
+        $this->assertLessThan( time(), $expiration, 'Purged cookie should expire immediately.' );
+
+        $visibloc_test_state['preview_role'] = '';
+
+        $this->emulateRedirectRequest( $visibloc_test_redirect_state['location'] );
+
+        $admin_bar = new Visibloc_Test_Admin_Bar();
+        visibloc_jlg_add_role_switcher_menu( $admin_bar );
+
+        $this->assertArrayHasKey( 'visibloc-preview-error', $admin_bar->nodes, 'Invalid role redirect should surface an error notice.' );
+        $this->assertStringContainsString( 'rôle demandé', $admin_bar->nodes['visibloc-preview-error']['title'] );
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_stop_preview_request_clears_cookie_and_removes_alert(): void {
+        global $visibloc_test_state, $visibloc_test_redirect_state;
+
+        $user_id = 23;
+
+        $visibloc_test_state['effective_user_id']             = $user_id;
+        $visibloc_test_state['current_user']                  = new Visibloc_Test_User( $user_id, [ 'administrator' ] );
+        $visibloc_test_state['can_preview_users'][ $user_id ] = true;
+        $visibloc_test_state['can_impersonate_users'][ $user_id ] = false;
+        $visibloc_test_state['allowed_preview_roles']         = [ 'administrator' ];
+        $visibloc_test_state['preview_role']                  = 'guest';
+
+        $_GET = [ 'foo' => 'bar' ];
+        $_SERVER['REQUEST_URI'] = '/page/?foo=bar';
+
+        $admin_bar = new Visibloc_Test_Admin_Bar();
+        visibloc_jlg_add_role_switcher_menu( $admin_bar );
+
+        $this->assertArrayHasKey( 'visibloc-alert', $admin_bar->nodes, 'Guest preview should display alert in toolbar.' );
+        $this->assertStringContainsString( 'Visiteur (Déconnecté)', $admin_bar->nodes['visibloc-alert']['title'] );
+        $this->assertArrayHasKey( 'visibloc-stop-preview', $admin_bar->nodes, 'Guest preview should expose stop link.' );
+
+        $_GET = [
+            'stop_preview_role' => 'true',
+            '_wpnonce'          => 'nonce-visibloc_switch_role_stop',
+            'foo'               => 'bar',
+        ];
+
+        $_SERVER['REQUEST_URI'] = '/page/?stop_preview_role=true&_wpnonce=nonce-visibloc_switch_role_stop&foo=bar';
+
+        try {
+            visibloc_jlg_handle_role_switching();
+            $this->fail( 'Expected redirect exception was not thrown.' );
+        } catch ( Visibloc_Test_Redirect_Exception $exception ) {
+            // Expected.
+        }
+
+        $this->assertSame( 'https://example.test/page/?foo=bar', $visibloc_test_redirect_state['location'], 'Stop preview redirect should clean control params.' );
+
+        $cookie = $this->getLatestCookieLog();
+        $this->assertNotNull( $cookie, 'Stop preview should emit cookie purge.' );
+        $this->assertSame( '', $cookie['value'] ?? null );
+        $this->assertLessThan( time(), $cookie['expires'] ?? time() );
+
+        $visibloc_test_state['preview_role'] = '';
+        $this->emulateRedirectRequest( $visibloc_test_redirect_state['location'] );
+
+        $admin_bar_after = new Visibloc_Test_Admin_Bar();
+        visibloc_jlg_add_role_switcher_menu( $admin_bar_after );
+
+        $this->assertArrayNotHasKey( 'visibloc-alert', $admin_bar_after->nodes, 'Toolbar alert should disappear once preview stops.' );
+    }
+
+    private function getLatestCookieLog(): ?array {
+        global $visibloc_test_cookie_log;
+
+        if ( empty( $visibloc_test_cookie_log ) ) {
+            return null;
+        }
+
+        return $visibloc_test_cookie_log[ array_key_last( $visibloc_test_cookie_log ) ];
+    }
+
+    private function emulateRedirectRequest( string $url ): void {
+        $parts = parse_url( $url );
+        $path  = $parts['path'] ?? '/';
+        $query = $parts['query'] ?? '';
+        $host  = $parts['host'] ?? 'example.test';
+
+        $_SERVER['HTTP_HOST']   = $host;
+        $_SERVER['REQUEST_URI'] = $path . ( '' !== $query ? '?' . $query : '' );
+
+        parse_str( $query, $query_args );
+        $_GET = $query_args;
+    }
+}

--- a/visi-bloc-jlg/tests/phpunit/role-switcher-test-loader.php
+++ b/visi-bloc-jlg/tests/phpunit/role-switcher-test-loader.php
@@ -1,0 +1,45 @@
+<?php
+
+if ( isset( $GLOBALS['visibloc_role_switcher_loaded'] ) && $GLOBALS['visibloc_role_switcher_loaded'] ) {
+    return;
+}
+
+$role_switcher_path = dirname( __DIR__, 2 ) . '/includes/role-switcher.php';
+$role_switcher_code = file_get_contents( $role_switcher_path );
+
+if ( false === $role_switcher_code ) {
+    throw new RuntimeException( 'Unable to read role switcher source.' );
+}
+
+$role_switcher_code = preg_replace(
+    '/function\s+visibloc_jlg_set_preview_cookie\s*\(/',
+    'function visibloc_jlg_set_preview_cookie_original(',
+    $role_switcher_code,
+    1,
+    $replacement_count
+);
+
+if ( 1 !== $replacement_count ) {
+    throw new RuntimeException( 'Failed to prepare role switcher source for testing.' );
+}
+
+eval( '?>' . $role_switcher_code );
+
+if ( ! isset( $GLOBALS['visibloc_test_cookie_log'] ) ) {
+    $GLOBALS['visibloc_test_cookie_log'] = [];
+}
+
+if ( ! function_exists( 'visibloc_jlg_set_preview_cookie' ) ) {
+    function visibloc_jlg_set_preview_cookie( $value, $expires ) {
+        global $visibloc_test_cookie_log;
+
+        $visibloc_test_cookie_log[] = [
+            'value'   => $value,
+            'expires' => $expires,
+        ];
+
+        return true;
+    }
+}
+
+$GLOBALS['visibloc_role_switcher_loaded'] = true;


### PR DESCRIPTION
## Summary
- add a PHPUnit loader that rewrites the role switcher to log preview cookie writes for tests
- cover preview, invalid, and stop role switch requests plus toolbar rendering in a new integration test
- update the existing capabilities test to reuse the shared loader

## Testing
- ./vendor/bin/phpunit --configuration phpunit.xml.dist

------
https://chatgpt.com/codex/tasks/task_e_68d675a786cc832ebb54921c3c76f7d9