### PR TITLE
Refactor PHPUnit integration tests to use test services

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,5 +2,10 @@
     "name": "visibloc/wp-visibloc",
     "require-dev": {
         "phpunit/phpunit": "^9.6"
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Visibloc\\Tests\\Support\\": "visi-bloc-jlg/tests/phpunit/src/"
+        }
     }
 }

--- a/visi-bloc-jlg/tests/phpunit/bootstrap.php
+++ b/visi-bloc-jlg/tests/phpunit/bootstrap.php
@@ -3,6 +3,18 @@
  * Bootstrap for integration tests.
  */
 
+use Visibloc\Tests\Support\TestServices;
+
+$autoloader = dirname(__DIR__, 3) . '/vendor/autoload.php';
+
+if ( ! file_exists( $autoloader ) ) {
+    throw new RuntimeException( 'Composer autoloader not found. Please run `composer install` before executing the tests.' );
+}
+
+require_once $autoloader;
+
+TestServices::bootstrap();
+
 if ( ! defined( 'ABSPATH' ) ) {
     define( 'ABSPATH', __DIR__ . '/../../' );
 }

--- a/visi-bloc-jlg/tests/phpunit/integration/AdminRequestGuardsTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/AdminRequestGuardsTest.php
@@ -1,14 +1,19 @@
 <?php
 
 use PHPUnit\Framework\TestCase;
+use Visibloc\Tests\Support\PluginFacade;
+use Visibloc\Tests\Support\TestServices;
 
 require_once __DIR__ . '/../role-switcher-test-loader.php';
 
 class AdminRequestGuardsTest extends TestCase {
+    private PluginFacade $plugin;
+
     protected function setUp(): void {
         parent::setUp();
 
         visibloc_test_reset_state();
+        $this->plugin = TestServices::plugin();
     }
 
     protected function tearDown(): void {
@@ -40,7 +45,7 @@ class AdminRequestGuardsTest extends TestCase {
             ]
         );
 
-        $this->assertTrue( visibloc_jlg_is_admin_or_technical_request() );
+        $this->assertTrue( $this->plugin->isAdminOrTechnicalRequest() );
     }
 
     public function test_dashboard_ajax_request_is_detected(): void {
@@ -52,7 +57,7 @@ class AdminRequestGuardsTest extends TestCase {
             ]
         );
 
