### PR TITLE
Use display: initial fallback for device visibility CSS

### DIFF
--- a/visi-bloc-jlg/includes/assets.php
+++ b/visi-bloc-jlg/includes/assets.php
@@ -286,13 +286,14 @@ function visibloc_jlg_normalize_block_declarations( $selector, $declaration ) {
                 $fallback .= ';';
             }
 
-            foreach ( $normalized as $index => $value ) {
-                if ( 0 === strcasecmp( $value, $fallback ) ) {
-                    unset( $normalized[ $index ] );
-                }
-            }
-
-            $normalized = array_values( $normalized );
+            $normalized = array_values(
+                array_filter(
+                    $normalized,
+                    static function ( $value ) use ( $fallback ) {
+                        return 0 !== strcasecmp( trim( $value ), $fallback );
+                    }
+                )
+            );
 
             array_unshift( $normalized, $fallback );
         }
@@ -306,12 +307,14 @@ function visibloc_jlg_get_display_fallback_for_selector( $selector ) {
         return null;
     }
 
+    $fallback = 'display: initial !important;';
+
     if ( false !== strpos( $selector, '-only' ) ) {
-        return 'display: initial !important;';
+        return $fallback;
     }
 
     if ( preg_match( '/^\\.vb-hide-on-(mobile|tablet|desktop)$/', $selector ) ) {
-        return 'display: initial !important;';
+        return $fallback;
     }
 
     return null;

--- a/visi-bloc-jlg/tests/phpunit/integration/DeviceVisibilityCssTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/DeviceVisibilityCssTest.php
@@ -44,14 +44,14 @@ class DeviceVisibilityCssTest extends TestCase {
         $this->assertStringNotContainsString('display: none !important;', $block);
     }
 
-    public function test_hide_on_selectors_use_block_fallback(): void {
+    public function test_hide_on_selectors_use_initial_fallback(): void {
         $this->assertSame(
             'display: initial !important;',
             visibloc_jlg_get_display_fallback_for_selector( '.vb-hide-on-desktop' )
         );
     }
 
-    public function test_only_selectors_keep_block_fallback(): void {
+    public function test_only_selectors_keep_initial_fallback(): void {
         $this->assertSame(
             'display: initial !important;',
             visibloc_jlg_get_display_fallback_for_selector( '.vb-tablet-only' )
@@ -110,6 +110,24 @@ class DeviceVisibilityCssTest extends TestCase {
             '.vb-tablet-only',
             [
                 'display: initial !important;',
+                'display: revert !important;',
+            ]
+        );
+
+        $this->assertSame(
+            [
+                'display: initial !important;',
+                'display: revert !important;',
+            ],
+            $declarations
+        );
+    }
+
+    public function test_normalize_block_declarations_handles_initial_with_whitespace(): void {
+        $declarations = visibloc_jlg_normalize_block_declarations(
+            '.vb-tablet-only',
+            [
+                "  display: initial !important;   ",
                 'display: revert !important;',
             ]
         );


### PR DESCRIPTION
## Summary
- ensure the fallback declaration for device visibility selectors resolves to `display: initial !important;` and de-duplicates cleanly before `display: revert`
- expand the device visibility integration tests to reflect the new fallback value and cover inline declaration handling
- manually verified the generated `.vb-*` base rules remain unchanged for their target breakpoints

## Testing
- ../vendor/bin/phpunit --configuration ../phpunit.xml.dist tests/phpunit/integration/DeviceVisibilityCssTest.php

------
https://chatgpt.com/codex/tasks/task_e_68dc3193ce6c832e9b72d1bb63127336