### PR TITLE
Sort scheduled group metadata chronologically

### DIFF
--- a/visi-bloc-jlg/includes/admin-settings.php
+++ b/visi-bloc-jlg/includes/admin-settings.php
@@ -848,6 +848,55 @@ function visibloc_jlg_collect_group_block_metadata() {
         }
     }
 
+    if ( ! empty( $collected['scheduled'] ) ) {
+        usort(
+            $collected['scheduled'],
+            static function ( $a, $b ) {
+                $normalize_timestamp = static function ( $value ) {
+                    if ( null === $value || '' === $value ) {
+                        return null;
+                    }
+
+                    if ( is_numeric( $value ) ) {
+                        return (int) $value;
+                    }
+
+                    $timestamp = strtotime( (string) $value );
+
+                    return false === $timestamp ? null : $timestamp;
+                };
+
+                $a_start = $normalize_timestamp( $a['start'] ?? null );
+                $b_start = $normalize_timestamp( $b['start'] ?? null );
+
+                if ( null !== $a_start && null === $b_start ) {
+                    return -1;
+                }
+
+                if ( null === $a_start && null !== $b_start ) {
+                    return 1;
+                }
+
+                if ( $a_start !== $b_start ) {
+                    return $a_start <=> $b_start;
+                }
+
+                $a_end = $normalize_timestamp( $a['end'] ?? null );
+                $b_end = $normalize_timestamp( $b['end'] ?? null );
+
+                if ( null !== $a_end && null === $b_end ) {
+                    return -1;
+                }
+
+                if ( null === $a_end && null !== $b_end ) {
+                    return 1;
+                }
+
+                return $a_end <=> $b_end;
+            }
+        );
+    }
+
     set_transient( $cache_key, $collected, HOUR_IN_SECONDS );
 
     return $collected;

--- a/visi-bloc-jlg/tests/phpunit/integration/GroupBlockSummaryTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/GroupBlockSummaryTest.php
@@ -263,15 +263,34 @@ HTML;
         $this->assertSame( [ 101, 102 ], $device_ids );
 
         $this->assertCount( 2, $metadata['scheduled'] );
+
         $scheduled_windows = array_map(
             static function ( $item ) {
-                return [ $item['id'], $item['start'] ?? null, $item['end'] ?? null ];
+                return [
+                    'id'    => $item['id'],
+                    'start' => $item['start'] ?? null,
+                    'end'   => $item['end'] ?? null,
+                ];
             },
             $metadata['scheduled']
         );
 
-        $this->assertContains( [ 101, '2024-05-01T09:00:00', '2024-05-10T17:00:00' ], $scheduled_windows );
-        $this->assertContains( [ 102, '2024-06-15T12:00:00', null ], $scheduled_windows );
+        $this->assertSame(
+            [
+                [
+                    'id'    => 101,
+                    'start' => '2024-05-01T09:00:00',
+                    'end'   => '2024-05-10T17:00:00',
+                ],
+                [
+                    'id'    => 102,
+                    'start' => '2024-06-15T12:00:00',
+                    'end'   => null,
+                ],
+            ],
+            $scheduled_windows,
+            'Scheduled entries should be sorted chronologically by their start then end dates.'
+        );
 
         $grouped_hidden = visibloc_jlg_group_posts_by_id( $metadata['hidden'] );
         $this->assertCount( 1, $grouped_hidden );
@@ -281,5 +300,33 @@ HTML;
 
         $cached_metadata = visibloc_jlg_collect_group_block_metadata();
         $this->assertSame( $metadata, $cached_metadata );
+
+        $cached_scheduled_windows = array_map(
+            static function ( $item ) {
+                return [
+                    'id'    => $item['id'],
+                    'start' => $item['start'] ?? null,
+                    'end'   => $item['end'] ?? null,
+                ];
+            },
+            $cached_metadata['scheduled']
+        );
+
+        $this->assertSame(
+            [
+                [
+                    'id'    => 101,
+                    'start' => '2024-05-01T09:00:00',
+                    'end'   => '2024-05-10T17:00:00',
+                ],
+                [
+                    'id'    => 102,
+                    'start' => '2024-06-15T12:00:00',
+                    'end'   => null,
+                ],
+            ],
+            $cached_scheduled_windows,
+            'Cached scheduled entries should preserve the chronological order.'
+        );
     }
 }


### PR DESCRIPTION
## Summary
- sort scheduled group metadata entries by start and end timestamps so null values are last
- extend the integration test to assert the chronological order for live and cached results

## Testing
- ./vendor/bin/phpunit --configuration phpunit.xml.dist

------
https://chatgpt.com/codex/tasks/task_e_68dd691b7c14832eb5ed364ec26d53bd