### PR TITLE
Add PHPUnit CI workflow with Composer script

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,0 +1,53 @@
+name: PHPUnit
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  tests:
+    name: PHPUnit Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          tools: composer
+          coverage: none
+          ini-values: memory_limit=-1
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist
+
+      - name: Run PHPUnit
+        run: composer run test:phpunit
+
+      - name: Upload test artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: phpunit-artifacts
+          path: |
+            build/logs/
+            storage/logs/
+            tests/_output/
+            coverage/
+          if-no-files-found: ignore

--- a/composer.json
+++ b/composer.json
@@ -2,5 +2,8 @@
     "name": "visibloc/wp-visibloc",
     "require-dev": {
         "phpunit/phpunit": "^9.6"
+    },
+    "scripts": {
+        "test:phpunit": "vendor/bin/phpunit -c phpunit.xml.dist"
     }
 }


### PR DESCRIPTION
## Summary
- add a Composer script to run PHPUnit using the project configuration
- create a dedicated GitHub Actions workflow that installs PHP dependencies and runs the tests
- enable Composer dependency caching and upload PHPUnit artifacts for analysis

## Testing
- composer run test:phpunit

------
https://chatgpt.com/codex/tasks/task_e_68de45405fd4832eb73bc6a9ea78e468