### PR TITLE
Clear cached editor assets and device CSS during uninstall

### DIFF
--- a/visi-bloc-jlg/tests/phpunit/integration/UninstallCleanupTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/UninstallCleanupTest.php
@@ -9,10 +9,14 @@ class UninstallCleanupTest extends TestCase {
         parent::setUp();
 
         $GLOBALS['visibloc_test_options'] = [];
+        $GLOBALS['visibloc_test_transients'] = [];
+        $GLOBALS['visibloc_test_object_cache'] = [];
     }
 
     protected function tearDown(): void {
         $GLOBALS['visibloc_test_options'] = [];
+        $GLOBALS['visibloc_test_transients'] = [];
+        $GLOBALS['visibloc_test_object_cache'] = [];
 
         parent::tearDown();
     }
@@ -39,5 +43,29 @@ class UninstallCleanupTest extends TestCase {
             '__default__',
             get_option( 'visibloc_supported_blocks', '__default__' )
         );
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_uninstall_clears_editor_asset_and_device_css_caches(): void {
+        set_transient( 'visibloc_jlg_missing_editor_assets', 'yes', 0 );
+        wp_cache_set( 'visibloc_device_css_cache', [ 'cached' => true ], 'visibloc_jlg' );
+
+        $this->assertSame( 'yes', get_transient( 'visibloc_jlg_missing_editor_assets' ) );
+        $this->assertSame(
+            [ 'cached' => true ],
+            wp_cache_get( 'visibloc_device_css_cache', 'visibloc_jlg' )
+        );
+
+        if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+            define( 'WP_UNINSTALL_PLUGIN', true );
+        }
+
+        require dirname( __DIR__, 3 ) . '/uninstall.php';
+
+        $this->assertFalse( get_transient( 'visibloc_jlg_missing_editor_assets' ) );
+        $this->assertFalse( wp_cache_get( 'visibloc_device_css_cache', 'visibloc_jlg' ) );
     }
 }

--- a/visi-bloc-jlg/uninstall.php
+++ b/visi-bloc-jlg/uninstall.php
@@ -14,3 +14,6 @@ delete_transient( 'visibloc_hidden_posts' );
 delete_transient( 'visibloc_device_posts' );
 delete_transient( 'visibloc_scheduled_posts' );
 delete_transient( 'visibloc_group_block_metadata' );
+delete_transient( 'visibloc_jlg_missing_editor_assets' );
+
+wp_cache_delete( 'visibloc_device_css_cache', 'visibloc_jlg' );


### PR DESCRIPTION
## Summary
- clear the editor asset transient and device CSS object cache when uninstalling the plugin
- extend the uninstall integration test suite to cover cache cleanup and reset the in-memory fixtures

## Testing
- ./vendor/bin/phpunit -c phpunit.xml.dist

------
https://chatgpt.com/codex/tasks/task_e_68dc439ce874832e90d61a10cba75b2a