### PR TITLE
Normalize boolean attribute handling for visibility flags

### DIFF
--- a/visi-bloc-jlg/tests/phpunit/bootstrap.php
+++ b/visi-bloc-jlg/tests/phpunit/bootstrap.php
@@ -549,6 +549,10 @@ if ( ! function_exists( 'visibloc_jlg_normalize_boolean' ) ) {
             return $value;
         }
 
+        if ( null === $value ) {
+            return false;
+        }
+
         if ( is_array( $value ) || is_object( $value ) ) {
             return false;
         }

--- a/visi-bloc-jlg/tests/phpunit/integration/GroupBlockSummaryTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/GroupBlockSummaryTest.php
@@ -77,12 +77,24 @@ HTML;
 <div class="wp-block-group">Also visible</div>
 <!-- /wp:core/group -->
 
+<!-- wp:core/group {"isHidden":[]} -->
+<div class="wp-block-group">Array flag should be ignored</div>
+<!-- /wp:core/group -->
+
+<!-- wp:core/group {"isHidden":{"unexpected":true}} -->
+<div class="wp-block-group">Object-like flag should be ignored</div>
+<!-- /wp:core/group -->
+
 <!-- wp:core/group {"isSchedulingEnabled":"false","publishStartDate":"2099-01-01T00:00:00","publishEndDate":"2099-01-02T00:00:00"} -->
 <div class="wp-block-group">Scheduling disabled via string</div>
 <!-- /wp:core/group -->
 
 <!-- wp:core/group {"isSchedulingEnabled":"0","publishStartDate":"2099-02-01T00:00:00"} -->
 <div class="wp-block-group">Scheduling disabled via zero</div>
+<!-- /wp:core/group -->
+
+<!-- wp:core/group {"isSchedulingEnabled":[],"publishStartDate":"2099-03-01T00:00:00"} -->
+<div class="wp-block-group">Scheduling disabled via array</div>
 <!-- /wp:core/group -->
 HTML;
 

--- a/visi-bloc-jlg/tests/phpunit/integration/VisibilityLogicTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/VisibilityLogicTest.php
@@ -84,7 +84,7 @@ class VisibilityLogicTest extends TestCase {
     }
 
     /**
-     * @dataProvider visibloc_false_string_provider
+     * @dataProvider visibloc_falsey_attribute_provider
      */
     public function test_hidden_flag_falsey_strings_do_not_hide_block( $raw_value ): void {
         $block = [
@@ -97,12 +97,12 @@ class VisibilityLogicTest extends TestCase {
         $this->assertSame(
             '<p>Visible content</p>',
             visibloc_jlg_render_block_filter( '<p>Visible content</p>', $block ),
-            'String representations of false should not hide the block.'
+            'False-like attribute values should not hide the block.'
         );
     }
 
     /**
-     * @dataProvider visibloc_false_string_provider
+     * @dataProvider visibloc_falsey_attribute_provider
      */
     public function test_scheduling_flag_falsey_strings_do_not_enable_window( $raw_value ): void {
         $block = [
@@ -117,7 +117,7 @@ class VisibilityLogicTest extends TestCase {
         $this->assertSame(
             '<p>Future content</p>',
             visibloc_jlg_render_block_filter( '<p>Future content</p>', $block ),
-            'Scheduling should be skipped when the flag is stored as a false-like string.'
+            'Scheduling should be skipped when the flag is stored as a false-like value.'
         );
     }
 
@@ -192,10 +192,13 @@ class VisibilityLogicTest extends TestCase {
         );
     }
 
-    public function visibloc_false_string_provider(): array {
+    public function visibloc_falsey_attribute_provider(): array {
         return [
-            'string-false' => [ 'false' ],
-            'string-zero'  => [ '0' ],
+            'string-false'    => [ 'false' ],
+            'string-zero'     => [ '0' ],
+            'null-value'      => [ null ],
+            'empty-array'     => [ [] ],
+            'stdclass-object' => [ (object) [] ],
         ];
     }
 

--- a/visi-bloc-jlg/visi-bloc-jlg.php
+++ b/visi-bloc-jlg/visi-bloc-jlg.php
@@ -51,6 +51,10 @@ if ( ! function_exists( 'visibloc_jlg_normalize_boolean' ) ) {
             return $value;
         }
 
+        if ( null === $value ) {
+            return false;
+        }
+
         if ( is_array( $value ) || is_object( $value ) ) {
             return false;
         }


### PR DESCRIPTION
## Summary
- add a null guard to the visibloc_jlg_normalize_boolean helper so non-scalar values never trigger scheduling or hidden states
- extend visibility logic and admin summary integration tests to cover false-like, array, and object attributes
- sync the PHPUnit bootstrap helper with the production normalization logic

## Testing
- ./vendor/bin/phpunit -c phpunit.xml.dist

------
https://chatgpt.com/codex/tasks/task_e_68d6ac48cab8832e84859f8ca442653a