### PR TITLE
Handle missing editor assets with admin notice

### DIFF
--- a/visi-bloc-jlg/tests/e2e/specs/missing-editor-assets-notice.spec.js
+++ b/visi-bloc-jlg/tests/e2e/specs/missing-editor-assets-notice.spec.js
@@ -1,0 +1,43 @@
+import fs from 'fs';
+import path from 'path';
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+const PLUGIN_SLUG = 'visi-bloc-jlg/visi-bloc-jlg.php';
+const PLUGIN_ROOT = path.resolve( __dirname, '../../..' );
+const ASSET_FILE = path.join( PLUGIN_ROOT, 'build/index.asset.php' );
+const BACKUP_FILE = `${ ASSET_FILE }.bak-e2e`;
+
+function restoreAssetFile() {
+    if ( fs.existsSync( BACKUP_FILE ) ) {
+        fs.renameSync( BACKUP_FILE, ASSET_FILE );
+    }
+}
+
+test.describe( 'Visi-Bloc missing editor assets notice', () => {
+    test.beforeEach( async ( { requestUtils } ) => {
+        restoreAssetFile();
+        await requestUtils.activatePlugin( PLUGIN_SLUG );
+    } );
+
+    test.afterEach( async ( { requestUtils } ) => {
+        restoreAssetFile();
+        await requestUtils.deactivatePlugin( PLUGIN_SLUG );
+    } );
+
+    test( 'displays an admin notice with the build command when assets are missing', async ( { admin, page } ) => {
+        if ( ! fs.existsSync( ASSET_FILE ) ) {
+            test.skip();
+        }
+
+        fs.renameSync( ASSET_FILE, BACKUP_FILE );
+
+        try {
+            await admin.visitAdminPage( 'post-new.php' );
+
+            const notice = page.locator( '.notice.notice-error' ).filter( { hasText: 'npm install && npm run build' } );
+            await expect( notice ).toBeVisible();
+        } finally {
+            restoreAssetFile();
+        }
+    } );
+} );

--- a/visi-bloc-jlg/tests/phpunit/integration/EditorAssetsTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/EditorAssetsTest.php
@@ -1,0 +1,106 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../../includes/assets.php';
+
+class EditorAssetsTest extends TestCase {
+    private string $assetFile;
+    private string $assetBackup;
+    private $previousUser;
+    private array $previousRoles;
+
+    protected function setUp(): void {
+        parent::setUp();
+
+        $this->assetFile   = dirname( __DIR__, 3 ) . '/build/index.asset.php';
+        $this->assetBackup = $this->assetFile . '.bak-test';
+        $this->previousUser = $GLOBALS['visibloc_test_state']['current_user'] ?? null;
+        $this->previousRoles = $GLOBALS['visibloc_test_state']['roles'] ?? [];
+
+        if ( isset( $GLOBALS['visibloc_test_transients'][ VISIBLOC_JLG_MISSING_EDITOR_ASSETS_TRANSIENT ] ) ) {
+            unset( $GLOBALS['visibloc_test_transients'][ VISIBLOC_JLG_MISSING_EDITOR_ASSETS_TRANSIENT ] );
+        }
+    }
+
+    protected function tearDown(): void {
+        if ( file_exists( $this->assetBackup ) && ! file_exists( $this->assetFile ) ) {
+            rename( $this->assetBackup, $this->assetFile );
+        } elseif ( file_exists( $this->assetBackup ) ) {
+            unlink( $this->assetBackup );
+        }
+
+        $GLOBALS['visibloc_test_state']['current_user'] = $this->previousUser;
+        $GLOBALS['visibloc_test_state']['roles']        = $this->previousRoles;
+
+        delete_transient( VISIBLOC_JLG_MISSING_EDITOR_ASSETS_TRANSIENT );
+
+        parent::tearDown();
+    }
+
+    public function test_missing_asset_sets_transient_flag(): void {
+        $this->assertFileExists( $this->assetFile );
+        $this->temporarilyRemoveAssetFile();
+
+        try {
+            $this->assertFalse( get_transient( VISIBLOC_JLG_MISSING_EDITOR_ASSETS_TRANSIENT ) );
+
+            visibloc_jlg_enqueue_editor_assets();
+
+            $this->assertNotFalse( get_transient( VISIBLOC_JLG_MISSING_EDITOR_ASSETS_TRANSIENT ) );
+        } finally {
+            $this->restoreAssetFile();
+        }
+    }
+
+    public function test_notice_rendered_for_users_who_manage_options(): void {
+        set_transient( VISIBLOC_JLG_MISSING_EDITOR_ASSETS_TRANSIENT, true, 0 );
+
+        $administrator = $GLOBALS['visibloc_test_state']['roles']['administrator'] ?? (object) [
+            'name'         => 'Administrator',
+            'capabilities' => [],
+        ];
+        $administrator->capabilities['manage_options'] = true;
+        $GLOBALS['visibloc_test_state']['roles']['administrator'] = $administrator;
+        $GLOBALS['visibloc_test_state']['current_user']            = new Visibloc_Test_User( 1, [ 'administrator' ] );
+
+        ob_start();
+        visibloc_jlg_render_missing_editor_assets_notice();
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString( 'notice notice-error', $output );
+        $this->assertStringContainsString( 'npm install && npm run build', $output );
+    }
+
+    public function test_notice_not_rendered_for_users_without_capability(): void {
+        set_transient( VISIBLOC_JLG_MISSING_EDITOR_ASSETS_TRANSIENT, true, 0 );
+        $GLOBALS['visibloc_test_state']['current_user'] = new Visibloc_Test_User( 2, [ 'editor' ] );
+
+        $editor = $GLOBALS['visibloc_test_state']['roles']['editor'] ?? (object) [
+            'name'         => 'Editor',
+            'capabilities' => [],
+        ];
+        unset( $editor->capabilities['manage_options'] );
+        $GLOBALS['visibloc_test_state']['roles']['editor'] = $editor;
+
+        ob_start();
+        visibloc_jlg_render_missing_editor_assets_notice();
+        $output = ob_get_clean();
+
+        $this->assertSame( '', trim( $output ) );
+    }
+
+    private function temporarilyRemoveAssetFile(): void {
+        if ( file_exists( $this->assetBackup ) ) {
+            unlink( $this->assetBackup );
+        }
+
+        rename( $this->assetFile, $this->assetBackup );
+    }
+
+    private function restoreAssetFile(): void {
+        if ( file_exists( $this->assetBackup ) ) {
+            rename( $this->assetBackup, $this->assetFile );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- cache a transient flag when the block editor build assets are missing and surface an admin error notice with the rebuild command for site managers
- clear the flag when assets load successfully and log the issue once to assist debugging
- add PHPUnit coverage plus a Playwright spec that exercises the missing asset workflow

## Testing
- `vendor/bin/phpunit -c phpunit.xml.dist`
- `npx playwright test tests/e2e/specs/missing-editor-assets-notice.spec.js` *(fails: local WordPress environment with REST API/Docker is unavailable in CI sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68dc3547b054832eb4fc8ccd85d994be