### PR TITLE
Lock body scroll while the mobile role switcher is open

### DIFF
--- a/visi-bloc-jlg/assets/role-switcher-frontend.css
+++ b/visi-bloc-jlg/assets/role-switcher-frontend.css
@@ -154,3 +154,16 @@
         display: none;
     }
 }
+
+html.visibloc-role-switcher--locked,
+html.visibloc-role-switcher--locked body {
+    overflow: hidden;
+    touch-action: none;
+}
+
+html.visibloc-role-switcher--locked body {
+    padding-right: calc(
+        var(--visibloc-role-switcher-body-padding-right, 0px) +
+        var(--visibloc-role-switcher-scrollbar-width, 0px)
+    );
+}


### PR DESCRIPTION
## Summary
- add scroll lock management to the role switcher frontend script, including cleanup when the widget is removed
- extend frontend styles so the scroll-lock class hides overflow while preserving existing body padding
- expand the mobile role switcher e2e test to assert the scroll lock behavior and confirm the panel still closes from Escape and outside clicks

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd69150300832e99505f64d453e173