### PR TITLE
Add inline translation hook for Hidden block label

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 vendor/
+visi-bloc-jlg/languages/*.mo

--- a/visi-bloc-jlg/includes/i18n-inline.php
+++ b/visi-bloc-jlg/includes/i18n-inline.php
@@ -1,12 +1,22 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) { exit; }
 
-function visibloc_jlg_inline_translate_hidden_block( $translation, $text, $domain ) {
-    if ( 'Hidden block' === $text ) {
-        return 'Bloc caché';
-    }
+if ( ! function_exists( 'visibloc_jlg_inline_translate_hidden_block' ) ) {
+    /**
+     * Provide inline translations for strings that are generated dynamically.
+     *
+     * @param string $translation The translated text.
+     * @param string $text        The original text to translate.
+     * @param string $domain      Textdomain for the translated string.
+     * @return string The filtered translation.
+     */
+    function visibloc_jlg_inline_translate_hidden_block( $translation, $text, $domain ) {
+        if ( 'Hidden block' === $text ) {
+            return 'Bloc caché';
+        }
 
-    return $translation;
+        return $translation;
+    }
 }
 
 add_filter( 'gettext_visi-bloc-jlg', 'visibloc_jlg_inline_translate_hidden_block', 10, 3 );

--- a/visi-bloc-jlg/languages/visi-bloc-jlg-fr_FR.po
+++ b/visi-bloc-jlg/languages/visi-bloc-jlg-fr_FR.po
@@ -7,6 +7,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 
-#: includes/visibility-logic.php
+#. Translators: Preview badge label displayed on hidden blocks in the editor.
+#: includes/visibility-logic.php includes/i18n-inline.php
 msgid "Hidden block"
 msgstr "Bloc caché"


### PR DESCRIPTION
## Summary
- ignore compiled `.mo` catalogues so the plugin ships without binary translations
- document the "Hidden block" inline translation and guard the helper registration

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de3dbfc2a8832e9b77978e8eaeca4b