### PR TITLE
Improve admin dashboard responsiveness

### DIFF
--- a/visi-bloc-jlg/assets/admin-responsive.css
+++ b/visi-bloc-jlg/assets/admin-responsive.css
@@ -1,0 +1,107 @@
+.visibloc-admin-post-list {
+    list-style: disc;
+    padding-left: 20px;
+    margin: 0 0 1em;
+}
+
+.visibloc-admin-post-list li {
+    margin-bottom: 0.5em;
+}
+
+.visibloc-admin-post-list li:last-child {
+    margin-bottom: 0;
+}
+
+.visibloc-admin-table-wrapper {
+    overflow-x: auto;
+}
+
+.visibloc-admin-scheduled-table a {
+    word-break: break-word;
+}
+
+@media (max-width: 782px) {
+    .visibloc-admin-post-list {
+        list-style: none;
+        padding-left: 0;
+        margin: 0;
+    }
+
+    .visibloc-admin-post-list li {
+        display: block;
+        margin-bottom: 12px;
+        padding: 12px 14px;
+        border: 1px solid #dcdcde;
+        border-radius: 4px;
+        background: #fff;
+    }
+
+    .visibloc-admin-post-list li:last-child {
+        margin-bottom: 0;
+    }
+
+    .visibloc-admin-post-list a {
+        display: block;
+        text-decoration: none;
+        color: inherit;
+        word-break: break-word;
+    }
+
+    .visibloc-admin-table-wrapper {
+        overflow: visible;
+    }
+
+    .visibloc-admin-scheduled-table,
+    .visibloc-admin-scheduled-table thead,
+    .visibloc-admin-scheduled-table tbody,
+    .visibloc-admin-scheduled-table tr,
+    .visibloc-admin-scheduled-table th,
+    .visibloc-admin-scheduled-table td {
+        display: block;
+        width: 100%;
+    }
+
+    .visibloc-admin-scheduled-table {
+        border: 0;
+        box-shadow: none;
+    }
+
+    .visibloc-admin-scheduled-table thead {
+        display: none;
+    }
+
+    .visibloc-admin-scheduled-table tbody {
+        display: block;
+    }
+
+    .visibloc-admin-scheduled-table tr {
+        margin-bottom: 12px;
+        border: 1px solid #dcdcde;
+        border-radius: 4px;
+        background: #fff;
+        padding: 12px 14px;
+        box-sizing: border-box;
+    }
+
+    .visibloc-admin-scheduled-table tr:last-child {
+        margin-bottom: 0;
+    }
+
+    .visibloc-admin-scheduled-table td {
+        padding: 0;
+        margin: 0 0 10px;
+        border-bottom: 0;
+    }
+
+    .visibloc-admin-scheduled-table td:last-child {
+        margin-bottom: 0;
+    }
+
+    .visibloc-admin-scheduled-table td::before {
+        content: attr(data-label);
+        display: block;
+        font-weight: 600;
+        margin-bottom: 4px;
+        color: #1d2327;
+    }
+}

