### PR TITLE
Use block display fallback for device visibility CSS

### DIFF
--- a/visi-bloc-jlg/includes/assets.php
+++ b/visi-bloc-jlg/includes/assets.php
@@ -433,7 +433,7 @@ function visibloc_jlg_get_display_fallback_for_selector( $selector ) {
         return null;
     }
 
-    $fallback = 'display: initial !important;';
+    $fallback = 'display: block !important;';
 
     if ( false !== strpos( $selector, '-only' ) ) {
         return $fallback;

--- a/visi-bloc-jlg/tests/phpunit/integration/DeviceVisibilityCssTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/DeviceVisibilityCssTest.php
@@ -28,7 +28,7 @@ class DeviceVisibilityCssTest extends TestCase {
         $this->assertNotNull( $block );
         $this->assertStringContainsString('.vb-hide-on-mobile,', $block);
         $this->assertStringContainsString(
-            ".vb-tablet-only {\n        display: initial !important;\n        display: revert !important;\n    }",
+            ".vb-tablet-only {\n        display: block !important;\n        display: revert !important;\n    }",
             $block
         );
     }
@@ -39,21 +39,21 @@ class DeviceVisibilityCssTest extends TestCase {
 
         $this->assertNotNull( $block );
         $this->assertStringContainsString('.vb-hide-on-mobile,', $block);
-        $this->assertStringContainsString('display: initial !important;', $block);
+        $this->assertStringContainsString('display: block !important;', $block);
         $this->assertStringContainsString('display: revert !important;', $block);
         $this->assertStringNotContainsString('display: none !important;', $block);
     }
 
-    public function test_hide_on_selectors_use_initial_fallback(): void {
+    public function test_hide_on_selectors_use_block_fallback(): void {
         $this->assertSame(
-            'display: initial !important;',
+            'display: block !important;',
             visibloc_jlg_get_display_fallback_for_selector( '.vb-hide-on-desktop' )
         );
     }
 
-    public function test_only_selectors_keep_initial_fallback(): void {
+    public function test_only_selectors_keep_block_fallback(): void {
         $this->assertSame(
-            'display: initial !important;',
+            'display: block !important;',
             visibloc_jlg_get_display_fallback_for_selector( '.vb-tablet-only' )
         );
     }
@@ -81,12 +81,12 @@ class DeviceVisibilityCssTest extends TestCase {
         $block = $this->extractMediaQueryBlock( $css, '@media (min-width: 1025px) and (max-width: 1200px)' );
 
         $this->assertNotNull( $block );
-        $this->assertStringContainsString('display: initial !important;', $block);
+        $this->assertStringContainsString('display: block !important;', $block);
         $this->assertStringContainsString('display: revert !important;', $block);
-        $this->assertStringNotContainsString('display: block !important;', $block);
+        $this->assertStringNotContainsString('display: initial !important;', $block);
     }
 
-    public function test_normalize_block_declarations_adds_single_initial_fallback_inline(): void {
+    public function test_normalize_block_declarations_adds_single_block_fallback_inline(): void {
         $declarations = visibloc_jlg_normalize_block_declarations(
             '.vb-tablet-only',
             [
@@ -97,7 +97,7 @@ class DeviceVisibilityCssTest extends TestCase {
 
         $this->assertSame(
             [
-                'display: initial !important;',
+                'display: block !important;',
                 'display: revert !important;',
                 'color: red;',
             ],
@@ -105,36 +105,36 @@ class DeviceVisibilityCssTest extends TestCase {
         );
     }
 
-    public function test_normalize_block_declarations_keeps_existing_initial_fallback_only_once(): void {
+    public function test_normalize_block_declarations_keeps_existing_block_fallback_only_once(): void {
         $declarations = visibloc_jlg_normalize_block_declarations(
             '.vb-tablet-only',
             [
-                'display: initial !important;',
+                'display: block !important;',
                 'display: revert !important;',
             ]
         );
 
         $this->assertSame(
             [
-                'display: initial !important;',
+                'display: block !important;',
                 'display: revert !important;',
             ],
             $declarations
         );
     }
 
-    public function test_normalize_block_declarations_handles_initial_with_whitespace(): void {
+    public function test_normalize_block_declarations_handles_block_with_whitespace(): void {
         $declarations = visibloc_jlg_normalize_block_declarations(
             '.vb-tablet-only',
             [
-                "  display: initial !important;   ",
+                "  display: block !important;   ",
                 'display: revert !important;',
             ]
         );
 
         $this->assertSame(
             [
-                'display: initial !important;',
+                'display: block !important;',
                 'display: revert !important;',
             ],
             $declarations


### PR DESCRIPTION
## Summary
- switch device visibility fallback declarations to `display: block !important;` to better match block wrapper expectations
- update integration tests to validate the new fallback behavior and normalization logic

## Testing
- vendor/bin/phpunit --filter DeviceVisibilityCssTest

------
https://chatgpt.com/codex/tasks/task_e_68dd914e5dbc832e8b733a408a48d3b3