### PR TITLE
Add WP-CLI command to rebuild index

### DIFF
--- a/visi-bloc-jlg/includes/cli.php
+++ b/visi-bloc-jlg/includes/cli.php
@@ -1,0 +1,64 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+    return;
+}
+
+if ( ! function_exists( 'visibloc_jlg_cli_count_posts_to_scan' ) ) {
+    /**
+     * Count the total number of posts scanned when rebuilding the group block summary index.
+     *
+     * @return int
+     */
+    function visibloc_jlg_cli_count_posts_to_scan() {
+        $post_types = apply_filters( 'visibloc_jlg_scanned_post_types', [ 'post', 'page', 'wp_template', 'wp_template_part' ] );
+        $page       = 1;
+        $scanned    = 0;
+
+        while ( true ) {
+            $query = new WP_Query(
+                [
+                    'post_type'              => $post_types,
+                    'post_status'            => [ 'publish', 'future', 'draft', 'pending', 'private' ],
+                    'posts_per_page'         => 100,
+                    'paged'                  => $page,
+                    'fields'                 => 'ids',
+                    'no_found_rows'          => true,
+                    'update_post_meta_cache' => false,
+                    'update_post_term_cache' => false,
+                ]
+            );
+
+            if ( empty( $query->posts ) ) {
+                break;
+            }
+
+            $scanned += count( $query->posts );
+            $page++;
+        }
+
+        return $scanned;
+    }
+}
+
+if ( ! function_exists( 'visibloc_jlg_cli_rebuild_index_command' ) ) {
+    /**
+     * Handle the `wp visibloc rebuild-index` command.
+     */
+    function visibloc_jlg_cli_rebuild_index_command() {
+        $scanned_posts = visibloc_jlg_cli_count_posts_to_scan();
+        $summaries     = visibloc_jlg_rebuild_group_block_summary_index();
+        $entries_count = is_array( $summaries ) ? count( $summaries ) : 0;
+
+        WP_CLI::log( sprintf( 'Scanned %d posts.', $scanned_posts ) );
+        WP_CLI::log( sprintf( 'Created %d index entries.', $entries_count ) );
+
+        visibloc_jlg_clear_caches();
+
+        WP_CLI::success( 'Group block summary caches cleared.' );
+    }
+}
+
+WP_CLI::add_command( 'visibloc rebuild-index', 'visibloc_jlg_cli_rebuild_index_command' );
+

