### PR TITLE
Add PHPUnit CI workflow with composer script

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,0 +1,43 @@
+name: PHPUnit
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  tests:
+    name: PHPUnit
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          coverage: xdebug
+          tools: composer
+          cache: composer
+
+      - name: Validate Composer configuration
+        run: composer validate --no-check-lock
+
+      - name: Install dependencies
+        run: composer install --no-progress --prefer-dist --no-interaction
+
+      - name: Prepare log directories
+        run: mkdir -p build/logs
+
+      - name: Run PHPUnit tests
+        run: composer test:phpunit
+
+      - name: Upload PHPUnit artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: phpunit-logs
+          path: |
+            build/logs
+          if-no-files-found: ignore

--- a/composer.json
+++ b/composer.json
@@ -2,5 +2,8 @@
     "name": "visibloc/wp-visibloc",
     "require-dev": {
         "phpunit/phpunit": "^9.6"
+    },
+    "scripts": {
+        "test:phpunit": "vendor/bin/phpunit -c phpunit.xml.dist"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,4 +5,8 @@
             <directory suffix="Test.php">visi-bloc-jlg/tests/phpunit/integration</directory>
         </testsuite>
     </testsuites>
+    <logging>
+        <log type="junit" target="build/logs/junit.xml"/>
+        <log type="coverage-clover" target="build/logs/clover.xml"/>
+    </logging>
 </phpunit>


### PR DESCRIPTION
## Summary
- add a Composer script for running PHPUnit with the repository configuration
- enable PHPUnit logging outputs for artifact collection in CI
- create a GitHub Actions workflow that caches Composer dependencies and runs the PHPUnit suite

## Testing
- composer test:phpunit

------
https://chatgpt.com/codex/tasks/task_e_68de3e34cca4832ea5677b6ff22386ac