### PR TITLE
Refactor bootstrap into Plugin class

### DIFF
--- a/visi-bloc-jlg/autoload.php
+++ b/visi-bloc-jlg/autoload.php
@@ -1,0 +1,15 @@
+<?php
+spl_autoload_register(
+    static function ( $class ) {
+        if ( 0 !== strpos( $class, 'VisiBloc\\' ) ) {
+            return;
+        }
+
+        $relative = substr( $class, strlen( 'VisiBloc\\' ) );
+        $path     = __DIR__ . '/src/' . str_replace( '\\', '/', $relative ) . '.php';
+
+        if ( is_readable( $path ) ) {
+            require_once $path;
+        }
+    }
+);

--- a/visi-bloc-jlg/src/Plugin.php
+++ b/visi-bloc-jlg/src/Plugin.php
@@ -1,0 +1,250 @@
+<?php
+
+namespace VisiBloc;
+
+class Plugin {
+    /**
+     * Absolute path to the main plugin file.
+     *
+     * @var string
+     */
+    private $plugin_file;
+
+    /**
+     * Absolute path to the plugin directory.
+     *
+     * @var string
+     */
+    private $plugin_dir;
+
+    /**
+     * Cached plugin basename.
+     *
+     * @var string
+     */
+    private $plugin_basename;
+
+    /**
+     * Cached preview capability result.
+     *
+     * @var bool|null
+     */
+    private $cached_can_preview = null;
+
+    /**
+     * Instantiate the plugin wrapper.
+     *
+     * @param string $plugin_file Absolute path to the main plugin file.
+     */
+    public function __construct( $plugin_file ) {
+        $this->plugin_file     = $plugin_file;
+        $this->plugin_dir      = dirname( $plugin_file );
+        $this->plugin_basename = function_exists( 'plugin_basename' )
+            ? plugin_basename( $plugin_file )
+            : basename( $plugin_file );
+    }
+
+    /**
+     * Register the plugin hooks and dependencies.
+     */
+    public function register() {
+        $this->define_version_constant();
+        $this->define_default_supported_blocks();
+        $this->register_settings_hooks();
+        $this->register_assets_hooks();
+        $this->register_visibility_hooks();
+        $this->register_inline_i18n_hooks();
+        $this->register_role_switcher_hooks();
+        $this->register_cli_commands();
+        $this->load_textdomain();
+    }
+
+    /**
+     * Register the WordPress settings hooks.
+     */
+    protected function register_settings_hooks() {
+        require_once $this->plugin_dir . '/includes/block-utils.php';
+        require_once $this->plugin_dir . '/includes/admin-settings.php';
+
+        add_action( 'init', [ $this, 'register_supported_blocks_setting' ] );
+    }
+
+    /**
+     * Register public/admin asset hooks.
+     */
+    protected function register_assets_hooks() {
+        require_once $this->plugin_dir . '/includes/assets.php';
+    }
+
+    /**
+     * Register hooks responsible for block visibility.
+     */
+    protected function register_visibility_hooks() {
+        require_once $this->plugin_dir . '/includes/datetime-utils.php';
+        require_once $this->plugin_dir . '/includes/visibility-logic.php';
+    }
+
+    /**
+     * Register hooks for inline internationalisation helpers.
+     */
+    protected function register_inline_i18n_hooks() {
+        require_once $this->plugin_dir . '/includes/i18n-inline.php';
+    }
+
+    /**
+     * Register hooks that power the role switcher UX.
+     */
+    protected function register_role_switcher_hooks() {
+        require_once $this->plugin_dir . '/includes/role-switcher.php';
+    }
+
+    /**
+     * Register WP-CLI specific commands when available.
+     */
+    protected function register_cli_commands() {
+        if ( defined( 'WP_CLI' ) && WP_CLI ) {
+            require_once $this->plugin_dir . '/includes/cli.php';
+        }
+    }
+
+    /**
+     * Load the plugin text domain for translations.
+     */
+    protected function load_textdomain() {
+        if ( function_exists( 'load_plugin_textdomain' ) ) {
+            load_plugin_textdomain(
+                'visi-bloc-jlg',
+                false,
+                dirname( $this->plugin_basename ) . '/languages'
+            );
+        }
+    }
+
+    /**
+     * Register the "visibloc_supported_blocks" option.
+     */
+    public function register_supported_blocks_setting() {
+        if ( ! function_exists( 'register_setting' ) ) {
+            return;
+        }
+
+        register_setting(
+            'visibloc',
+            'visibloc_supported_blocks',
+            [
+                'type'              => 'array',
+                'sanitize_callback' => 'visibloc_jlg_normalize_block_names',
+                'default'           => [],
+                'show_in_rest'      => [
+                    'schema' => [
+                        'type'  => 'array',
+                        'items' => [
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ]
+        );
+    }
+
+    /**
+     * Retrieve a sanitized value from the request.
+     *
+     * @param string $key Query arg key.
+     * @return string
+     */
+    public function get_sanitized_query_arg( $key ) {
+        if ( ! isset( $_GET[ $key ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+            return '';
+        }
+
+        $value = $_GET[ $key ]; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+        if ( ! is_string( $value ) ) {
+            return '';
+        }
+
+        return sanitize_key( wp_unslash( $value ) );
+    }
+
+    /**
+     * Convert a value into a strict boolean representation.
+     *
+     * @param mixed $value Raw value.
+     * @return bool
+     */
+    public function normalize_boolean( $value ) {
+        if ( is_bool( $value ) ) {
+            return $value;
+        }
+
+        if ( null === $value ) {
+            return false;
+        }
+
+        if ( is_array( $value ) || is_object( $value ) ) {
+            return false;
+        }
+
+        $filtered = filter_var( $value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE );
+
+        return true === $filtered;
+    }
+
+    /**
+     * Determine if the current user can preview hidden blocks.
+     *
+     * @return bool
+     */
+    public function can_user_preview() {
+        if ( null !== $this->cached_can_preview ) {
+            return $this->cached_can_preview;
+        }
+
+        if ( function_exists( 'visibloc_jlg_get_preview_runtime_context' ) ) {
+            $runtime_context           = visibloc_jlg_get_preview_runtime_context();
+            $this->cached_can_preview = ! empty( $runtime_context['can_preview_hidden_blocks'] );
+
+            return $this->cached_can_preview;
+        }
+
+        $this->cached_can_preview = false;
+
+        return $this->cached_can_preview;
+    }
+
+    /**
+     * Ensure the plugin version constant is defined.
+     */
+    protected function define_version_constant() {
+        if ( defined( 'VISIBLOC_JLG_VERSION' ) ) {
+            return;
+        }
+
+        $version = '0.0.0';
+
+        if ( function_exists( 'get_file_data' ) ) {
+            $plugin_data = get_file_data( $this->plugin_file, [ 'Version' => 'Version' ] );
+            $version     = isset( $plugin_data['Version'] ) && '' !== $plugin_data['Version']
+                ? $plugin_data['Version']
+                : $version;
+        } else {
+            $plugin_contents = @file_get_contents( $this->plugin_file );
+
+            if ( false !== $plugin_contents && preg_match( '/^\s*\*\s*Version:\s*(.+)$/mi', $plugin_contents, $matches ) ) {
+                $version = trim( $matches[1] );
+            }
+        }
+
+        define( 'VISIBLOC_JLG_VERSION', $version );
+    }
+
+    /**
+     * Ensure the default supported blocks constant is declared.
+     */
+    protected function define_default_supported_blocks() {
+        if ( ! defined( 'VISIBLOC_JLG_DEFAULT_SUPPORTED_BLOCKS' ) ) {
+            define( 'VISIBLOC_JLG_DEFAULT_SUPPORTED_BLOCKS', [ 'core/group' ] );
+        }
+    }
+}

--- a/visi-bloc-jlg/visi-bloc-jlg.php
+++ b/visi-bloc-jlg/visi-bloc-jlg.php
@@ -8,155 +8,45 @@
  * Domain Path:       /languages
  */
 
-if ( ! defined( 'WPINC' ) ) { exit; }
+if ( ! defined( 'WPINC' ) ) {
+    exit;
+}
 
-if ( ! defined( 'VISIBLOC_JLG_VERSION' ) ) {
-    $visibloc_version = '0.0.0';
+require_once __DIR__ . '/autoload.php';
 
-    if ( function_exists( 'get_file_data' ) ) {
-        $plugin_data      = get_file_data( __FILE__, [ 'Version' => 'Version' ] );
-        $visibloc_version = isset( $plugin_data['Version'] ) && '' !== $plugin_data['Version']
-            ? $plugin_data['Version']
-            : $visibloc_version;
-    } else {
-        $plugin_contents = @file_get_contents( __FILE__ );
+use VisiBloc\Plugin;
 
-        if ( false !== $plugin_contents && preg_match( '/^\s*\*\s*Version:\s*(.+)$/mi', $plugin_contents, $matches ) ) {
-            $visibloc_version = trim( $matches[1] );
-        }
+$visibloc_jlg_plugin = new Plugin( __FILE__ );
+
+if ( ! function_exists( 'visibloc_jlg' ) ) {
+    function visibloc_jlg() {
+        global $visibloc_jlg_plugin;
+
+        return $visibloc_jlg_plugin;
     }
-
-    define( 'VISIBLOC_JLG_VERSION', $visibloc_version );
 }
-
-if ( ! defined( 'VISIBLOC_JLG_DEFAULT_SUPPORTED_BLOCKS' ) ) {
-    define( 'VISIBLOC_JLG_DEFAULT_SUPPORTED_BLOCKS', [ 'core/group' ] );
-}
-
-require_once __DIR__ . '/includes/block-utils.php';
 
 if ( ! function_exists( 'visibloc_jlg_get_sanitized_query_arg' ) ) {
-    /**
-     * Retrieve a sanitized value from the $_GET superglobal using sanitize_key.
-     *
-     * Only string values are accepted to avoid unexpected sanitization results
-     * or PHP notices when arrays/objects are provided.
-     *
-     * @param string $key Query arg key to read from $_GET.
-     * @return string Sanitized string or an empty string when unavailable/invalid.
-     */
     function visibloc_jlg_get_sanitized_query_arg( $key ) {
-        if ( ! isset( $_GET[ $key ] ) ) {
-            return '';
-        }
-
-        $value = $_GET[ $key ];
-
-        if ( ! is_string( $value ) ) {
-            return '';
-        }
-
-        return sanitize_key( wp_unslash( $value ) );
+        return visibloc_jlg()->get_sanitized_query_arg( $key );
     }
-}
-
-if ( ! function_exists( 'visibloc_jlg_register_supported_blocks_setting' ) ) {
-    function visibloc_jlg_register_supported_blocks_setting() {
-        if ( ! function_exists( 'register_setting' ) ) {
-            return;
-        }
-
-        register_setting(
-            'visibloc',
-            'visibloc_supported_blocks',
-            [
-                'type'              => 'array',
-                'sanitize_callback' => 'visibloc_jlg_normalize_block_names',
-                'default'           => [],
-                'show_in_rest'      => [
-                    'schema' => [
-                        'type'  => 'array',
-                        'items' => [
-                            'type' => 'string',
-                        ],
-                    ],
-                ],
-            ]
-        );
-    }
-
-    add_action( 'init', 'visibloc_jlg_register_supported_blocks_setting' );
 }
 
 if ( ! function_exists( 'visibloc_jlg_normalize_boolean' ) ) {
-    /**
-     * Convert a block attribute value to a strict boolean.
-     *
-     * Arrays and objects are treated as false to avoid PHP warnings triggered
-     * by filter_var() while scalar/string values are normalized using
-     * FILTER_VALIDATE_BOOLEAN. Invalid or empty values default to false.
-     *
-     * @param mixed $value Raw attribute value.
-     * @return bool Normalized boolean value.
-     */
     function visibloc_jlg_normalize_boolean( $value ) {
-        if ( is_bool( $value ) ) {
-            return $value;
-        }
-
-        if ( null === $value ) {
-            return false;
-        }
-
-        if ( is_array( $value ) || is_object( $value ) ) {
-            return false;
-        }
-
-        $filtered = filter_var( $value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE );
-
-        return true === $filtered;
+        return visibloc_jlg()->normalize_boolean( $value );
     }
 }
 
-// Charge les différents modules du plugin
-require_once __DIR__ . '/includes/datetime-utils.php';
-require_once __DIR__ . '/includes/admin-settings.php';
-require_once __DIR__ . '/includes/assets.php';
-require_once __DIR__ . '/includes/visibility-logic.php';
-require_once __DIR__ . '/includes/i18n-inline.php';
-require_once __DIR__ . '/includes/role-switcher.php';
-if ( defined( 'WP_CLI' ) && WP_CLI ) {
-    require_once __DIR__ . '/includes/cli.php';
-}
-
-/**
- * Initialise la localisation du plugin.
- */
-function visi_bloc_jlg_load_textdomain() {
-    load_plugin_textdomain( 'visi-bloc-jlg', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
-}
-add_action( 'plugins_loaded', 'visi_bloc_jlg_load_textdomain' );
-
-/**
- * Vérifie si l'utilisateur actuellement connecté a un rôle autorisé à voir les aperçus.
- *
- * @return bool True si l'utilisateur peut voir les aperçus, sinon false.
- */
-function visibloc_jlg_can_user_preview() {
-    static $cached_can_preview = null;
-
-    if ( null !== $cached_can_preview ) {
-        return $cached_can_preview;
+if ( ! function_exists( 'visibloc_jlg_can_user_preview' ) ) {
+    function visibloc_jlg_can_user_preview() {
+        return visibloc_jlg()->can_user_preview();
     }
-
-    if ( function_exists( 'visibloc_jlg_get_preview_runtime_context' ) ) {
-        $runtime_context = visibloc_jlg_get_preview_runtime_context();
-        $cached_can_preview = ! empty( $runtime_context['can_preview_hidden_blocks'] );
-
-        return $cached_can_preview;
-    }
-
-    $cached_can_preview = false;
-
-    return $cached_can_preview;
 }
+
+add_action(
+    'plugins_loaded',
+    static function () use ( $visibloc_jlg_plugin ) {
+        $visibloc_jlg_plugin->register();
+    }
+);


### PR DESCRIPTION
## Summary
- add a lightweight autoloader and `VisiBloc\Plugin` class to encapsulate hook registration
- update the plugin bootstrap to instantiate the class and proxy legacy helpers through instance methods

## Testing
- php -l visi-bloc-jlg/src/Plugin.php
- php -l visi-bloc-jlg/visi-bloc-jlg.php

------
https://chatgpt.com/codex/tasks/task_e_68de469ed874832e912f0a7585293613