### PR TITLE
Support visibility controls for additional blocks

### DIFF
--- a/visi-bloc-jlg/includes/visibility-logic.php
+++ b/visi-bloc-jlg/includes/visibility-logic.php
@@ -1,7 +1,57 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-add_filter( 'render_block_core/group', 'visibloc_jlg_render_block_filter', 10, 2 );
+function visibloc_jlg_get_supported_blocks() {
+    $default_blocks = [ 'core/group' ];
+    $filtered_blocks = apply_filters( 'visibloc_supported_blocks', $default_blocks );
+
+    if ( ! is_array( $filtered_blocks ) ) {
+        return $default_blocks;
+    }
+
+    $sanitized = [];
+
+    foreach ( $filtered_blocks as $block_name ) {
+        if ( ! is_string( $block_name ) ) {
+            continue;
+        }
+
+        $trimmed = trim( $block_name );
+
+        if ( '' === $trimmed ) {
+            continue;
+        }
+
+        $sanitized[ $trimmed ] = true;
+    }
+
+    if ( empty( $sanitized ) ) {
+        return $default_blocks;
+    }
+
+    return array_keys( $sanitized );
+}
+
+function visibloc_jlg_is_supported_block( $block_name ) {
+    if ( ! is_string( $block_name ) || '' === $block_name ) {
+        return false;
+    }
+
+    return in_array( $block_name, visibloc_jlg_get_supported_blocks(), true );
+}
+
+function visibloc_jlg_render_block_visibility_router( $block_content, $block ) {
+    $block_name = is_array( $block ) && isset( $block['blockName'] ) ? $block['blockName'] : '';
+
+    if ( ! visibloc_jlg_is_supported_block( $block_name ) ) {
+        return $block_content;
+    }
+
+    return visibloc_jlg_render_block_filter( $block_content, $block );
+}
+
+add_filter( 'render_block', 'visibloc_jlg_render_block_visibility_router', 10, 2 );
+
 function visibloc_jlg_render_block_filter( $block_content, $block ) {
     if ( empty( $block['attrs'] ) ) { return $block_content; }
 

--- a/visi-bloc-jlg/tests/phpunit/integration/VisibilityLogicTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/VisibilityLogicTest.php
@@ -7,6 +7,7 @@ require_once __DIR__ . '/../../../includes/assets.php';
 class VisibilityLogicTest extends TestCase {
     protected function setUp(): void {
         visibloc_test_reset_state();
+        remove_all_filters( 'visibloc_supported_blocks' );
     }
 
     public function test_administrator_impersonating_editor_sees_editor_view_without_hidden_blocks(): void {
@@ -207,6 +208,43 @@ class VisibilityLogicTest extends TestCase {
             '<p>Guest view</p>',
             visibloc_jlg_render_block_filter( '<p>Guest view</p>', $logged_out_block ),
             'Previewing as a guest should expose content intended for visitors.'
+        );
+    }
+
+    public function test_render_block_filter_supports_additional_block_names(): void {
+        add_filter(
+            'visibloc_supported_blocks',
+            static function ( $blocks ) {
+                $blocks[] = 'core/columns';
+
+                return $blocks;
+            }
+        );
+
+        $hidden_columns_block = [
+            'blockName' => 'core/columns',
+            'attrs'     => [
+                'isHidden' => true,
+            ],
+        ];
+
+        $this->assertSame(
+            '',
+            apply_filters( 'render_block', '<p>Columns hidden</p>', $hidden_columns_block ),
+            'Hidden columns blocks should be filtered once registered as supported.',
+        );
+
+        $visible_columns_block = [
+            'blockName' => 'core/columns',
+            'attrs'     => [
+                'isHidden' => false,
+            ],
+        ];
+
+        $this->assertSame(
+            '<p>Columns visible</p>',
+            apply_filters( 'render_block', '<p>Columns visible</p>', $visible_columns_block ),
+            'Columns blocks should render when not hidden.',
         );
     }
 


### PR DESCRIPTION
## Summary
- add a filter-driven list of supported blocks in the editor and reuse it for block attributes, controls, and list view updates
- generalize the PHP render filter to honor the supported block list via a shared helper
- extend PHPUnit and Playwright tests to cover an additional core block (core/columns)

## Testing
- `vendor/bin/phpunit`
- `CI=1 npm run test:e2e` *(fails: missing system library libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68dad6ed5e8c832e86c95c02dd06a886