### PR TITLE
Add caching for generated device visibility CSS

### DIFF
--- a/visi-bloc-jlg/includes/admin-settings.php
+++ b/visi-bloc-jlg/includes/admin-settings.php
@@ -697,6 +697,9 @@ function visibloc_jlg_clear_caches( $unused_post_id = null ) {
     delete_transient( 'visibloc_device_posts' );
     delete_transient( 'visibloc_scheduled_posts' );
     delete_transient( 'visibloc_group_block_metadata' );
+    if ( function_exists( 'wp_cache_delete' ) ) {
+        wp_cache_delete( 'visibloc_device_css_cache', 'visibloc_jlg' );
+    }
 }
 
 add_action( 'save_post', 'visibloc_jlg_refresh_group_block_summary_on_save', 20, 3 );

--- a/visi-bloc-jlg/includes/assets.php
+++ b/visi-bloc-jlg/includes/assets.php
@@ -66,6 +66,21 @@ function visibloc_jlg_generate_device_visibility_css( $can_preview, $mobile_bp =
     $mobile_bp = $mobile_bp > 0 ? $mobile_bp : $default_mobile_bp;
     $tablet_bp = $tablet_bp > 0 ? $tablet_bp : $default_tablet_bp;
 
+    $cache_group = 'visibloc_jlg';
+    $cache_key   = 'visibloc_device_css_cache';
+    $bucket_key  = sprintf(
+        '%d:%d:%d',
+        $can_preview ? 1 : 0,
+        (int) $mobile_bp,
+        (int) $tablet_bp
+    );
+
+    $cached_css = wp_cache_get( $cache_key, $cache_group );
+
+    if ( is_array( $cached_css ) && array_key_exists( $bucket_key, $cached_css ) ) {
+        return $cached_css[ $bucket_key ];
+    }
+
     $css_lines      = [];
     $current_blocks = visibloc_jlg_build_visibility_blocks( $mobile_bp, $tablet_bp );
 
@@ -110,7 +125,17 @@ function visibloc_jlg_generate_device_visibility_css( $can_preview, $mobile_bp =
         }
     }
 
