### PR TITLE
Handle non-scalar visibility role inputs

### DIFF
--- a/visi-bloc-jlg/includes/visibility-logic.php
+++ b/visi-bloc-jlg/includes/visibility-logic.php
@@ -20,7 +20,25 @@ function visibloc_jlg_render_block_filter( $block_content, $block ) {
             $visibility_roles = [ $raw_visibility_roles ];
         }
 
-        $visibility_roles = array_filter( array_map( 'sanitize_key', $visibility_roles ) );
+        $visibility_roles = array_values(
+            array_filter(
+                array_map(
+                    static function ( $raw_role ) {
+                        if ( ! is_scalar( $raw_role ) ) {
+                            return null;
+                        }
+
+                        $sanitized_role = sanitize_key( (string) $raw_role );
+
+                        return '' === $sanitized_role ? null : $sanitized_role;
+                    },
+                    $visibility_roles
+                ),
+                static function ( $role ) {
+                    return null !== $role;
+                }
+            )
+        );
     }
 
     $has_hidden_flag      = isset( $attrs['isHidden'] ) ? visibloc_jlg_normalize_boolean( $attrs['isHidden'] ) : false;

--- a/visi-bloc-jlg/tests/phpunit/integration/VisibilityLogicTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/VisibilityLogicTest.php
@@ -140,6 +140,24 @@ class VisibilityLogicTest extends TestCase {
         );
     }
 
+    public function test_visibility_roles_ignore_nested_values(): void {
+        $block = [
+            'blockName' => 'core/group',
+            'attrs'     => [
+                'visibilityRoles' => [
+                    [ 'nested' => [ 'array' ] ],
+                    (object) [ 'role' => 'editor' ],
+                ],
+            ],
+        ];
+
+        $this->assertSame(
+            '<p>Visible content</p>',
+            visibloc_jlg_render_block_filter( '<p>Visible content</p>', $block ),
+            'Non-scalar visibility role values should be ignored without affecting rendering.'
+        );
+    }
+
     public function test_visibility_roles_accepts_logged_out_string_marker(): void {
         $block = [
             'blockName' => 'core/group',


### PR DESCRIPTION
## Summary
- sanitize visibility role inputs by casting scalars to strings before sanitizing and skipping empty keys
- add integration coverage to ensure nested visibility role data does not break rendering

## Testing
- vendor/bin/phpunit -c phpunit.xml.dist

------
https://chatgpt.com/codex/tasks/task_e_68d723c76b3c832e8a25ebe9db8f062f