### PR TITLE
Update CLI rebuild command stats output

### DIFF
--- a/visi-bloc-jlg/includes/cli.php
+++ b/visi-bloc-jlg/includes/cli.php
@@ -48,17 +48,35 @@ if ( ! function_exists( 'visibloc_jlg_cli_count_posts_to_scan' ) ) {
     }
 }
 
+if ( ! function_exists( 'visibloc_jlg_cli_calculate_rebuild_stats' ) ) {
+    /**
+     * Execute the index rebuild and return statistics about the operation.
+     *
+     * @return array{
+     *     scanned_posts:int,
+     *     entries_count:int,
+     * }
+     */
+    function visibloc_jlg_cli_calculate_rebuild_stats() {
+        $summaries     = visibloc_jlg_rebuild_group_block_summary_index();
+        $entries_count = is_countable( $summaries ) ? count( $summaries ) : 0;
+        $scanned_posts = visibloc_jlg_cli_count_posts_to_scan();
+
+        return [
+            'scanned_posts' => $scanned_posts,
+            'entries_count' => $entries_count,
+        ];
+    }
+}
+
 if ( ! function_exists( 'visibloc_jlg_cli_rebuild_index_command' ) ) {
     /**
      * Handle the `wp visibloc rebuild-index` command.
      */
     function visibloc_jlg_cli_rebuild_index_command() {
-        $scanned_posts = visibloc_jlg_cli_count_posts_to_scan();
-        $summaries     = visibloc_jlg_rebuild_group_block_summary_index();
-        $entries_count = is_countable( $summaries ) ? count( $summaries ) : 0;
+        $stats = visibloc_jlg_cli_calculate_rebuild_stats();
 
-        WP_CLI::log( sprintf( 'Scanned %d posts.', $scanned_posts ) );
-        WP_CLI::log( sprintf( 'Created %d index entries.', $entries_count ) );
+        WP_CLI::log( sprintf( 'Scanned %d posts and created %d index entries.', $stats['scanned_posts'], $stats['entries_count'] ) );
 
         visibloc_jlg_clear_caches();
 

--- a/visi-bloc-jlg/tests/phpunit/integration/CliRebuildIndexTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/CliRebuildIndexTest.php
@@ -128,10 +128,7 @@ HTML;
         $this->assertArrayHasKey( 103, $summaries );
 
         $this->assertSame(
-            [
-                'Scanned 3 posts.',
-                'Created 2 index entries.',
-            ],
+            [ 'Scanned 3 posts and created 2 index entries.' ],
             WP_CLI::$log_messages
         );
 


### PR DESCRIPTION
## Summary
- add a helper to gather rebuild statistics so the CLI command can log the combined post/entry counts before clearing caches
- align the CLI integration test with the new consolidated log message

## Testing
- vendor/bin/phpunit -c phpunit.xml.dist

------
https://chatgpt.com/codex/tasks/task_e_68dc31989a4c832eacf17e7be6b4299f