### PR TITLE
Add Composer autoload bootstrap for plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,5 +2,10 @@
     "name": "visibloc/wp-visibloc",
     "require-dev": {
         "phpunit/phpunit": "^9.6"
+    },
+    "autoload": {
+        "psr-4": {
+            "VisiBloc\\": "visi-bloc-jlg/src/"
+        }
     }
 }

--- a/visi-bloc-jlg/src/Plugin.php
+++ b/visi-bloc-jlg/src/Plugin.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace VisiBloc;
+
+class Plugin
+{
+    /**
+     * @var string
+     */
+    private $plugin_dir;
+
+    /**
+     * @var bool
+     */
+    private $bootstrapped = false;
+
+    /**
+     * @param string $plugin_dir
+     */
+    public function __construct($plugin_dir)
+    {
+        $this->plugin_dir = rtrim($plugin_dir, '/\\');
+    }
+
+    public function bootstrap()
+    {
+        if ($this->bootstrapped) {
+            return;
+        }
+
+        $this->bootstrapped = true;
+        $this->load_dependencies();
+    }
+
+    private function load_dependencies()
+    {
+        $includes_dir = $this->plugin_dir . '/includes';
+
+        $files = [
+            'block-utils.php',
+            'datetime-utils.php',
+            'admin-settings.php',
+            'assets.php',
+            'visibility-logic.php',
+            'i18n-inline.php',
+            'role-switcher.php',
+        ];
+
+        foreach ($files as $file) {
+            $path = $includes_dir . '/' . $file;
+
+            if (file_exists($path)) {
+                require_once $path;
+            }
+        }
+
+        $cli_path = $includes_dir . '/cli.php';
+
+        if (defined('WP_CLI') && WP_CLI && file_exists($cli_path)) {
+            require_once $cli_path;
+        }
+    }
+}

--- a/visi-bloc-jlg/visi-bloc-jlg.php
+++ b/visi-bloc-jlg/visi-bloc-jlg.php
@@ -33,7 +33,11 @@ if ( ! defined( 'VISIBLOC_JLG_DEFAULT_SUPPORTED_BLOCKS' ) ) {
     define( 'VISIBLOC_JLG_DEFAULT_SUPPORTED_BLOCKS', [ 'core/group' ] );
 }
 
-require_once __DIR__ . '/includes/block-utils.php';
+$autoloader = dirname( __DIR__ ) . '/vendor/autoload.php';
+
+if ( file_exists( $autoloader ) ) {
+    require_once $autoloader;
+}
 
 if ( ! function_exists( 'visibloc_jlg_get_sanitized_query_arg' ) ) {
     /**
@@ -118,16 +122,15 @@ if ( ! function_exists( 'visibloc_jlg_normalize_boolean' ) ) {
     }
 }
 
-// Charge les différents modules du plugin
-require_once __DIR__ . '/includes/datetime-utils.php';
-require_once __DIR__ . '/includes/admin-settings.php';
-require_once __DIR__ . '/includes/assets.php';
-require_once __DIR__ . '/includes/visibility-logic.php';
-require_once __DIR__ . '/includes/i18n-inline.php';
-require_once __DIR__ . '/includes/role-switcher.php';
-if ( defined( 'WP_CLI' ) && WP_CLI ) {
-    require_once __DIR__ . '/includes/cli.php';
-}
+
+add_action(
+    'plugins_loaded',
+    static function () {
+        if ( class_exists( \VisiBloc\Plugin::class ) ) {
+            ( new \VisiBloc\Plugin( __DIR__ ) )->bootstrap();
+        }
+    }
+);
 
 /**
  * Initialise la localisation du plugin.


### PR DESCRIPTION
## Summary
- add a PSR-4 autoload definition for the `VisiBloc` namespace
- load Composer's autoloader in the plugin entry point and bootstrap a new `VisiBloc\Plugin` class that includes the plugin modules

## Testing
- composer dump-autoload

------
https://chatgpt.com/codex/tasks/task_e_68de46a34594832eac93c889cc4e5667