### PR TITLE
Add transient caching for device visibility CSS

### DIFF
--- a/visi-bloc-jlg/includes/admin-settings.php
+++ b/visi-bloc-jlg/includes/admin-settings.php
@@ -935,6 +935,23 @@ function visibloc_jlg_clear_caches( $unused_post_id = null ) {
     delete_transient( 'visibloc_device_posts' );
     delete_transient( 'visibloc_scheduled_posts' );
     delete_transient( 'visibloc_group_block_metadata' );
+
+    if ( function_exists( 'get_option' ) ) {
+        $registered_transients = get_option( 'visibloc_device_css_transient_keys', [] );
+
+        if ( is_array( $registered_transients ) ) {
+            foreach ( $registered_transients as $transient_key ) {
+                if ( ! is_string( $transient_key ) || '' === $transient_key ) {
+                    continue;
+                }
+
+                delete_transient( $transient_key );
+            }
+        }
+
+        delete_option( 'visibloc_device_css_transient_keys' );
+    }
+
     if ( function_exists( 'wp_cache_delete' ) ) {
         wp_cache_delete( 'visibloc_device_css_cache', 'visibloc_jlg' );
     }


### PR DESCRIPTION
## Summary
- cache generated device visibility CSS in a persistent transient keyed by the cache bucket
- track and clear device visibility CSS transient keys when clearing plugin caches
- cover transient reuse and cache invalidation with new integration tests

## Testing
- vendor/bin/phpunit -c phpunit.xml.dist

------
https://chatgpt.com/codex/tasks/task_e_68de3e3814dc832ea8fb91eadddfe94b