### PR TITLE
Use VISIBLOC_JLG_VERSION for public style handles

### DIFF
--- a/visi-bloc-jlg/includes/assets.php
+++ b/visi-bloc-jlg/includes/assets.php
@@ -30,14 +30,15 @@ function visibloc_jlg_enqueue_public_styles() {
     $device_style_src       = plugins_url( 'assets/device-visibility.css', $plugin_main_file );
     $default_handle         = 'visibloc-jlg-device-visibility';
     $dynamic_handle         = 'visibloc-jlg-device-visibility-dynamic';
+    $style_version          = defined( 'VISIBLOC_JLG_VERSION' ) ? VISIBLOC_JLG_VERSION : '1.1';
 
     if ( $has_custom_breakpoints ) {
         wp_dequeue_style( $default_handle );
         wp_deregister_style( $default_handle );
-        wp_register_style( $dynamic_handle, false, [], '1.1' );
+        wp_register_style( $dynamic_handle, false, [], $style_version );
         $device_handle = $dynamic_handle;
     } else {
-        wp_register_style( $default_handle, $device_style_src, [], '1.1' );
+        wp_register_style( $default_handle, $device_style_src, [], $style_version );
         $device_handle = $default_handle;
     }
 
@@ -50,7 +51,7 @@ function visibloc_jlg_enqueue_public_styles() {
     }
 
     if ( $can_preview ) {
-        wp_enqueue_style( 'visibloc-jlg-public-styles', plugins_url( 'admin-styles.css', $plugin_main_file ) );
+        wp_enqueue_style( 'visibloc-jlg-public-styles', plugins_url( 'admin-styles.css', $plugin_main_file ), [], $style_version );
     }
 }
 


### PR DESCRIPTION
## Summary
- reuse the plugin version constant when registering device visibility styles
- add the version argument to the public preview stylesheet to enable cache busting
- fall back to the previous literal if the plugin version constant is unavailable

## Testing
- php -l visi-bloc-jlg/includes/assets.php

------
https://chatgpt.com/codex/tasks/task_e_68dac83236d4832e966b3f82bb43eebd