### PR TITLE
Add responsive positioning for preview badges

### DIFF
--- a/visi-bloc-jlg/admin-styles.css
+++ b/visi-bloc-jlg/admin-styles.css
@@ -41,3 +41,29 @@
     font-weight: bold;
     z-index: 100;
 }
+
+.vb-label-top::before {
+    bottom: auto;
+    top: -12px;
+    transform: translateY(-100%);
+}
+
+@media (max-width: 782px) {
+    .bloc-cache-apercu,
+    .bloc-schedule-apercu {
+        padding-top: 16px;
+    }
+
+    .bloc-cache-apercu::before,
+    .bloc-schedule-apercu::before,
+    .vb-label-top::before {
+        position: static;
+        display: inline-flex;
+        align-items: center;
+        margin: 0 0 8px;
+        padding: 4px 12px;
+        border-radius: 999px;
+        transform: none;
+        box-shadow: none;
+    }
+}

--- a/visi-bloc-jlg/includes/assets.php
+++ b/visi-bloc-jlg/includes/assets.php
@@ -201,8 +201,37 @@ function visibloc_jlg_generate_device_visibility_css( $can_preview, $mobile_bp =
     }
 
     if ( $can_preview ) {
-        $css_lines[] = '.vb-desktop-only, .vb-tablet-only, .vb-mobile-only, .vb-hide-on-desktop, .vb-hide-on-tablet, .vb-hide-on-mobile { position: relative; outline: 2px dashed #0073aa; outline-offset: 2px; }';
-        $css_lines[] = '.vb-desktop-only::before, .vb-tablet-only::before, .vb-mobile-only::before, .vb-hide-on-desktop::before, .vb-hide-on-tablet::before, .vb-hide-on-mobile::before { content: attr(data-visibloc-label); position: absolute; bottom: -2px; right: -2px; background-color: #0073aa; color: white; padding: 2px 8px; font-size: 11px; font-family: sans-serif; font-weight: bold; z-index: 99; border-radius: 3px 0 3px 0; }';
+        $preview_selectors = [
+            '.vb-desktop-only',
+            '.vb-tablet-only',
+            '.vb-mobile-only',
+            '.vb-hide-on-desktop',
+            '.vb-hide-on-tablet',
+            '.vb-hide-on-mobile',
+        ];
+
+        $selectors_without_pseudo = implode( ', ', $preview_selectors );
+        $selectors_with_pseudo    = implode( '::before, ', $preview_selectors ) . '::before';
+
+        $css_lines[] = sprintf(
+            '%s { position: relative; outline: 2px dashed #0073aa; outline-offset: 2px; }',
+            $selectors_without_pseudo
+        );
+
+        $css_lines[] = sprintf(
+            '%s { content: attr(data-visibloc-label); position: absolute; bottom: -2px; right: -2px; background-color: #0073aa; color: white; padding: 2px 8px; font-size: 11px; font-family: sans-serif; font-weight: bold; z-index: 99; border-radius: 3px 0 3px 0; line-height: 1.4; text-align: left; box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15); }',
+            $selectors_with_pseudo
+        );
+
+        $css_lines[] = '.vb-label-top::before { bottom: auto; top: -2px; transform: translateY(-100%); border-radius: 3px 3px 0 0; }';
+
+        $css_lines[] = '@media (max-width: 782px) {';
+        $css_lines[] = sprintf(
+            '    %s::before { position: static; display: inline-flex; align-items: center; justify-content: flex-start; gap: 4px; margin: 0 0 8px; right: auto; bottom: auto; left: auto; top: auto; transform: none; border-radius: 999px; padding: 4px 12px; box-shadow: none; }',
+            $selectors_without_pseudo
+        );
+        $css_lines[] = '    .vb-label-top::before { margin-bottom: 8px; }';
+        $css_lines[] = '}';
 
         $labels = [
             '.vb-hide-on-mobile::before'   => __( 'Caché sur Mobile', 'visi-bloc-jlg' ),

--- a/visi-bloc-jlg/includes/visibility-logic.php
+++ b/visi-bloc-jlg/includes/visibility-logic.php
@@ -105,7 +105,7 @@ function visibloc_jlg_render_block_filter( $block_content, $block ) {
 
     if ( $should_show_hidden_preview ) {
         $hidden_preview_markup = sprintf(
-            '<div class="bloc-cache-apercu" data-visibloc-label="%s">%s</div>',
+            '<div class="bloc-cache-apercu vb-label-top" data-visibloc-label="%s">%s</div>',
             esc_attr__( 'Hidden block', 'visi-bloc-jlg' ),
             $block_content
         );
@@ -130,7 +130,7 @@ function visibloc_jlg_render_block_filter( $block_content, $block ) {
                     $start_date_fr,
                     $end_date_fr
                 );
-                return '<div class="bloc-schedule-apercu" data-schedule-info="' . esc_attr( $info ) . '">' . $block_content . '</div>';
+                return '<div class="bloc-schedule-apercu vb-label-top" data-schedule-info="' . esc_attr( $info ) . '">' . $block_content . '</div>';
             }
             return '';
         }

--- a/visi-bloc-jlg/tests/phpunit/integration/VisibilityLogicTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/VisibilityLogicTest.php
@@ -84,6 +84,7 @@ class VisibilityLogicTest extends TestCase {
         $output = visibloc_jlg_render_block_filter( '<p>Hidden admin content</p>', $block );
 
         $this->assertStringContainsString( 'bloc-cache-apercu', $output );
+        $this->assertStringContainsString( 'vb-label-top', $output );
         $this->assertStringContainsString( '<p>Hidden admin content</p>', $output );
     }
 
@@ -317,6 +318,7 @@ class VisibilityLogicTest extends TestCase {
         $output = visibloc_jlg_render_block_filter( '<p>Scheduled content</p>', $block );
 
         $this->assertStringContainsString( 'bloc-schedule-apercu', $output );
+        $this->assertStringContainsString( 'vb-label-top', $output );
         $this->assertStringContainsString( 'Programmé (Début:', $output );
         $this->assertStringContainsString( '<p>Scheduled content</p>', $output );
     }


### PR DESCRIPTION
## Summary
- adjust the generated preview badge CSS so badges reflow above the block on narrow screens and add a `vb-label-top` helper
- update admin preview styles to mirror the responsive behavior
- tag preview wrappers with the new helper class and extend tests to cover it

## Testing
- ./vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68dcf6a59a58832ebcf9131635ee5615