### PR TITLE
Use site timezone for scheduling checks

### DIFF
--- a/visi-bloc-jlg/includes/visibility-logic.php
+++ b/visi-bloc-jlg/includes/visibility-logic.php
@@ -119,7 +119,19 @@ function visibloc_jlg_render_block_filter( $block_content, $block ) {
     }
 
     if ( $has_schedule_enabled ) {
-        $current_time = current_time( 'timestamp', true );
+        $current_time = null;
+
+        if ( function_exists( 'current_datetime' ) ) {
+            $current_datetime = current_datetime();
+
+            if ( $current_datetime instanceof DateTimeInterface ) {
+                $current_time = $current_datetime->getTimestamp();
+            }
+        }
+
+        if ( null === $current_time ) {
+            $current_time = (int) current_time( 'timestamp' );
+        }
 
         $start_time = visibloc_jlg_parse_schedule_datetime( $attrs['publishStartDate'] ?? null );
         $end_time   = visibloc_jlg_parse_schedule_datetime( $attrs['publishEndDate'] ?? null );

--- a/visi-bloc-jlg/tests/phpunit/bootstrap.php
+++ b/visi-bloc-jlg/tests/phpunit/bootstrap.php
@@ -378,6 +378,12 @@ function current_time( $type, $gmt = 0 ) {
     return ( new DateTimeImmutable( '@' . $timestamp ) )->setTimezone( $timezone )->format( 'Y-m-d H:i:s' );
 }
 
+function current_datetime() {
+    $timestamp = visibloc_test_get_current_time();
+
+    return ( new DateTimeImmutable( '@' . $timestamp ) )->setTimezone( wp_timezone() );
+}
+
 if ( ! function_exists( 'wp_json_encode' ) ) {
     function wp_json_encode( $data ) {
         return json_encode( $data );

--- a/visi-bloc-jlg/tests/phpunit/integration/VisibilityLogicTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/VisibilityLogicTest.php
@@ -350,6 +350,27 @@ class VisibilityLogicTest extends TestCase {
         );
     }
 
+    public function test_scheduled_block_remains_hidden_after_window_with_local_timezone(): void {
+        visibloc_test_set_timezone( 'Europe/Paris' );
+
+        $block = [
+            'blockName' => 'core/group',
+            'attrs'     => [
+                'isSchedulingEnabled' => true,
+                'publishStartDate'    => '2024-07-10 10:00:00',
+                'publishEndDate'      => '2024-07-10 18:00:00',
+            ],
+        ];
+
+        $this->setCurrentTimeForSiteTimezone( '2024-07-10 18:30:00' );
+
+        $this->assertSame(
+            '',
+            visibloc_jlg_render_block_filter( '<p>Scheduled content</p>', $block ),
+            'Blocks should remain hidden after the scheduled end in the configured site timezone.'
+        );
+    }
+
     private function setCurrentTimeForSiteTimezone( string $datetime ): void {
         $timestamp = visibloc_jlg_parse_schedule_datetime( $datetime );
 
@@ -357,9 +378,7 @@ class VisibilityLogicTest extends TestCase {
             $this->fail( sprintf( 'Failed to parse datetime string "%s" for test setup.', $datetime ) );
         }
 
-        $offset = visibloc_test_get_timezone_offset( $timestamp );
-
-        visibloc_test_set_current_time( $timestamp + $offset );
+        visibloc_test_set_current_time( $timestamp );
     }
 
     public function test_generate_device_visibility_css_respects_preview_context(): void {


### PR DESCRIPTION
## Summary
- read the current timestamp using WordPress' site timezone helpers instead of forcing UTC
- add a bootstrap stub for current_datetime() and adjust schedule tests to work with site-local timestamps
- extend scheduling integration coverage with a post-window assertion in a non-UTC timezone

## Testing
- vendor/bin/phpunit -c phpunit.xml.dist

------
https://chatgpt.com/codex/tasks/task_e_68dc26930228832ea8a454da63264b67