### PR TITLE
Adjust mobile role switcher spacing for safe areas

### DIFF
--- a/visi-bloc-jlg/assets/role-switcher-frontend.css
+++ b/visi-bloc-jlg/assets/role-switcher-frontend.css
@@ -3,10 +3,14 @@
     left: 0;
     right: 0;
     bottom: 1rem;
+    bottom: calc(1rem + constant(safe-area-inset-bottom));
+    bottom: calc(1rem + env(safe-area-inset-bottom));
     display: none;
     justify-content: center;
     align-items: flex-end;
     padding: 0 1rem;
+    padding: 0 1rem calc(1rem + constant(safe-area-inset-bottom));
+    padding: 0 1rem calc(1rem + env(safe-area-inset-bottom));
     z-index: 100000;
     pointer-events: none;
 }


### PR DESCRIPTION
## Summary
- incorporate safe-area inset values into the mobile role switcher positioning
- add matching bottom padding to maintain the spacing with device safe areas

## Testing
- Manual QA: Viewed the role switcher preview page in Chromium responsive mode (iPhone profile) to confirm spacing and layout


------
https://chatgpt.com/codex/tasks/task_e_68dd0e953a1c832eb7fb109b048082c1