### PR TITLE
Improve CLI rebuild index command stats reporting

### DIFF
--- a/visi-bloc-jlg/includes/admin-settings.php
+++ b/visi-bloc-jlg/includes/admin-settings.php
@@ -572,10 +572,11 @@ function visibloc_jlg_store_group_block_summary_index( $index ) {
     update_option( 'visibloc_group_block_summary', $index, false );
 }
 
-function visibloc_jlg_rebuild_group_block_summary_index() {
+function visibloc_jlg_rebuild_group_block_summary_index( &$scanned_posts = null ) {
     $post_types = apply_filters( 'visibloc_jlg_scanned_post_types', [ 'post', 'page', 'wp_template', 'wp_template_part' ] );
     $page       = 1;
     $summaries  = [];
+    $scanned    = 0;
 
     while ( true ) {
         $query = new WP_Query( [
@@ -594,6 +595,7 @@ function visibloc_jlg_rebuild_group_block_summary_index() {
         }
 
         foreach ( $query->posts as $post_id ) {
+            $scanned++;
             $summary = visibloc_jlg_generate_group_block_summary_from_content( $post_id );
 
             if ( visibloc_jlg_group_block_summary_has_data( $summary ) ) {
@@ -605,6 +607,10 @@ function visibloc_jlg_rebuild_group_block_summary_index() {
     }
 
     visibloc_jlg_store_group_block_summary_index( $summaries );
+
+    if ( func_num_args() > 0 ) {
+        $scanned_posts = $scanned;
+    }
 
     return $summaries;
 }

--- a/visi-bloc-jlg/includes/cli.php
+++ b/visi-bloc-jlg/includes/cli.php
@@ -11,50 +11,13 @@ if ( ! class_exists( 'WP_CLI' ) ) {
     return;
 }
 
-if ( ! function_exists( 'visibloc_jlg_cli_count_posts_to_scan' ) ) {
-    /**
-     * Count the total number of posts scanned when rebuilding the group block summary index.
-     *
-     * @return int
-     */
-    function visibloc_jlg_cli_count_posts_to_scan() {
-        $post_types = apply_filters( 'visibloc_jlg_scanned_post_types', [ 'post', 'page', 'wp_template', 'wp_template_part' ] );
-        $page       = 1;
-        $scanned    = 0;
-
-        while ( true ) {
-            $query = new WP_Query(
-                [
-                    'post_type'              => $post_types,
-                    'post_status'            => [ 'publish', 'future', 'draft', 'pending', 'private' ],
-                    'posts_per_page'         => 100,
-                    'paged'                  => $page,
-                    'fields'                 => 'ids',
-                    'no_found_rows'          => true,
-                    'update_post_meta_cache' => false,
-                    'update_post_term_cache' => false,
-                ]
-            );
-
-            if ( empty( $query->posts ) ) {
-                break;
-            }
-
-            $scanned += count( $query->posts );
-            $page++;
-        }
-
-        return $scanned;
-    }
-}
-
 if ( ! function_exists( 'visibloc_jlg_cli_rebuild_index_command' ) ) {
     /**
      * Handle the `wp visibloc rebuild-index` command.
      */
     function visibloc_jlg_cli_rebuild_index_command() {
-        $scanned_posts = visibloc_jlg_cli_count_posts_to_scan();
-        $summaries     = visibloc_jlg_rebuild_group_block_summary_index();
+        $scanned_posts = 0;
+        $summaries     = visibloc_jlg_rebuild_group_block_summary_index( $scanned_posts );
         $entries_count = is_countable( $summaries ) ? count( $summaries ) : 0;
 
         WP_CLI::log( sprintf( 'Scanned %d posts.', $scanned_posts ) );


### PR DESCRIPTION
## Summary
- expose the number of scanned posts from visibloc_jlg_rebuild_group_block_summary_index
- reuse the reported stats in the WP-CLI command to avoid a duplicate query

## Testing
- ./vendor/bin/phpunit -c phpunit.xml.dist

------
https://chatgpt.com/codex/tasks/task_e_68dc2f789668832eb886bd3b7a53509f