--- a/visi-bloc-jlg/tests/phpunit/integration/CliRebuildIndexTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/CliRebuildIndexTest.php
@@ -1,0 +1,143 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @runTestsInSeparateProcesses
+ */
+class CliRebuildIndexTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        if ( ! defined( 'WP_CLI' ) ) {
+            define( 'WP_CLI', true );
+        }
+
+        if ( ! class_exists( 'WP_CLI' ) ) {
+            eval(
+                'class WP_CLI {' .
+                '    public static $commands = [];' .
+                '    public static $log_messages = [];' .
+                '    public static $success_messages = [];' .
+                '    public static function add_command( $name, $callable ) {' .
+                '        self::$commands[ $name ] = $callable;' .
+                '    }' .
+                '    public static function log( $message ) {' .
+                '        self::$log_messages[] = (string) $message;' .
+                '    }' .
+                '    public static function success( $message ) {' .
+                '        self::$success_messages[] = (string) $message;' .
+                '    }' .
+                '}'
+            );
+        }
+
+        if ( ! function_exists( 'visibloc_jlg_rebuild_group_block_summary_index' ) ) {
+            require_once __DIR__ . '/../../../includes/admin-settings.php';
+        }
+
+        if ( empty( WP_CLI::$commands ) || ! isset( WP_CLI::$commands['visibloc rebuild-index'] ) ) {
+            require_once __DIR__ . '/../../../includes/cli.php';
+        }
+
+        visibloc_test_reset_state();
+
+        $GLOBALS['visibloc_posts']           = [];
+        $GLOBALS['visibloc_test_options']    = [];
+        $GLOBALS['visibloc_test_transients'] = [];
+
+        if ( function_exists( 'visibloc_jlg_store_group_block_summary_index' ) ) {
+            visibloc_jlg_store_group_block_summary_index( [] );
+        }
+
+        if ( function_exists( 'visibloc_jlg_clear_caches' ) ) {
+            visibloc_jlg_clear_caches();
+        }
+
+        WP_CLI::$log_messages     = [];
+        WP_CLI::$success_messages = [];
+    }
+
+    protected function tearDown(): void {
+        if ( function_exists( 'visibloc_jlg_store_group_block_summary_index' ) ) {
+            visibloc_jlg_store_group_block_summary_index( [] );
+        }
+
+        if ( function_exists( 'visibloc_jlg_clear_caches' ) ) {
+            visibloc_jlg_clear_caches();
+        }
+
+        $GLOBALS['visibloc_posts']           = [];
+        $GLOBALS['visibloc_test_options']    = [];
+        $GLOBALS['visibloc_test_transients'] = [];
+
+        parent::tearDown();
+    }
+
+    public function test_rebuild_index_command_scans_posts_and_clears_caches(): void {
+        $this->assertArrayHasKey( 'visibloc rebuild-index', WP_CLI::$commands );
+
+        $command = WP_CLI::$commands['visibloc rebuild-index'];
+        $this->assertIsCallable( $command );
+
+        $hidden_group_content = <<<'HTML'
+<!-- wp:core/group {"isHidden":true} -->
+<div class="wp-block-group">Hidden group</div>
+<!-- /wp:core/group -->
+HTML;
+
+        $device_group_content = <<<'HTML'
+<!-- wp:core/group {"deviceVisibility":"mobile"} -->
+<div class="wp-block-group">Mobile only</div>
+<!-- /wp:core/group -->
+HTML;
+
+        $paragraph_content = <<<'HTML'
+<!-- wp:paragraph -->
+<p>Regular content without target blocks.</p>
+<!-- /wp:paragraph -->
+HTML;
+
+        $GLOBALS['visibloc_posts'] = [
+            101 => [
+                'post_content' => $hidden_group_content,
+                'post_type'    => 'post',
+                'post_status'  => 'publish',
+            ],
+            102 => [
+                'post_content' => $paragraph_content,
+                'post_type'    => 'post',
+                'post_status'  => 'draft',
+            ],
+            103 => [
+                'post_content' => $device_group_content,
+                'post_type'    => 'page',
+                'post_status'  => 'private',
+            ],
+        ];
+
+        set_transient( 'visibloc_hidden_posts', [ 'cached' ], 3600 );
+        set_transient( 'visibloc_group_block_metadata', [ 'cached' ], 3600 );
+
+        call_user_func( $command );
+
+        $summaries = visibloc_jlg_get_group_block_summary_index();
+
+        $this->assertSame( 2, count( $summaries ) );
+        $this->assertArrayHasKey( 101, $summaries );
+        $this->assertArrayHasKey( 103, $summaries );
+
+        $this->assertSame(
+            [
+                'Scanned 3 posts.',
+                'Created 2 index entries.',
+            ],
+            WP_CLI::$log_messages
+        );
+
+        $this->assertSame( [ 'Group block summary caches cleared.' ], WP_CLI::$success_messages );
+
+        $this->assertFalse( get_transient( 'visibloc_hidden_posts' ) );
+        $this->assertFalse( get_transient( 'visibloc_group_block_metadata' ) );
+    }
+}

--- a/visi-bloc-jlg/visi-bloc-jlg.php
+++ b/visi-bloc-jlg/visi-bloc-jlg.php
@@ -90,6 +90,9 @@ require_once __DIR__ . '/includes/admin-settings.php';
 require_once __DIR__ . '/includes/assets.php';
 require_once __DIR__ . '/includes/visibility-logic.php';
 require_once __DIR__ . '/includes/role-switcher.php';
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+    require_once __DIR__ . '/includes/cli.php';
+}
 
 /**
  * Initialise la localisation du plugin.


### PR DESCRIPTION
## Summary
- add a WP-CLI registration file that rebuilds the group block summary index and clears caches
- load the CLI bootstrap conditionally from the main plugin entry point
- cover the CLI workflow with an integration test that simulates WP_CLI

## Testing
- ./vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68dc221aac54832e83b8f7682fd8199c