### PR TITLE
Disable caching when preview role is active

### DIFF
--- a/visi-bloc-jlg/includes/role-switcher.php
+++ b/visi-bloc-jlg/includes/role-switcher.php
@@ -584,6 +584,29 @@ if ( ! function_exists( 'visibloc_jlg_get_preview_runtime_context' ) ) {
     }
 }
 
+add_action( 'init', 'visibloc_jlg_disable_caching_during_preview', 0 );
+function visibloc_jlg_disable_caching_during_preview() {
+    static $headers_sent = false;
+
+    if ( $headers_sent ) {
+        return;
+    }
+
+    $context = visibloc_jlg_get_preview_runtime_context();
+
+    if ( empty( $context['should_apply_preview_role'] ) || empty( $context['preview_role'] ) ) {
+        return;
+    }
+
+    $headers_sent = true;
+
+    if ( ! defined( 'DONOTCACHEPAGE' ) ) {
+        define( 'DONOTCACHEPAGE', true );
+    }
+
+    nocache_headers();
+}
+
 add_action( 'init', 'visibloc_jlg_handle_role_switching' );
 function visibloc_jlg_handle_role_switching() {
     $context = visibloc_jlg_get_user_preview_context( visibloc_jlg_get_effective_user_id() );


### PR DESCRIPTION
## Summary
- detect active preview cookies early in the request lifecycle
- disable caching by defining DONOTCACHEPAGE and sending nocache headers once per request

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d920efe470832eb6ef1b470659e7bf