### PR TITLE
Normalize boolean block flags

### DIFF
--- a/visi-bloc-jlg/includes/admin-settings.php
+++ b/visi-bloc-jlg/includes/admin-settings.php
@@ -436,7 +436,9 @@ function visibloc_jlg_generate_group_block_summary_from_content( $post_id, $post
     foreach ( $found as $block ) {
         $attrs = isset( $block['attrs'] ) && is_array( $block['attrs'] ) ? $block['attrs'] : [];
 
-        if ( ! empty( $attrs['isHidden'] ) ) {
+        $is_hidden = isset( $attrs['isHidden'] ) ? visibloc_jlg_normalize_boolean( $attrs['isHidden'] ) : false;
+
+        if ( $is_hidden ) {
             $hidden_count++;
         }
 
@@ -449,7 +451,11 @@ function visibloc_jlg_generate_group_block_summary_from_content( $post_id, $post
             || ! empty( $attrs['publishEndDate'] )
         );
 
-        if ( ! empty( $attrs['isSchedulingEnabled'] ) && $has_scheduling_window ) {
+        $has_scheduling_enabled = isset( $attrs['isSchedulingEnabled'] )
+            ? visibloc_jlg_normalize_boolean( $attrs['isSchedulingEnabled'] )
+            : false;
+
+        if ( $has_scheduling_enabled && $has_scheduling_window ) {
             $scheduled[] = [
                 'start' => isset( $attrs['publishStartDate'] ) ? (string) $attrs['publishStartDate'] : null,
                 'end'   => isset( $attrs['publishEndDate'] ) ? (string) $attrs['publishEndDate'] : null,

--- a/visi-bloc-jlg/includes/visibility-logic.php
+++ b/visi-bloc-jlg/includes/visibility-logic.php
@@ -23,8 +23,8 @@ function visibloc_jlg_render_block_filter( $block_content, $block ) {
         $visibility_roles = array_filter( array_map( 'sanitize_key', $visibility_roles ) );
     }
 
-    $has_hidden_flag      = ! empty( $attrs['isHidden'] );
-    $has_schedule_enabled = ! empty( $attrs['isSchedulingEnabled'] );
+    $has_hidden_flag      = isset( $attrs['isHidden'] ) ? visibloc_jlg_normalize_boolean( $attrs['isHidden'] ) : false;
+    $has_schedule_enabled = isset( $attrs['isSchedulingEnabled'] ) ? visibloc_jlg_normalize_boolean( $attrs['isSchedulingEnabled'] ) : false;
 
     if ( ! $has_hidden_flag && ! $has_schedule_enabled && empty( $visibility_roles ) ) {
         return $block_content;

--- a/visi-bloc-jlg/tests/phpunit/bootstrap.php
+++ b/visi-bloc-jlg/tests/phpunit/bootstrap.php
@@ -7,6 +7,10 @@ if ( ! defined( 'ABSPATH' ) ) {
     define( 'ABSPATH', __DIR__ . '/../../' );
 }
 
+if ( ! defined( 'WPINC' ) ) {
+    define( 'WPINC', 'wp-includes' );
+}
+
 $GLOBALS['visibloc_posts']            = [];
 $GLOBALS['visibloc_test_options']     = [];
 $GLOBALS['visibloc_test_transients']  = [];
@@ -525,6 +529,22 @@ if ( ! class_exists( 'WP_Query' ) ) {
 if ( ! function_exists( 'absint' ) ) {
     function absint( $maybeint ) {
         return (int) abs( $maybeint );
+    }
+}
+
+if ( ! function_exists( 'visibloc_jlg_normalize_boolean' ) ) {
+    function visibloc_jlg_normalize_boolean( $value ) {
+        if ( is_bool( $value ) ) {
+            return $value;
+        }
+
+        if ( is_array( $value ) || is_object( $value ) ) {
+            return false;
+        }
+
+        $filtered = filter_var( $value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE );
+
+        return true === $filtered;
     }
 }
 

--- a/visi-bloc-jlg/tests/phpunit/integration/GroupBlockSummaryTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/GroupBlockSummaryTest.php
@@ -67,6 +67,32 @@ HTML;
         );
     }
 
+    public function test_summary_ignores_false_like_strings_for_hidden_and_scheduled_flags(): void {
+        $sample_content = <<<'HTML'
+<!-- wp:core/group {"isHidden":"false"} -->
+<div class="wp-block-group">Should be visible</div>
+<!-- /wp:core/group -->
+
+<!-- wp:core/group {"isHidden":"0"} -->
+<div class="wp-block-group">Also visible</div>
+<!-- /wp:core/group -->
+
+<!-- wp:core/group {"isSchedulingEnabled":"false","publishStartDate":"2099-01-01T00:00:00","publishEndDate":"2099-01-02T00:00:00"} -->
+<div class="wp-block-group">Scheduling disabled via string</div>
+<!-- /wp:core/group -->
+
+<!-- wp:core/group {"isSchedulingEnabled":"0","publishStartDate":"2099-02-01T00:00:00"} -->
+<div class="wp-block-group">Scheduling disabled via zero</div>
+<!-- /wp:core/group -->
+HTML;
+
+        $summary = visibloc_jlg_generate_group_block_summary_from_content( 202, $sample_content );
+
+        $this->assertSame( 0, $summary['hidden'] );
+        $this->assertSame( 0, $summary['device'] );
+        $this->assertSame( [], $summary['scheduled'] );
+    }
+
     public function test_rebuild_and_collect_group_block_metadata_caches_results_for_admin_renderers(): void {
         $primary_content = <<<'HTML'
 <!-- wp:core/group {"isHidden":true} -->

--- a/visi-bloc-jlg/tests/phpunit/integration/VisibilityLogicTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/VisibilityLogicTest.php
@@ -83,6 +83,44 @@ class VisibilityLogicTest extends TestCase {
         $this->assertStringContainsString( '<p>Hidden admin content</p>', $output );
     }
 
+    /**
+     * @dataProvider visibloc_false_string_provider
+     */
+    public function test_hidden_flag_falsey_strings_do_not_hide_block( $raw_value ): void {
+        $block = [
+            'blockName' => 'core/group',
+            'attrs'     => [
+                'isHidden' => $raw_value,
+            ],
+        ];
+
+        $this->assertSame(
+            '<p>Visible content</p>',
+            visibloc_jlg_render_block_filter( '<p>Visible content</p>', $block ),
+            'String representations of false should not hide the block.'
+        );
+    }
+
+    /**
+     * @dataProvider visibloc_false_string_provider
+     */
+    public function test_scheduling_flag_falsey_strings_do_not_enable_window( $raw_value ): void {
+        $block = [
+            'blockName' => 'core/group',
+            'attrs'     => [
+                'isSchedulingEnabled' => $raw_value,
+                'publishStartDate'    => '2099-01-01 00:00:00',
+                'publishEndDate'      => '2099-01-02 00:00:00',
+            ],
+        ];
+
+        $this->assertSame(
+            '<p>Future content</p>',
+            visibloc_jlg_render_block_filter( '<p>Future content</p>', $block ),
+            'Scheduling should be skipped when the flag is stored as a false-like string.'
+        );
+    }
+
     public function test_visibility_roles_accepts_string_role_values(): void {
         global $visibloc_test_state;
 
@@ -152,6 +190,13 @@ class VisibilityLogicTest extends TestCase {
             visibloc_jlg_render_block_filter( '<p>Guest view</p>', $logged_out_block ),
             'Previewing as a guest should expose content intended for visitors.'
         );
+    }
+
+    public function visibloc_false_string_provider(): array {
+        return [
+            'string-false' => [ 'false' ],
+            'string-zero'  => [ '0' ],
+        ];
     }
 
     public function test_scheduled_block_hidden_outside_window_without_preview_permission(): void {

--- a/visi-bloc-jlg/visi-bloc-jlg.php
+++ b/visi-bloc-jlg/visi-bloc-jlg.php
@@ -35,6 +35,32 @@ if ( ! function_exists( 'visibloc_jlg_get_sanitized_query_arg' ) ) {
     }
 }
 
+if ( ! function_exists( 'visibloc_jlg_normalize_boolean' ) ) {
+    /**
+     * Convert a block attribute value to a strict boolean.
+     *
+     * Arrays and objects are treated as false to avoid PHP warnings triggered
+     * by filter_var() while scalar/string values are normalized using
+     * FILTER_VALIDATE_BOOLEAN. Invalid or empty values default to false.
+     *
+     * @param mixed $value Raw attribute value.
+     * @return bool Normalized boolean value.
+     */
+    function visibloc_jlg_normalize_boolean( $value ) {
+        if ( is_bool( $value ) ) {
+            return $value;
+        }
+
+        if ( is_array( $value ) || is_object( $value ) ) {
+            return false;
+        }
+
+        $filtered = filter_var( $value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE );
+
+        return true === $filtered;
+    }
+}
+
 // Charge les différents modules du plugin
 require_once __DIR__ . '/includes/datetime-utils.php';
 require_once __DIR__ . '/includes/admin-settings.php';


### PR DESCRIPTION
## Summary
- add a shared `visibloc_jlg_normalize_boolean()` helper and reuse it when reading block attributes
- ensure front-end visibility logic and admin summaries ignore false-like strings for hidden/scheduled flags
- extend integration tests and bootstrap helpers to cover normalized boolean behaviour

## Testing
- ./vendor/bin/phpunit -c phpunit.xml.dist

------
https://chatgpt.com/codex/tasks/task_e_68d6985ce788832e935304b7418325cf