### PR TITLE
Add CSS fallback for revert display in visibility blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Visi-Bloc – JLG is a WordPress plugin that adds advanced visibility controls t
 - **Role-based visibility** – restrict blocks to selected roles or to logged-in/out visitors.
 - **Scheduling** – set start and end dates for blocks to appear.
 - **Manual hide** – hide blocks from the front end while still previewable to permitted roles.
-- **Device visibility utilities** – apply classes like `vb-hide-on-mobile`, `vb-mobile-only`, `vb-tablet-only`, or `vb-desktop-only` to control display by screen width.
+- **Device visibility utilities** – apply classes like `vb-hide-on-mobile`, `vb-mobile-only`, `vb-tablet-only`, or `vb-desktop-only` to control display by screen width, with automatic CSS fallbacks for browsers that do not yet support `display: revert`.
 - **Role preview switcher** – administrators (or roles explicitly granted via the `visibloc_jlg_allowed_impersonator_roles` filter) can preview the site as another role from the toolbar.
 
 ## Installation

--- a/visi-bloc-jlg/tests/phpunit/integration/DeviceVisibilityCssTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/DeviceVisibilityCssTest.php
@@ -27,7 +27,9 @@ class DeviceVisibilityCssTest extends TestCase {
 
         $this->assertNotNull( $block );
         $this->assertStringContainsString('.vb-hide-on-mobile,', $block);
-        $this->assertStringContainsString('.vb-tablet-only { display: revert !important; }', $block);
+        $this->assertStringContainsString('.vb-tablet-only {', $block);
+        $this->assertStringContainsString('display: block !important;', $block);
+        $this->assertStringContainsString('display: revert !important;', $block);
     }
 
     public function test_mobile_breakpoint_lower_than_default_does_not_hide_classes_above_new_threshold(): void {
@@ -36,7 +38,9 @@ class DeviceVisibilityCssTest extends TestCase {
 
         $this->assertNotNull( $block );
         $this->assertStringContainsString('.vb-hide-on-mobile,', $block);
-        $this->assertStringContainsString('.vb-tablet-only { display: revert !important; }', $block);
+        $this->assertStringContainsString('.vb-tablet-only {', $block);
+        $this->assertStringContainsString('display: block !important;', $block);
+        $this->assertStringContainsString('display: revert !important;', $block);
         $this->assertStringNotContainsString('display: none !important;', $block);
     }
 


### PR DESCRIPTION
## Summary
- add a helper that appends a block-level display fallback before display: revert for visibility CSS rules
- adjust the integration tests to assert the new fallback declarations
- document the improved browser compatibility in the README

## Testing
- ./vendor/bin/phpunit -c phpunit.xml.dist --testsuite Integration

------
https://chatgpt.com/codex/tasks/task_e_68dad6acb70c832e9b611e5fb25c7863