-    return implode( "\n", $css_lines );
+    $css = implode( "\n", $css_lines );
+
+    if ( ! is_array( $cached_css ) ) {
+        $cached_css = [];
+    }
+
+    $cached_css[ $bucket_key ] = $css;
+
+    wp_cache_set( $cache_key, $cached_css, $cache_group );
+
+    return $css;
 }
 
 function visibloc_jlg_build_visibility_blocks( $mobile_bp, $tablet_bp ) {

--- a/visi-bloc-jlg/tests/phpunit/bootstrap.php
+++ b/visi-bloc-jlg/tests/phpunit/bootstrap.php
@@ -240,6 +240,72 @@ function wp_date( $format, $timestamp ) {
     return gmdate( $format, $timestamp );
 }
 
+if ( ! function_exists( 'visibloc_jlg_get_wp_datetime_format' ) ) {
+    function visibloc_jlg_get_wp_datetime_format() {
+        return 'Y-m-d H:i:s';
+    }
+}
+
+$GLOBALS['visibloc_test_object_cache'] = [];
+
+function visibloc_test_cache_normalize_group( $group ) {
+    return ( '' === $group ) ? 'default' : $group;
+}
+
+function wp_cache_get( $key, $group = '', $force = false, &$found = null ) {
+    $group = visibloc_test_cache_normalize_group( $group );
+
+    if ( isset( $GLOBALS['visibloc_test_object_cache'][ $group ][ $key ] ) ) {
+        $entry = $GLOBALS['visibloc_test_object_cache'][ $group ][ $key ];
+
+        if ( isset( $entry['expires'] ) && $entry['expires'] > 0 && $entry['expires'] < time() ) {
+            unset( $GLOBALS['visibloc_test_object_cache'][ $group ][ $key ] );
+        } else {
+            if ( is_bool( $found ) || null === $found ) {
+                $found = true;
+            }
+
+            return $entry['value'];
+        }
+    }
+
+    if ( is_bool( $found ) || null === $found ) {
+        $found = false;
+    }
+
+    return false;
+}
+
+function wp_cache_set( $key, $value, $group = '', $expire = 0 ) {
+    $group   = visibloc_test_cache_normalize_group( $group );
+    $expires = ( is_numeric( $expire ) && $expire > 0 ) ? ( time() + (int) $expire ) : 0;
+
+    if ( ! isset( $GLOBALS['visibloc_test_object_cache'][ $group ] ) ) {
+        $GLOBALS['visibloc_test_object_cache'][ $group ] = [];
+    }
+
+    $GLOBALS['visibloc_test_object_cache'][ $group ][ $key ] = [
+        'value'   => $value,
+        'expires' => $expires,
+    ];
+
+    return true;
+}
+
+function wp_cache_delete( $key, $group = '', $force = false ) {
+    $group = visibloc_test_cache_normalize_group( $group );
+
+    if ( isset( $GLOBALS['visibloc_test_object_cache'][ $group ][ $key ] ) ) {
+        unset( $GLOBALS['visibloc_test_object_cache'][ $group ][ $key ] );
+
+        if ( empty( $GLOBALS['visibloc_test_object_cache'][ $group ] ) ) {
+            unset( $GLOBALS['visibloc_test_object_cache'][ $group ] );
+        }
+    }
+
+    return true;
+}
+
 function set_transient( $key, $value, $expiration ) {
     $expires_at = ( is_numeric( $expiration ) && $expiration > 0 ) ? ( time() + (int) $expiration ) : 0;
 

--- a/visi-bloc-jlg/tests/phpunit/integration/DeviceVisibilityCssTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/DeviceVisibilityCssTest.php
@@ -3,8 +3,21 @@
 use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../../../includes/assets.php';
+require_once __DIR__ . '/../../../includes/admin-settings.php';
 
 class DeviceVisibilityCssTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        if ( isset( $GLOBALS['visibloc_test_object_cache'] ) ) {
+            $GLOBALS['visibloc_test_object_cache'] = [];
+        }
+
+        if ( function_exists( 'visibloc_jlg_clear_caches' ) ) {
+            visibloc_jlg_clear_caches();
+        }
+    }
+
     public function test_mobile_breakpoint_lower_than_default_unhides_tablet_classes(): void {
         $css = visibloc_jlg_generate_device_visibility_css( false, 600, 1024 );
 
@@ -25,6 +38,33 @@ class DeviceVisibilityCssTest extends TestCase {
         $this->assertStringContainsString('.vb-hide-on-mobile,', $block);
         $this->assertStringContainsString('.vb-tablet-only { display: revert !important; }', $block);
         $this->assertStringNotContainsString('display: none !important;', $block);
+    }
+
+    public function test_cached_css_is_returned_when_available(): void {
+        $expected = '/* cached css */';
+        wp_cache_set(
+            'visibloc_device_css_cache',
+            [ '0:600:1024' => $expected ],
+            'visibloc_jlg'
+        );
+
+        $css = visibloc_jlg_generate_device_visibility_css( false, 600, 1024 );
+
+        $this->assertSame( $expected, $css );
+    }
+
+    public function test_clear_caches_removes_cached_device_css(): void {
+        $initial = visibloc_jlg_generate_device_visibility_css( false, 600, 1024 );
+
+        $cache = wp_cache_get( 'visibloc_device_css_cache', 'visibloc_jlg' );
+        $this->assertIsArray( $cache );
+        $this->assertArrayHasKey( '0:600:1024', $cache );
+        $this->assertSame( $initial, $cache['0:600:1024'] );
+
+        visibloc_jlg_clear_caches();
+
+        $cache_after_clear = wp_cache_get( 'visibloc_device_css_cache', 'visibloc_jlg' );
+        $this->assertFalse( $cache_after_clear );
     }
 
     private function extractMediaQueryBlock( string $css, string $query ): ?string {


### PR DESCRIPTION
## Summary
- add an object cache layer for generated device visibility CSS so repeated requests reuse existing output
- clear the cached CSS whenever plugin caches are purged to avoid stale breakpoints
- extend the PHPUnit bootstrap and device visibility tests to cover cache hit and invalidation scenarios

## Testing
- vendor/bin/phpunit -c phpunit.xml.dist

------
https://chatgpt.com/codex/tasks/task_e_68d91df79204832e99b593b39b0a4e2f