### PR TITLE
Ensure role switcher ignores mismatched host headers

### DIFF
--- a/visi-bloc-jlg/tests/phpunit/bootstrap.php
+++ b/visi-bloc-jlg/tests/phpunit/bootstrap.php
@@ -236,6 +236,23 @@ function visibloc_jlg_parse_schedule_datetime( $value ) {
     return $datetime->getTimestamp();
 }
 
+if ( ! function_exists( 'visibloc_jlg_get_wp_datetime_format' ) ) {
+    function visibloc_jlg_get_wp_datetime_format() {
+        $date_format = get_option( 'date_format', 'F j, Y' );
+        $time_format = get_option( 'time_format', 'H:i' );
+
+        if ( ! is_string( $date_format ) || '' === trim( $date_format ) ) {
+            $date_format = 'F j, Y';
+        }
+
+        if ( ! is_string( $time_format ) || '' === trim( $time_format ) ) {
+            $time_format = 'H:i';
+        }
+
+        return trim( $date_format . ' ' . $time_format );
+    }
+}
+
 function wp_date( $format, $timestamp ) {
     return gmdate( $format, $timestamp );
 }


### PR DESCRIPTION
## Summary
- derive the canonical site host from `home_url()` when rebuilding the current request URL
- guard the preview redirect against mismatched host headers with a new integration test
- stub the datetime format helper in the test bootstrap so the suite can load visibility helpers

## Testing
- ./vendor/bin/phpunit --configuration phpunit.xml.dist

------
https://chatgpt.com/codex/tasks/task_e_68d91df07574832e95de414afa473304