--- a/visi-bloc-jlg/includes/admin-settings.php
+++ b/visi-bloc-jlg/includes/admin-settings.php
@@ -309,7 +309,7 @@ function visibloc_jlg_render_hidden_blocks_section( $hidden_posts ) {
             <?php if ( empty( $grouped_hidden_posts ) ) : ?>
                 <p><?php esc_html_e( "Aucun bloc masqué manuellement n'a été trouvé.", 'visi-bloc-jlg' ); ?></p>
             <?php else : ?>
-                <ul style="list-style: disc; padding-left: 20px;">
+                <ul class="visibloc-admin-post-list">
                     <?php foreach ( $grouped_hidden_posts as $post_data ) :
                         $block_count = isset( $post_data['block_count'] ) ? (int) $post_data['block_count'] : 0;
                         $label       = $post_data['title'] ?? '';
@@ -338,7 +338,7 @@ function visibloc_jlg_render_device_visibility_section( $device_posts ) {
             <?php if ( empty( $grouped_device_posts ) ) : ?>
                 <p><?php esc_html_e( "Aucun bloc avec une règle de visibilité par appareil n'a été trouvé.", 'visi-bloc-jlg' ); ?></p>
             <?php else : ?>
-                <ul style="list-style: disc; padding-left: 20px;">
+                <ul class="visibloc-admin-post-list">
                     <?php foreach ( $grouped_device_posts as $post_data ) :
                         $block_count = isset( $post_data['block_count'] ) ? (int) $post_data['block_count'] : 0;
                         $label       = $post_data['title'] ?? '';
@@ -360,6 +360,10 @@ function visibloc_jlg_render_device_visibility_section( $device_posts ) {
 function visibloc_jlg_render_scheduled_blocks_section( $scheduled_posts ) {
     $datetime_format = visibloc_jlg_get_wp_datetime_format();
 
+    $title_column_label = __( "Titre de l'article / Modèle", 'visi-bloc-jlg' );
+    $start_column_label = __( 'Date de début', 'visi-bloc-jlg' );
+    $end_column_label   = __( 'Date de fin', 'visi-bloc-jlg' );
+
     ?>
     <div class="postbox">
         <h2 class="hndle"><span><?php esc_html_e( 'Tableau de bord des blocs programmés', 'visi-bloc-jlg' ); ?></span></h2>
@@ -367,15 +371,16 @@ function visibloc_jlg_render_scheduled_blocks_section( $scheduled_posts ) {
             <?php if ( empty( $scheduled_posts ) ) : ?>
                 <p><?php esc_html_e( "Aucun bloc programmé n'a été trouvé sur votre site.", 'visi-bloc-jlg' ); ?></p>
             <?php else : ?>
-                <table class="wp-list-table widefat striped">
-                    <thead>
-                        <tr>
-                            <th><?php esc_html_e( "Titre de l'article / Modèle", 'visi-bloc-jlg' ); ?></th>
-                            <th><?php esc_html_e( 'Date de début', 'visi-bloc-jlg' ); ?></th>
-                            <th><?php esc_html_e( 'Date de fin', 'visi-bloc-jlg' ); ?></th>
-                        </tr>
-                    </thead>
-                    <tbody>
+                <div class="visibloc-admin-table-wrapper">
+                    <table class="wp-list-table widefat striped visibloc-admin-scheduled-table">
+                        <thead>
+                            <tr>
+                                <th scope="col"><?php echo esc_html( $title_column_label ); ?></th>
+                                <th scope="col"><?php echo esc_html( $start_column_label ); ?></th>
+                                <th scope="col"><?php echo esc_html( $end_column_label ); ?></th>
+                            </tr>
+                        </thead>
+                        <tbody>
                         <?php foreach ( $scheduled_posts as $scheduled_block ) :
                             $start_datetime = visibloc_jlg_create_schedule_datetime( $scheduled_block['start'] ?? null );
                             $end_datetime   = visibloc_jlg_create_schedule_datetime( $scheduled_block['end'] ?? null );
@@ -384,15 +389,16 @@ function visibloc_jlg_render_scheduled_blocks_section( $scheduled_posts ) {
                             $end_display   = null !== $end_datetime ? wp_date( $datetime_format, $end_datetime->getTimestamp() ) : '–';
                             ?>
                             <tr>
-                                <td>
+                                <td data-label="<?php echo esc_attr( $title_column_label ); ?>">
                                     <a href="<?php echo esc_url( $scheduled_block['link'] ); ?>"><?php echo esc_html( $scheduled_block['title'] ); ?></a>
                                 </td>
-                                <td><?php echo esc_html( $start_display ); ?></td>
-                                <td><?php echo esc_html( $end_display ); ?></td>
+                                <td data-label="<?php echo esc_attr( $start_column_label ); ?>"><?php echo esc_html( $start_display ); ?></td>
+                                <td data-label="<?php echo esc_attr( $end_column_label ); ?>"><?php echo esc_html( $end_display ); ?></td>
                             </tr>
                         <?php endforeach; ?>
-                    </tbody>
-                </table>
+                        </tbody>
+                    </table>
+                </div>
             <?php endif; ?>
         </div>
     </div>

--- a/visi-bloc-jlg/includes/assets.php
+++ b/visi-bloc-jlg/includes/assets.php
@@ -59,6 +59,23 @@ function visibloc_jlg_enqueue_public_styles() {
     }
 }
 
+add_action( 'admin_enqueue_scripts', 'visibloc_jlg_enqueue_admin_styles' );
+function visibloc_jlg_enqueue_admin_styles( $hook_suffix ) {
+    if ( 'toplevel_page_visi-bloc-jlg-help' !== $hook_suffix ) {
+        return;
+    }
+
+    $plugin_main_file = __DIR__ . '/../visi-bloc-jlg.php';
+    $style_version    = defined( 'VISIBLOC_JLG_VERSION' ) ? VISIBLOC_JLG_VERSION : '1.1';
+
+    wp_enqueue_style(
+        'visibloc-jlg-admin-responsive',
+        plugins_url( 'assets/admin-responsive.css', $plugin_main_file ),
+        [],
+        $style_version
+    );
+}
+
 add_action( 'enqueue_block_editor_assets', 'visibloc_jlg_enqueue_editor_assets' );
 function visibloc_jlg_enqueue_editor_assets() {
     $plugin_main_file = __DIR__ . '/../visi-bloc-jlg.php';


### PR DESCRIPTION
## Summary
- add responsive classes to the hidden/device post lists and scheduled blocks table
- create and load an admin-only responsive stylesheet for narrow viewports
- ensure small screens display stacked list and table entries without horizontal scrolling

## Testing
- php -l visi-bloc-jlg/includes/admin-settings.php
- php -l visi-bloc-jlg/includes/assets.php

------
https://chatgpt.com/codex/tasks/task_e_68dcf6a1a6fc832e81b87b177d344f9e