### PR TITLE
Support visibility controls for multiple block types

### DIFF
--- a/visi-bloc-jlg/tests/phpunit/integration/VisibilityLogicTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/VisibilityLogicTest.php
@@ -173,6 +173,36 @@ class VisibilityLogicTest extends TestCase {
         );
     }
 
+    public function test_supported_columns_block_respects_hidden_flag(): void {
+        $block = [
+            'blockName' => 'core/columns',
+            'attrs'     => [
+                'isHidden' => true,
+            ],
+        ];
+
+        $this->assertSame(
+            '',
+            visibloc_jlg_render_block_filter( '<p>Columns content</p>', $block ),
+            'Supported non-group blocks should be filtered using the same visibility logic.'
+        );
+    }
+
+    public function test_router_skips_unsupported_blocks(): void {
+        $block = [
+            'blockName' => 'core/paragraph',
+            'attrs'     => [
+                'isHidden' => true,
+            ],
+        ];
+
+        $this->assertSame(
+            '<p>Paragraph</p>',
+            visibloc_jlg_maybe_filter_rendered_block( '<p>Paragraph</p>', $block ),
+            'Unsupported blocks should not be altered by the render router.'
+        );
+    }
+
     public function test_guest_preview_forces_logged_out_state_without_impersonation(): void {
         global $visibloc_test_state;
 


### PR DESCRIPTION
## Summary
- share a filterable supported block list between the editor controls and saved markup handling
- switch the PHP render logic to a block-agnostic router so every supported block honours the visibility rules
- expand the PHPUnit and Playwright coverage to verify the columns block persists and renders the new attributes

## Testing
- `./vendor/bin/phpunit -c phpunit.xml.dist`
- `CI=1 npm run test:e2e --prefix visi-bloc-jlg` *(fails: missing libatk-1.0.so.0 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dae52231dc832ea84470d8a89ef96c