### PR TITLE
Harden CLI rebuild index command guards

### DIFF
--- a/visi-bloc-jlg/includes/cli.php
+++ b/visi-bloc-jlg/includes/cli.php
@@ -1,7 +1,13 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
 
 if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+    return;
+}
+
+if ( ! class_exists( 'WP_CLI' ) ) {
     return;
 }
 
@@ -49,7 +55,7 @@ if ( ! function_exists( 'visibloc_jlg_cli_rebuild_index_command' ) ) {
     function visibloc_jlg_cli_rebuild_index_command() {
         $scanned_posts = visibloc_jlg_cli_count_posts_to_scan();
         $summaries     = visibloc_jlg_rebuild_group_block_summary_index();
-        $entries_count = is_array( $summaries ) ? count( $summaries ) : 0;
+        $entries_count = is_countable( $summaries ) ? count( $summaries ) : 0;
 
         WP_CLI::log( sprintf( 'Scanned %d posts.', $scanned_posts ) );
         WP_CLI::log( sprintf( 'Created %d index entries.', $entries_count ) );


### PR DESCRIPTION
## Summary
- guard the CLI bootstrap so it only registers commands when the WP_CLI class is available
- harden the rebuild handler by checking the returned value is countable before counting entries

## Testing
- vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68dc268936d4832e918616ec904ed7f1