-        $this->assertTrue( visibloc_jlg_is_admin_or_technical_request() );
+        $this->assertTrue( $this->plugin->isAdminOrTechnicalRequest() );
     }
 
     /**
@@ -78,7 +83,7 @@ class AdminRequestGuardsTest extends TestCase {
             define( 'REST_REQUEST', true );
         }
 
-        $this->assertTrue( visibloc_jlg_is_admin_or_technical_request() );
+        $this->assertTrue( $this->plugin->isAdminOrTechnicalRequest() );
     }
 
     public function test_cron_execution_is_detected(): void {
@@ -88,7 +93,7 @@ class AdminRequestGuardsTest extends TestCase {
             ]
         );
 
-        $this->assertTrue( visibloc_jlg_is_admin_or_technical_request() );
+        $this->assertTrue( $this->plugin->isAdminOrTechnicalRequest() );
     }
 
     public function test_front_end_request_is_not_detected(): void {
@@ -99,6 +104,6 @@ class AdminRequestGuardsTest extends TestCase {
             ]
         );
 
-        $this->assertFalse( visibloc_jlg_is_admin_or_technical_request() );
+        $this->assertFalse( $this->plugin->isAdminOrTechnicalRequest() );
     }
 }

--- a/visi-bloc-jlg/tests/phpunit/integration/CliRebuildIndexTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/CliRebuildIndexTest.php
@@ -1,11 +1,15 @@
 <?php
 
 use PHPUnit\Framework\TestCase;
+use Visibloc\Tests\Support\PluginFacade;
+use Visibloc\Tests\Support\TestServices;
 
 /**
  * @runTestsInSeparateProcesses
  */
 class CliRebuildIndexTest extends TestCase {
+    private PluginFacade $plugin;
+
     protected function setUp(): void {
         parent::setUp();
 
@@ -46,12 +50,14 @@ class CliRebuildIndexTest extends TestCase {
         $GLOBALS['visibloc_test_options']    = [];
         $GLOBALS['visibloc_test_transients'] = [];
 
+        $this->plugin = TestServices::plugin();
+
         if ( function_exists( 'visibloc_jlg_store_group_block_summary_index' ) ) {
-            visibloc_jlg_store_group_block_summary_index( [] );
+            $this->plugin->storeGroupBlockSummaryIndex( [] );
         }
 
         if ( function_exists( 'visibloc_jlg_clear_caches' ) ) {
-            visibloc_jlg_clear_caches();
+            $this->plugin->clearCaches();
         }
 
         WP_CLI::$log_messages     = [];
@@ -60,11 +66,11 @@ class CliRebuildIndexTest extends TestCase {
 
     protected function tearDown(): void {
         if ( function_exists( 'visibloc_jlg_store_group_block_summary_index' ) ) {
-            visibloc_jlg_store_group_block_summary_index( [] );
+            $this->plugin->storeGroupBlockSummaryIndex( [] );
         }
 
         if ( function_exists( 'visibloc_jlg_clear_caches' ) ) {
-            visibloc_jlg_clear_caches();
+            $this->plugin->clearCaches();
         }
 
         $GLOBALS['visibloc_posts']           = [];
@@ -121,7 +127,7 @@ HTML;
 
         call_user_func( $command );
 
-        $summaries = visibloc_jlg_get_group_block_summary_index();
+        $summaries = $this->plugin->getGroupBlockSummaryIndex();
 
         $this->assertSame( 2, count( $summaries ) );
         $this->assertArrayHasKey( 101, $summaries );

--- a/visi-bloc-jlg/tests/phpunit/integration/EditorAssetsTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/EditorAssetsTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use PHPUnit\Framework\TestCase;
+use Visibloc\Tests\Support\PluginFacade;
+use Visibloc\Tests\Support\TestServices;
 
 require_once __DIR__ . '/../../../includes/assets.php';
 
@@ -9,6 +11,7 @@ class EditorAssetsTest extends TestCase {
     private string $assetBackup;
     private $previousUser;
     private array $previousRoles;
+    private PluginFacade $plugin;
 
     protected function setUp(): void {
         parent::setUp();
@@ -21,6 +24,8 @@ class EditorAssetsTest extends TestCase {
         if ( isset( $GLOBALS['visibloc_test_transients'][ VISIBLOC_JLG_MISSING_EDITOR_ASSETS_TRANSIENT ] ) ) {
             unset( $GLOBALS['visibloc_test_transients'][ VISIBLOC_JLG_MISSING_EDITOR_ASSETS_TRANSIENT ] );
         }
+
+        $this->plugin = TestServices::plugin();
     }
 
     protected function tearDown(): void {
@@ -45,7 +50,7 @@ class EditorAssetsTest extends TestCase {
         try {
             $this->assertFalse( get_transient( VISIBLOC_JLG_MISSING_EDITOR_ASSETS_TRANSIENT ) );
 
-            visibloc_jlg_enqueue_editor_assets();
+            $this->plugin->enqueueEditorAssets();
 
             $this->assertNotFalse( get_transient( VISIBLOC_JLG_MISSING_EDITOR_ASSETS_TRANSIENT ) );
         } finally {
@@ -65,7 +70,7 @@ class EditorAssetsTest extends TestCase {
         $GLOBALS['visibloc_test_state']['current_user']            = new Visibloc_Test_User( 1, [ 'administrator' ] );
 
         ob_start();
-        visibloc_jlg_render_missing_editor_assets_notice();
+        $this->plugin->renderMissingEditorAssetsNotice();
         $output = ob_get_clean();
 
         $this->assertStringContainsString( 'notice notice-error', $output );
@@ -84,7 +89,7 @@ class EditorAssetsTest extends TestCase {
         $GLOBALS['visibloc_test_state']['roles']['editor'] = $editor;
 
         ob_start();
-        visibloc_jlg_render_missing_editor_assets_notice();
+        $this->plugin->renderMissingEditorAssetsNotice();
         $output = ob_get_clean();
 
         $this->assertSame( '', trim( $output ) );

--- a/visi-bloc-jlg/tests/phpunit/integration/GroupBlockSummaryTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/GroupBlockSummaryTest.php
@@ -1,11 +1,15 @@
 <?php
 
 use PHPUnit\Framework\TestCase;
+use Visibloc\Tests\Support\PluginFacade;
+use Visibloc\Tests\Support\TestServices;
 
 require_once __DIR__ . '/../../../includes/admin-settings.php';
 require_once __DIR__ . '/../../../includes/visibility-logic.php';
 
 class GroupBlockSummaryTest extends TestCase {
+    private PluginFacade $plugin;
+
     protected function setUp(): void {
         parent::setUp();
 
@@ -14,15 +18,12 @@ class GroupBlockSummaryTest extends TestCase {
         $GLOBALS['visibloc_test_options']    = [];
         $GLOBALS['visibloc_test_transients'] = [];
 
-        if ( function_exists( 'visibloc_jlg_clear_caches' ) ) {
-            visibloc_jlg_clear_caches();
-        }
+        $this->plugin = TestServices::plugin();
+        $this->plugin->clearCaches();
     }
 
     protected function tearDown(): void {
-        if ( function_exists( 'visibloc_jlg_clear_caches' ) ) {
-            visibloc_jlg_clear_caches();
-        }
+        $this->plugin->clearCaches();
 
         $GLOBALS['visibloc_posts']           = [];
         $GLOBALS['visibloc_test_options']    = [];
@@ -54,7 +55,7 @@ class GroupBlockSummaryTest extends TestCase {
 <!-- /wp:core/paragraph -->
 HTML;
 
-        $summary = visibloc_jlg_generate_group_block_summary_from_content( 101, $sample_content );
+        $summary = $this->plugin->generateGroupBlockSummaryFromContent( 101, $sample_content );
 
         $this->assertSame( 2, $summary['hidden'] );
         $this->assertSame( 1, $summary['device'] );
@@ -99,7 +100,7 @@ HTML;
 <!-- /wp:core/group -->
 HTML;
 
-        $summary = visibloc_jlg_generate_group_block_summary_from_content( 202, $sample_content );
+        $summary = $this->plugin->generateGroupBlockSummaryFromContent( 202, $sample_content );
 
         $this->assertSame( 0, $summary['hidden'] );
         $this->assertSame( 0, $summary['device'] );
@@ -139,7 +140,7 @@ HTML;
 <!-- /wp:myplugin/customblock -->
 HTML;
 
-            $summary = visibloc_jlg_generate_group_block_summary_from_content( 303, $sample_content );
+            $summary = $this->plugin->generateGroupBlockSummaryFromContent( 303, $sample_content );
 
             $this->assertSame( 2, $summary['hidden'] );
             $this->assertSame( 1, $summary['device'] );
@@ -175,7 +176,7 @@ HTML;
 <!-- /wp:myplugin/customblock -->
 HTML;
 
-            $summary = visibloc_jlg_generate_group_block_summary_from_content( 404, $sample_content );
+            $summary = $this->plugin->generateGroupBlockSummaryFromContent( 404, $sample_content );
 
             $this->assertSame( 1, $summary['hidden'] );
             $this->assertSame( 1, $summary['device'] );
@@ -248,7 +249,7 @@ HTML;
             ],
         ];
 
-        $summaries = visibloc_jlg_rebuild_group_block_summary_index();
+        $summaries = $this->plugin->rebuildGroupBlockSummaryIndex();
 
         $this->assertArrayHasKey( 101, $summaries );
         $this->assertArrayHasKey( 102, $summaries );
@@ -259,7 +260,7 @@ HTML;
         $this->assertSame( 1, $summaries[102]['device'] );
         $this->assertCount( 3, $summaries[102]['scheduled'] );
 
-        $metadata = visibloc_jlg_collect_group_block_metadata();
+        $metadata = $this->plugin->collectGroupBlockMetadata();
 
         $this->assertSame( $metadata, get_transient( 'visibloc_group_block_metadata' ) );
 
@@ -319,13 +320,13 @@ HTML;
             'Scheduled entries should be sorted chronologically by their start then end dates, with open starts last.'
         );
 
-        $grouped_hidden = visibloc_jlg_group_posts_by_id( $metadata['hidden'] );
+        $grouped_hidden = $this->plugin->groupPostsById( $metadata['hidden'] );
         $this->assertCount( 1, $grouped_hidden );
         $this->assertSame( 2, $grouped_hidden[0]['block_count'] );
 
         $GLOBALS['visibloc_test_options']['visibloc_group_block_summary'] = [];
 
-        $cached_metadata = visibloc_jlg_collect_group_block_metadata();
+        $cached_metadata = $this->plugin->collectGroupBlockMetadata();
         $this->assertSame( $metadata, $cached_metadata );
 
         $cached_scheduled_windows = array_map(

--- a/visi-bloc-jlg/tests/phpunit/integration/RoleSwitcherCapabilitiesTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/RoleSwitcherCapabilitiesTest.php
@@ -1,13 +1,18 @@
 <?php
 
 use PHPUnit\Framework\TestCase;
+use Visibloc\Tests\Support\PluginFacade;
+use Visibloc\Tests\Support\TestServices;
 
 require_once __DIR__ . '/../role-switcher-test-loader.php';
 
 class RoleSwitcherCapabilitiesTest extends TestCase {
+    private PluginFacade $plugin;
+
     protected function setUp(): void {
         visibloc_test_reset_state();
-        visibloc_jlg_store_real_user_id( null );
+        $this->plugin = TestServices::plugin();
+        $this->plugin->storeRealUserId( null );
     }
 
     public function test_guest_preview_only_applies_to_current_request_user(): void {
@@ -21,7 +26,7 @@ class RoleSwitcherCapabilitiesTest extends TestCase {
         $visibloc_test_state['preview_role']                = 'guest';
         $visibloc_test_state['current_user']                = new Visibloc_Test_User( 0, [] );
 
-        visibloc_jlg_store_real_user_id( $real_user_id );
+        $this->plugin->storeRealUserId( $real_user_id );
 
         $allcaps = [
             'read'         => true,
@@ -33,11 +38,11 @@ class RoleSwitcherCapabilitiesTest extends TestCase {
         $other_user = new Visibloc_Test_User( 99, [ 'administrator' ] );
         $this->assertSame(
             $allcaps,
-            visibloc_jlg_filter_user_capabilities( $allcaps, [], [], $other_user ),
+            $this->plugin->filterUserCapabilities( $allcaps, [], [], $other_user ),
             'Capabilities for unrelated users should remain unchanged during a guest preview.'
         );
 
-        $guest_user_caps = visibloc_jlg_filter_user_capabilities( $allcaps, [], [], new Visibloc_Test_User( 0, [] ) );
+        $guest_user_caps = $this->plugin->filterUserCapabilities( $allcaps, [], [], new Visibloc_Test_User( 0, [] ) );
 
         $this->assertArrayHasKey( 'exist', $guest_user_caps );
         $this->assertArrayHasKey( 'read', $guest_user_caps );

--- a/visi-bloc-jlg/tests/phpunit/integration/VisibilityLogicTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/VisibilityLogicTest.php
@@ -1,16 +1,22 @@
 <?php
 
 use PHPUnit\Framework\TestCase;
+use Visibloc\Tests\Support\PluginFacade;
+use Visibloc\Tests\Support\TestServices;
 
 require_once __DIR__ . '/../../../includes/assets.php';
 
 class VisibilityLogicTest extends TestCase {
+    private PluginFacade $plugin;
+
     protected function setUp(): void {
         visibloc_test_reset_state();
         remove_all_filters( 'visibloc_supported_blocks' );
         if ( isset( $GLOBALS['visibloc_test_options']['visibloc_supported_blocks'] ) ) {
             unset( $GLOBALS['visibloc_test_options']['visibloc_supported_blocks'] );
         }
+
+        $this->plugin = TestServices::plugin();
     }
 
     public function test_administrator_impersonating_editor_sees_editor_view_without_hidden_blocks(): void {
@@ -32,7 +38,7 @@ class VisibilityLogicTest extends TestCase {
 
         $this->assertSame(
             '<p>Editor content</p>',
-            visibloc_jlg_render_block_filter( '<p>Editor content</p>', $visible_for_editors ),
+            $this->plugin->renderBlockFilter( '<p>Editor content</p>', $visible_for_editors ),
             'Blocks targeted to editors should remain visible during editor preview.'
         );
 
@@ -45,7 +51,7 @@ class VisibilityLogicTest extends TestCase {
 
         $this->assertSame(
             '',
-            visibloc_jlg_render_block_filter( '<p>Administrator only</p>', $admin_only_block ),
+            $this->plugin->renderBlockFilter( '<p>Administrator only</p>', $admin_only_block ),
             'Administrator-only blocks must be hidden when previewing as an editor.'
         );
 
@@ -58,7 +64,7 @@ class VisibilityLogicTest extends TestCase {
 
         $this->assertSame(
             '',
-            visibloc_jlg_render_block_filter( '<p>Hidden content</p>', $hidden_block ),
+            $this->plugin->renderBlockFilter( '<p>Hidden content</p>', $hidden_block ),
             'Hidden blocks should not appear without preview permission for the simulated role.'
         );
     }
@@ -81,7 +87,7 @@ class VisibilityLogicTest extends TestCase {
             ],
         ];
 
-        $output = visibloc_jlg_render_block_filter( '<p>Hidden admin content</p>', $block );
+        $output = $this->plugin->renderBlockFilter( '<p>Hidden admin content</p>', $block );
 
         $this->assertStringContainsString( 'bloc-cache-apercu', $output );
         $this->assertStringContainsString( 'vb-label-top', $output );
@@ -101,7 +107,7 @@ class VisibilityLogicTest extends TestCase {
 
         $this->assertSame(
             '<p>Visible content</p>',
-            visibloc_jlg_render_block_filter( '<p>Visible content</p>', $block ),
+            $this->plugin->renderBlockFilter( '<p>Visible content</p>', $block ),
             'False-like attribute values should not hide the block.'
         );
     }
@@ -121,7 +127,7 @@ class VisibilityLogicTest extends TestCase {
 
         $this->assertSame(
             '<p>Future content</p>',
-            visibloc_jlg_render_block_filter( '<p>Future content</p>', $block ),
+            $this->plugin->renderBlockFilter( '<p>Future content</p>', $block ),
             'Scheduling should be skipped when the flag is stored as a false-like value.'
         );
     }
@@ -140,7 +146,7 @@ class VisibilityLogicTest extends TestCase {
 
         $this->assertSame(
             '<p>Visible content</p>',
-            visibloc_jlg_render_block_filter( '<p>Visible content</p>', $block ),
+            $this->plugin->renderBlockFilter( '<p>Visible content</p>', $block ),
             'A scalar string value should be treated as a single role entry.'
         );
     }
@@ -158,7 +164,7 @@ class VisibilityLogicTest extends TestCase {
 
         $this->assertSame(
             '<p>Visible content</p>',
-            visibloc_jlg_render_block_filter( '<p>Visible content</p>', $block ),
+            $this->plugin->renderBlockFilter( '<p>Visible content</p>', $block ),
             'Non-scalar visibility role values should be ignored without affecting rendering.'
         );
     }
@@ -173,7 +179,7 @@ class VisibilityLogicTest extends TestCase {
 
         $this->assertSame(
             '<p>Guest content</p>',
-            visibloc_jlg_render_block_filter( '<p>Guest content</p>', $block ),
+            $this->plugin->renderBlockFilter( '<p>Guest content</p>', $block ),
             'The logged-out marker should work when passed as a scalar value.'
         );
     }
@@ -197,7 +203,7 @@ class VisibilityLogicTest extends TestCase {
 
         $this->assertSame(
             '',
-            visibloc_jlg_render_block_filter( '<p>Members content</p>', $logged_in_block ),
+            $this->plugin->renderBlockFilter( '<p>Members content</p>', $logged_in_block ),
             'Previewing as a guest should hide blocks reserved for logged-in users even without impersonation rights.'
         );
 
@@ -210,7 +216,7 @@ class VisibilityLogicTest extends TestCase {
 
         $this->assertSame(
             '<p>Guest view</p>',
-            visibloc_jlg_render_block_filter( '<p>Guest view</p>', $logged_out_block ),
+            $this->plugin->renderBlockFilter( '<p>Guest view</p>', $logged_out_block ),
             'Previewing as a guest should expose content intended for visitors.'
         );
     }
@@ -262,7 +268,7 @@ class VisibilityLogicTest extends TestCase {
             ]
         );
 
-        $supported = visibloc_jlg_get_supported_blocks();
+        $supported = $this->plugin->getSupportedBlocks();
 
         $this->assertContains( 'core/group', $supported );
         $this->assertContains( 'core/columns', $supported );
@@ -292,7 +298,7 @@ class VisibilityLogicTest extends TestCase {
 
         $this->assertSame(
             '',
-            visibloc_jlg_render_block_filter( '<p>Scheduled content</p>', $block ),
+            $this->plugin->renderBlockFilter( '<p>Scheduled content</p>', $block ),
             'Scheduled blocks must remain hidden outside their window when no preview privilege is granted.'
         );
     }
@@ -315,7 +321,7 @@ class VisibilityLogicTest extends TestCase {
             ],
         ];
 
-        $output = visibloc_jlg_render_block_filter( '<p>Scheduled content</p>', $block );
+        $output = $this->plugin->renderBlockFilter( '<p>Scheduled content</p>', $block );
 
         $this->assertStringContainsString( 'bloc-schedule-apercu', $output );
         $this->assertStringContainsString( 'vb-label-top', $output );
@@ -339,7 +345,7 @@ class VisibilityLogicTest extends TestCase {
 
         $this->assertSame(
             '',
-            visibloc_jlg_render_block_filter( '<p>Scheduled content</p>', $block ),
+            $this->plugin->renderBlockFilter( '<p>Scheduled content</p>', $block ),
             'Blocks should remain hidden before the scheduled start when the site timezone is ahead of UTC.'
         );
     }
@@ -360,7 +366,7 @@ class VisibilityLogicTest extends TestCase {
 
         $this->assertSame(
             '',
-            visibloc_jlg_render_block_filter( '<p>Scheduled content</p>', $block ),
+            $this->plugin->renderBlockFilter( '<p>Scheduled content</p>', $block ),
             'Blocks should remain hidden before the scheduled start in the configured site timezone.'
         );
 
@@ -368,7 +374,7 @@ class VisibilityLogicTest extends TestCase {
 
         $this->assertSame(
             '<p>Scheduled content</p>',
-            visibloc_jlg_render_block_filter( '<p>Scheduled content</p>', $block ),
+            $this->plugin->renderBlockFilter( '<p>Scheduled content</p>', $block ),
             'Blocks should become visible once the local start time has passed.'
         );
     }
@@ -389,7 +395,7 @@ class VisibilityLogicTest extends TestCase {
 
         $this->assertSame(
             '',
-            visibloc_jlg_render_block_filter( '<p>Scheduled content</p>', $block ),
+            $this->plugin->renderBlockFilter( '<p>Scheduled content</p>', $block ),
             'Blocks should remain hidden before the start window in a timezone west of UTC.'
         );
 
@@ -397,13 +403,13 @@ class VisibilityLogicTest extends TestCase {
 
         $this->assertSame(
             '<p>Scheduled content</p>',
-            visibloc_jlg_render_block_filter( '<p>Scheduled content</p>', $block ),
+            $this->plugin->renderBlockFilter( '<p>Scheduled content</p>', $block ),
             'Blocks should become visible once the local start time has passed in a timezone west of UTC.'
         );
     }
 
     private function setCurrentTimeForSiteTimezone( string $datetime ): void {
-        $timestamp = visibloc_jlg_parse_schedule_datetime( $datetime );
+        $timestamp = $this->plugin->parseScheduleDatetime( $datetime );
 
         if ( null === $timestamp ) {
             $this->fail( sprintf( 'Failed to parse datetime string "%s" for test setup.', $datetime ) );
@@ -413,7 +419,7 @@ class VisibilityLogicTest extends TestCase {
     }
 
     public function test_generate_device_visibility_css_respects_preview_context(): void {
-        $css_without_preview = visibloc_jlg_generate_device_visibility_css( false, 781, 1024 );
+        $css_without_preview = $this->plugin->generateDeviceVisibilityCss( false, 781, 1024 );
         $expected_default_css = <<<CSS
 @media (max-width: 781px) {
     .vb-hide-on-mobile,
@@ -439,12 +445,12 @@ class VisibilityLogicTest extends TestCase {
 CSS;
         $this->assertSame( $expected_default_css, trim( $css_without_preview ) );
 
-        $css_with_custom_breakpoints = visibloc_jlg_generate_device_visibility_css( false, 700, 900 );
+        $css_with_custom_breakpoints = $this->plugin->generateDeviceVisibilityCss( false, 700, 900 );
         $this->assertStringContainsString( '@media (max-width: 700px)', $css_with_custom_breakpoints );
         $this->assertStringContainsString( '@media (min-width: 901px)', $css_with_custom_breakpoints );
         $this->assertStringNotContainsString( 'outline: 2px dashed', $css_with_custom_breakpoints );
 
-        $css_with_preview = visibloc_jlg_generate_device_visibility_css( true, 781, 1024 );
+        $css_with_preview = $this->plugin->generateDeviceVisibilityCss( true, 781, 1024 );
         $this->assertStringContainsString( 'outline: 2px dashed #0073aa', $css_with_preview );
         $this->assertStringContainsString( 'Visible sur Desktop Uniquement', $css_with_preview );
     }

--- a/visi-bloc-jlg/tests/phpunit/role-switcher-test-loader.php
+++ b/visi-bloc-jlg/tests/phpunit/role-switcher-test-loader.php
@@ -1,5 +1,17 @@
 <?php
 
+use Visibloc\Tests\Support\TestServices;
+
+if ( ! class_exists( TestServices::class, false ) ) {
+    $autoloader = dirname( __DIR__, 3 ) . '/vendor/autoload.php';
+
+    if ( file_exists( $autoloader ) ) {
+        require_once $autoloader;
+    }
+}
+
+TestServices::bootstrap();
+
 if ( isset( $GLOBALS['visibloc_role_switcher_loaded'] ) && $GLOBALS['visibloc_role_switcher_loaded'] ) {
     return;
 }

--- a/visi-bloc-jlg/tests/phpunit/src/PluginFacade.php
+++ b/visi-bloc-jlg/tests/phpunit/src/PluginFacade.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace Visibloc\Tests\Support;
+
+use BadMethodCallException;
+
+final class PluginFacade
+{
+    private function call(string $function, array $arguments = [])
+    {
+        if (! function_exists($function)) {
+            throw new BadMethodCallException(
+                sprintf('Expected function %s() to be available for testing.', $function)
+            );
+        }
+
+        return call_user_func_array($function, $arguments);
+    }
+
+    public function addRoleSwitcherMenu(object $adminBar): void
+    {
+        $this->call('visibloc_jlg_add_role_switcher_menu', [$adminBar]);
+    }
+
+    public function clearCaches($postId = null): void
+    {
+        $this->call('visibloc_jlg_clear_caches', [$postId]);
+    }
+
+    public function collectGroupBlockMetadata(): array
+    {
+        $result = $this->call('visibloc_jlg_collect_group_block_metadata');
+
+        return is_array($result) ? $result : [];
+    }
+
+    public function enqueueEditorAssets(): void
+    {
+        $this->call('visibloc_jlg_enqueue_editor_assets');
+    }
+
+    public function filterUserCapabilities(array $allcaps, array $caps, array $args, $user): array
+    {
+        $result = $this->call('visibloc_jlg_filter_user_capabilities', [$allcaps, $caps, $args, $user]);
+
+        return is_array($result) ? $result : $allcaps;
+    }
+
+    public function generateDeviceVisibilityCss(bool $canPreview, ?int $mobileBreakpoint = null, ?int $tabletBreakpoint = null): string
+    {
+        return (string) $this->call(
+            'visibloc_jlg_generate_device_visibility_css',
+            [$canPreview, $mobileBreakpoint, $tabletBreakpoint]
+        );
+    }
+
+    public function generateGroupBlockSummaryFromContent($postId, $content = null, $blockMatcher = null): array
+    {
+        $result = $this->call('visibloc_jlg_generate_group_block_summary_from_content', [$postId, $content, $blockMatcher]);
+
+        return is_array($result) ? $result : [];
+    }
+
+    public function getDisplayFallbackForSelector(string $selector): ?string
+    {
+        $result = $this->call('visibloc_jlg_get_display_fallback_for_selector', [$selector]);
+
+        return null === $result ? null : (string) $result;
+    }
+
+    public function getGroupBlockSummaryIndex(): array
+    {
+        $result = $this->call('visibloc_jlg_get_group_block_summary_index');
+
+        return is_array($result) ? $result : [];
+    }
+
+    public function getPreviewCookieExpirationTime($referenceTime = null): int
+    {
+        return (int) $this->call('visibloc_jlg_get_preview_cookie_expiration_time', [$referenceTime]);
+    }
+
+    public function getPreviewRoleFromCookie(): string
+    {
+        return (string) $this->call('visibloc_jlg_get_preview_role_from_cookie');
+    }
+
+    public function getPreviewRuntimeContext(bool $resetCache = false): array
+    {
+        $result = $this->call('visibloc_jlg_get_preview_runtime_context', [$resetCache]);
+
+        return is_array($result) ? $result : [];
+    }
+
+    public function getPreviewSwitchBaseUrl(): string
+    {
+        return (string) $this->call('visibloc_jlg_get_preview_switch_base_url');
+    }
+
+    public function getSanitizedQueryArg(string $key): string
+    {
+        return (string) $this->call('visibloc_jlg_get_sanitized_query_arg', [$key]);
+    }
+
+    public function getSupportedBlocks(): array
+    {
+        $result = $this->call('visibloc_jlg_get_supported_blocks');
+
+        return is_array($result) ? $result : [];
+    }
+
+    public function groupPostsById($posts): array
+    {
+        $result = $this->call('visibloc_jlg_group_posts_by_id', [$posts]);
+
+        return is_array($result) ? $result : [];
+    }
+
+    public function handleRoleSwitching(): void
+    {
+        $this->call('visibloc_jlg_handle_role_switching');
+    }
+
+    public function isAdminOrTechnicalRequest(): bool
+    {
+        return (bool) $this->call('visibloc_jlg_is_admin_or_technical_request');
+    }
+
+    public function missingEditorAssets(): bool
+    {
+        if (! function_exists('visibloc_jlg_missing_editor_assets')) {
+            return false;
+        }
+
+        $result = $this->call('visibloc_jlg_missing_editor_assets');
+
+        return (bool) $result;
+    }
+
+    public function normalizeBlockDeclarations(string $selector, $declaration): array
+    {
+        $result = $this->call('visibloc_jlg_normalize_block_declarations', [$selector, $declaration]);
+
+        return is_array($result) ? $result : [];
+    }
+
+    public function parseScheduleDatetime($value): ?int
+    {
+        $result = $this->call('visibloc_jlg_parse_schedule_datetime', [$value]);
+
+        if (null === $result) {
+            return null;
+        }
+
+        return is_numeric($result) ? (int) $result : null;
+    }
+
+    public function purgePreviewCookie(): bool
+    {
+        return (bool) $this->call('visibloc_jlg_purge_preview_cookie');
+    }
+
+    public function rebuildGroupBlockSummaryIndex(?int &$scannedPosts = null): array
+    {
+        $result = $this->call('visibloc_jlg_rebuild_group_block_summary_index', [&$scannedPosts]);
+
+        return is_array($result) ? $result : [];
+    }
+
+    public function renderBlockFilter(string $content, array $block): string
+    {
+        return (string) $this->call('visibloc_jlg_render_block_filter', [$content, $block]);
+    }
+
+    public function renderMissingEditorAssetsNotice(): void
+    {
+        $this->call('visibloc_jlg_render_missing_editor_assets_notice');
+    }
+
+    public function storeGroupBlockSummaryIndex(array $index): void
+    {
+        $this->call('visibloc_jlg_store_group_block_summary_index', [$index]);
+    }
+
+    public function storeRealUserId($userId): void
+    {
+        $this->call('visibloc_jlg_store_real_user_id', [$userId]);
+    }
+}

--- a/visi-bloc-jlg/tests/phpunit/src/TestServices.php
+++ b/visi-bloc-jlg/tests/phpunit/src/TestServices.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Visibloc\Tests\Support;
+
+final class TestServices
+{
+    private static ?self $instance = null;
+
+    private PluginFacade $plugin;
+
+    private function __construct()
+    {
+        $this->plugin = new PluginFacade();
+    }
+
+    public static function bootstrap(): self
+    {
+        if (null === self::$instance) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    public static function plugin(): PluginFacade
+    {
+        return self::bootstrap()->plugin;
+    }
+}


### PR DESCRIPTION
## Summary
- load Composer's autoloader in the PHPUnit bootstrap and role-switcher loader so tests initialize the plugin services container
- add test support classes that expose plugin helpers through a facade for reuse across integration tests
- update the PHPUnit integration suites to call the facade instead of global helper functions

## Testing
- ./vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68de46a49534832e823077022b583614