### PR TITLE
Add display fallback for visibility CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Visi-Bloc – JLG is a WordPress plugin that adds advanced visibility controls t
 - **Role-based visibility** – restrict blocks to selected roles or to logged-in/out visitors.
 - **Scheduling** – set start and end dates for blocks to appear.
 - **Manual hide** – hide blocks from the front end while still previewable to permitted roles.
-- **Device visibility utilities** – apply classes like `vb-hide-on-mobile`, `vb-mobile-only`, `vb-tablet-only`, or `vb-desktop-only` to control display by screen width.
+- **Device visibility utilities** – apply classes like `vb-hide-on-mobile`, `vb-mobile-only`, `vb-tablet-only`, or `vb-desktop-only` to control display by screen width. The generated CSS now includes a `display` fallback to support browsers that lack `display: revert`.
 - **Role preview switcher** – administrators (or roles explicitly granted via the `visibloc_jlg_allowed_impersonator_roles` filter) can preview the site as another role from the toolbar.
 
 ## Installation

--- a/visi-bloc-jlg/tests/phpunit/integration/DeviceVisibilityCssTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/DeviceVisibilityCssTest.php
@@ -27,7 +27,10 @@ class DeviceVisibilityCssTest extends TestCase {
 
         $this->assertNotNull( $block );
         $this->assertStringContainsString('.vb-hide-on-mobile,', $block);
-        $this->assertStringContainsString('.vb-tablet-only { display: revert !important; }', $block);
+        $this->assertStringContainsString(
+            ".vb-tablet-only {\n        display: block !important;\n        display: revert !important;\n    }",
+            $block
+        );
     }
 
     public function test_mobile_breakpoint_lower_than_default_does_not_hide_classes_above_new_threshold(): void {
@@ -36,7 +39,8 @@ class DeviceVisibilityCssTest extends TestCase {
 
         $this->assertNotNull( $block );
         $this->assertStringContainsString('.vb-hide-on-mobile,', $block);
-        $this->assertStringContainsString('.vb-tablet-only { display: revert !important; }', $block);
+        $this->assertStringContainsString('display: block !important;', $block);
+        $this->assertStringContainsString('display: revert !important;', $block);
         $this->assertStringNotContainsString('display: none !important;', $block);
     }
 

--- a/visi-bloc-jlg/tests/phpunit/integration/VisibilityLogicTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/VisibilityLogicTest.php
@@ -330,17 +330,23 @@ class VisibilityLogicTest extends TestCase {
 @media (max-width: 781px) {
     .vb-hide-on-mobile,
     .vb-tablet-only,
-    .vb-desktop-only { display: none !important; }
+    .vb-desktop-only {
+        display: none !important;
+    }
 }
 @media (min-width: 782px) and (max-width: 1024px) {
     .vb-hide-on-tablet,
     .vb-mobile-only,
-    .vb-desktop-only { display: none !important; }
+    .vb-desktop-only {
+        display: none !important;
+    }
 }
 @media (min-width: 1025px) {
     .vb-hide-on-desktop,
     .vb-mobile-only,
-    .vb-tablet-only { display: none !important; }
+    .vb-tablet-only {
+        display: none !important;
+    }
 }
 CSS;
         $this->assertSame( $expected_default_css, trim( $css_without_preview ) );


### PR DESCRIPTION
## Summary
- render visibility CSS blocks with multi-line declarations and display fallbacks when reverting visibility
- update integration tests to cover the new CSS output and fallback behavior
- note the improved browser compatibility for device visibility helpers in the README

## Testing
- ./vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68dae521ede8832e8128140fed40abf2