### PR TITLE
Add legend to supported blocks settings fieldset

### DIFF
--- a/visi-bloc-jlg/assets/admin-responsive.css
+++ b/visi-bloc-jlg/assets/admin-responsive.css
@@ -12,6 +12,20 @@
     margin-bottom: 0;
 }
 
+.visibloc-supported-blocks-fieldset {
+    border: 0;
+    margin: 0;
+    padding: 0;
+}
+
+.visibloc-supported-blocks-legend {
+    color: #1d2327;
+    font-size: 14px;
+    font-weight: 600;
+    margin: 0 0 12px;
+    padding: 0;
+}
+
 .visibloc-admin-table-wrapper {
     overflow-x: auto;
 }

--- a/visi-bloc-jlg/includes/admin-settings.php
+++ b/visi-bloc-jlg/includes/admin-settings.php
@@ -234,7 +234,10 @@ function visibloc_jlg_render_supported_blocks_section( $registered_block_types, 
                 <?php if ( empty( $registered_block_types ) ) : ?>
                     <p><em><?php esc_html_e( 'Aucun bloc enregistré n’a été détecté.', 'visi-bloc-jlg' ); ?></em></p>
                 <?php else : ?>
-                    <fieldset>
+                    <fieldset class="visibloc-supported-blocks-fieldset">
+                        <legend class="visibloc-supported-blocks-legend">
+                            <?php esc_html_e( 'Blocs compatibles', 'visi-bloc-jlg' ); ?>
+                        </legend>
                         <?php foreach ( $registered_block_types as $block ) :
                             $block_name  = isset( $block['name'] ) && is_string( $block['name'] ) ? $block['name'] : '';
                             $block_label = isset( $block['label'] ) && is_string( $block['label'] ) ? $block['label'] : $block_name;


### PR DESCRIPTION
## Summary
- add a translated legend to the supported blocks fieldset in the admin settings
- style the fieldset and legend to blend with the existing admin design

## Testing
- ./vendor/bin/phpunit -c phpunit.xml.dist

------
https://chatgpt.com/codex/tasks/task_e_68dd0e97866c832e88c61d861cf6370f