### PR TITLE
Ensure uninstall removes supported blocks option

### DIFF
--- a/visi-bloc-jlg/tests/phpunit/bootstrap.php
+++ b/visi-bloc-jlg/tests/phpunit/bootstrap.php
@@ -685,6 +685,14 @@ function update_option( $name, $value, $autoload = null ) {
     return true;
 }
 
+function delete_option( $name ) {
+    if ( isset( $GLOBALS['visibloc_test_options'][ $name ] ) ) {
+        unset( $GLOBALS['visibloc_test_options'][ $name ] );
+    }
+
+    return true;
+}
+
 function __( $text ) {
     return $text;
 }

--- a/visi-bloc-jlg/tests/phpunit/integration/UninstallCleanupTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/UninstallCleanupTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../role-switcher-test-loader.php';
+
+class UninstallCleanupTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        $GLOBALS['visibloc_test_options'] = [];
+    }
+
+    protected function tearDown(): void {
+        $GLOBALS['visibloc_test_options'] = [];
+
+        parent::tearDown();
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_supported_blocks_option_is_removed_on_uninstall(): void {
+        update_option( 'visibloc_supported_blocks', [ 'core/paragraph' ] );
+
+        $this->assertSame(
+            [ 'core/paragraph' ],
+            get_option( 'visibloc_supported_blocks' )
+        );
+
+        if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+            define( 'WP_UNINSTALL_PLUGIN', true );
+        }
+
+        require dirname( __DIR__, 3 ) . '/uninstall.php';
+
+        $this->assertSame(
+            '__default__',
+            get_option( 'visibloc_supported_blocks', '__default__' )
+        );
+    }
+}

--- a/visi-bloc-jlg/uninstall.php
+++ b/visi-bloc-jlg/uninstall.php
@@ -7,6 +7,7 @@ delete_option( 'visibloc_breakpoint_mobile' );
 delete_option( 'visibloc_breakpoint_tablet' );
 delete_option( 'visibloc_preview_roles' );
 delete_option( 'visibloc_group_block_summary' );
+delete_option( 'visibloc_supported_blocks' );
 
 // Supprime les transients de cache du plugin
 delete_transient( 'visibloc_hidden_posts' );


### PR DESCRIPTION
## Summary
- remove the visibloc_supported_blocks option during uninstall cleanup
- add a PHPUnit integration test covering uninstall option removal
- stub delete_option in the test bootstrap to reflect WordPress behaviour

## Testing
- ./vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68dc3d91b7f0832e8406afd38f750310