### PR TITLE
Include plugin version in CSS cache keys

### DIFF
--- a/visi-bloc-jlg/includes/assets.php
+++ b/visi-bloc-jlg/includes/assets.php
@@ -1,6 +1,21 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) exit;
 
+if ( ! defined( 'VISIBLOC_JLG_VERSION' ) ) {
+    $visibloc_version = '0.0.0';
+    $plugin_main_file = __DIR__ . '/../visi-bloc-jlg.php';
+
+    if ( is_readable( $plugin_main_file ) ) {
+        $plugin_contents = file_get_contents( $plugin_main_file );
+
+        if ( false !== $plugin_contents && preg_match( '/^\s*\*\s*Version:\s*(.+)$/mi', $plugin_contents, $matches ) ) {
+            $visibloc_version = trim( $matches[1] );
+        }
+    }
+
+    define( 'VISIBLOC_JLG_VERSION', $visibloc_version );
+}
+
 add_action( 'wp_enqueue_scripts', 'visibloc_jlg_enqueue_public_styles' );
 function visibloc_jlg_enqueue_public_styles() {
     $plugin_main_file = __DIR__ . '/../visi-bloc-jlg.php';
@@ -69,7 +84,8 @@ function visibloc_jlg_generate_device_visibility_css( $can_preview, $mobile_bp =
     $cache_group = 'visibloc_jlg';
     $cache_key   = 'visibloc_device_css_cache';
     $bucket_key  = sprintf(
-        '%d:%d:%d',
+        '%s:%d:%d:%d',
+        VISIBLOC_JLG_VERSION,
         $can_preview ? 1 : 0,
         (int) $mobile_bp,
         (int) $tablet_bp

--- a/visi-bloc-jlg/tests/phpunit/integration/DeviceVisibilityCssTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/DeviceVisibilityCssTest.php
@@ -42,9 +42,11 @@ class DeviceVisibilityCssTest extends TestCase {
 
     public function test_cached_css_is_returned_when_available(): void {
         $expected = '/* cached css */';
+        $cache_key = sprintf( '%s:%d:%d:%d', VISIBLOC_JLG_VERSION, 0, 600, 1024 );
+
         wp_cache_set(
             'visibloc_device_css_cache',
-            [ '0:600:1024' => $expected ],
+            [ $cache_key => $expected ],
             'visibloc_jlg'
         );
 
@@ -58,8 +60,9 @@ class DeviceVisibilityCssTest extends TestCase {
 
         $cache = wp_cache_get( 'visibloc_device_css_cache', 'visibloc_jlg' );
         $this->assertIsArray( $cache );
-        $this->assertArrayHasKey( '0:600:1024', $cache );
-        $this->assertSame( $initial, $cache['0:600:1024'] );
+        $cache_key = sprintf( '%s:%d:%d:%d', VISIBLOC_JLG_VERSION, 0, 600, 1024 );
+        $this->assertArrayHasKey( $cache_key, $cache );
+        $this->assertSame( $initial, $cache[ $cache_key ] );
 
         visibloc_jlg_clear_caches();
 

--- a/visi-bloc-jlg/visi-bloc-jlg.php
+++ b/visi-bloc-jlg/visi-bloc-jlg.php
@@ -10,6 +10,25 @@
 
 if ( ! defined( 'WPINC' ) ) { exit; }
 
+if ( ! defined( 'VISIBLOC_JLG_VERSION' ) ) {
+    $visibloc_version = '0.0.0';
+
+    if ( function_exists( 'get_file_data' ) ) {
+        $plugin_data      = get_file_data( __FILE__, [ 'Version' => 'Version' ] );
+        $visibloc_version = isset( $plugin_data['Version'] ) && '' !== $plugin_data['Version']
+            ? $plugin_data['Version']
+            : $visibloc_version;
+    } else {
+        $plugin_contents = @file_get_contents( __FILE__ );
+
+        if ( false !== $plugin_contents && preg_match( '/^\s*\*\s*Version:\s*(.+)$/mi', $plugin_contents, $matches ) ) {
+            $visibloc_version = trim( $matches[1] );
+        }
+    }
+
+    define( 'VISIBLOC_JLG_VERSION', $visibloc_version );
+}
+
 if ( ! function_exists( 'visibloc_jlg_get_sanitized_query_arg' ) ) {
     /**
      * Retrieve a sanitized value from the $_GET superglobal using sanitize_key.


### PR DESCRIPTION
## Summary
- define a VISIBLOC_JLG_VERSION constant based on the plugin header
- expose the version to assets loading and include it in the device CSS cache bucket key
- adjust the device visibility integration tests to match the new cache key format

## Testing
- ./vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68da7a30dcfc832eafda2a8edb6744ad