### PR TITLE
Ensure hide-on helpers use block display fallback

### DIFF
--- a/visi-bloc-jlg/includes/assets.php
+++ b/visi-bloc-jlg/includes/assets.php
@@ -302,7 +302,11 @@ function visibloc_jlg_get_display_fallback_for_selector( $selector ) {
         return 'display: block !important;';
     }
 
-    return 'display: block !important;';
+    if ( preg_match( '/^\\.vb-hide-on-(mobile|tablet|desktop)$/', $selector ) ) {
+        return 'display: block !important;';
+    }
+
+    return null;
 }
 
 function visibloc_jlg_format_media_query( $min, $max ) {


### PR DESCRIPTION
## Summary
- ensure `.vb-hide-on-*` helpers return a block-level fallback when display revert is applied
- keep the existing `.vb-*-only` fallback and avoid adding fallbacks for unrelated selectors

## Testing
- vendor/bin/phpunit -c phpunit.xml.dist

------
https://chatgpt.com/codex/tasks/task_e_68dbfb8d22d8832e9de138c142812658