### PR TITLE
Validate request host for role switcher URLs

### DIFF
--- a/visi-bloc-jlg/tests/phpunit/integration/RoleSwitcherRequestTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/RoleSwitcherRequestTest.php
@@ -293,13 +293,13 @@ class RoleSwitcherRequestTest extends TestCase {
         $visibloc_test_redirect_state = [];
         $GLOBALS['visibloc_test_cookie_log'] = [];
 
-        if ( function_exists( 'header_remove' ) ) {
+        if ( function_exists( 'header_remove' ) && ! headers_sent() ) {
             header_remove();
         }
     }
 
     protected function tearDown(): void {
-        if ( function_exists( 'header_remove' ) ) {
+        if ( function_exists( 'header_remove' ) && ! headers_sent() ) {
             header_remove();
         }
 
@@ -546,6 +546,14 @@ class RoleSwitcherRequestTest extends TestCase {
         visibloc_jlg_add_role_switcher_menu( $admin_bar_after );
 
         $this->assertArrayNotHasKey( 'visibloc-alert', $admin_bar_after->nodes, 'Toolbar alert should disappear once preview stops.' );
+    }
+
+    public function test_external_absolute_request_uri_is_neutralized(): void {
+        $_SERVER['REQUEST_URI'] = 'https://malicious.test/suspicious/?preview_role=guest&_wpnonce=fake';
+
+        $base_url = visibloc_jlg_get_preview_switch_base_url();
+
+        $this->assertSame( 'https://example.test/', $base_url );
     }
 
     private function getLatestCookieLog(): ?array {


### PR DESCRIPTION
## Summary
- ensure visibloc_jlg_get_current_request_url only accepts absolute URLs from the site host
- fall back to the canonical home URL when the request host or port differs
- cover the behavior with an integration test and guard header cleanup against sent headers

## Testing
- ./vendor/bin/phpunit --configuration phpunit.xml.dist

------
https://chatgpt.com/codex/tasks/task_e_68d99f6ed69c832eb5ae6e244ad8d632