### PR TITLE
Add search filter for supported blocks list

### DIFF
--- a/visi-bloc-jlg/assets/admin-supported-blocks.js
+++ b/visi-bloc-jlg/assets/admin-supported-blocks.js
@@ -1,0 +1,67 @@
+(function () {
+    'use strict';
+
+    var initSearch = function (input) {
+        var targetId = input.getAttribute('data-visibloc-blocks-target');
+        if (!targetId) {
+            return;
+        }
+
+        var container = document.getElementById(targetId);
+        if (!container) {
+            return;
+        }
+
+        var items = Array.prototype.slice.call(
+            container.querySelectorAll('[data-visibloc-block]')
+        );
+        if (!items.length) {
+            return;
+        }
+
+        var emptyMessage = container.querySelector('[data-visibloc-blocks-empty]');
+
+        var toggleItems = function () {
+            var query = input.value || '';
+            var normalizedQuery = query.trim().toLowerCase();
+            var visibleCount = 0;
+
+            items.forEach(function (item) {
+                var searchValue = item.getAttribute('data-visibloc-search-value') || '';
+                var isVisible = !normalizedQuery || searchValue.indexOf(normalizedQuery) !== -1;
+
+                item.style.display = isVisible ? '' : 'none';
+
+                if (isVisible) {
+                    visibleCount++;
+                }
+            });
+
+            if (emptyMessage) {
+                emptyMessage.hidden = visibleCount > 0;
+            }
+        };
+
+        input.addEventListener('input', toggleItems);
+        input.addEventListener('search', toggleItems);
+
+        toggleItems();
+    };
+
+    var onReady = function () {
+        var searchInputs = document.querySelectorAll('[data-visibloc-blocks-search]');
+        if (!searchInputs.length) {
+            return;
+        }
+
+        Array.prototype.forEach.call(searchInputs, function (input) {
+            initSearch(input);
+        });
+    };
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', onReady);
+    } else {
+        onReady();
+    }
+})();

--- a/visi-bloc-jlg/includes/admin-settings.php
+++ b/visi-bloc-jlg/includes/admin-settings.php
@@ -240,29 +240,64 @@ function visibloc_jlg_render_supported_blocks_section( $registered_block_types, 
                         <legend class="visibloc-supported-blocks-legend">
                             <?php esc_html_e( 'Blocs compatibles', 'visi-bloc-jlg' ); ?>
                         </legend>
-                        <?php foreach ( $registered_block_types as $block ) :
-                            $block_name  = isset( $block['name'] ) && is_string( $block['name'] ) ? $block['name'] : '';
-                            $block_label = isset( $block['label'] ) && is_string( $block['label'] ) ? $block['label'] : $block_name;
-
-                            if ( '' === $block_name ) {
-                                continue;
-                            }
-
-                            $is_default  = in_array( $block_name, $default_blocks, true );
-                            $is_checked  = $is_default || in_array( $block_name, $configured_blocks, true );
-                            $is_disabled = $is_default;
+                        <div class="visibloc-supported-blocks-search" style="margin-bottom: 12px;">
+                            <?php
+                            $search_input_id = 'visibloc-supported-blocks-search';
                             ?>
-                            <label style="display: block; margin-bottom: 6px;">
-                                <input type="checkbox" name="visibloc_supported_blocks[]" value="<?php echo esc_attr( $block_name ); ?>" <?php checked( $is_checked ); ?> <?php disabled( $is_disabled ); ?> />
-                                <?php echo esc_html( $block_label ); ?>
-                                <span class="description" style="margin-left: 4px;">
-                                    (<?php echo esc_html( $block_name ); ?>)
-                                    <?php if ( $is_default ) : ?>
-                                        — <?php esc_html_e( 'Toujours actif', 'visi-bloc-jlg' ); ?>
-                                    <?php endif; ?>
-                                </span>
+                            <label for="<?php echo esc_attr( $search_input_id ); ?>" class="screen-reader-text">
+                                <?php esc_html_e( 'Rechercher un bloc', 'visi-bloc-jlg' ); ?>
                             </label>
-                        <?php endforeach; ?>
+                            <input
+                                type="search"
+                                id="<?php echo esc_attr( $search_input_id ); ?>"
+                                class="regular-text"
+                                placeholder="<?php echo esc_attr__( 'Rechercher un bloc…', 'visi-bloc-jlg' ); ?>"
+                                autocomplete="off"
+                                data-visibloc-blocks-search
+                                data-visibloc-blocks-target="visibloc-supported-blocks-list"
+                            />
+                        </div>
+                        <div
+                            id="visibloc-supported-blocks-list"
+                            class="visibloc-supported-blocks-list"
+                            data-visibloc-blocks-container
+                        >
+                            <?php foreach ( $registered_block_types as $block ) :
+                                $block_name  = isset( $block['name'] ) && is_string( $block['name'] ) ? $block['name'] : '';
+                                $block_label = isset( $block['label'] ) && is_string( $block['label'] ) ? $block['label'] : $block_name;
+
+                                if ( '' === $block_name ) {
+                                    continue;
+                                }
+
+                                $is_default  = in_array( $block_name, $default_blocks, true );
+                                $is_checked  = $is_default || in_array( $block_name, $configured_blocks, true );
+                                $is_disabled = $is_default;
+                                $search_text = wp_strip_all_tags( $block_label . ' ' . $block_name );
+                                $search_value = function_exists( 'mb_strtolower' )
+                                    ? mb_strtolower( $search_text )
+                                    : strtolower( $search_text );
+                                ?>
+                                <label
+                                    class="visibloc-supported-blocks-item"
+                                    data-visibloc-block
+                                    data-visibloc-search-value="<?php echo esc_attr( $search_value ); ?>"
+                                    style="display: block; margin-bottom: 6px;"
+                                >
+                                    <input type="checkbox" name="visibloc_supported_blocks[]" value="<?php echo esc_attr( $block_name ); ?>" <?php checked( $is_checked ); ?> <?php disabled( $is_disabled ); ?> />
+                                    <?php echo esc_html( $block_label ); ?>
+                                    <span class="description" style="margin-left: 4px;">
+                                        (<?php echo esc_html( $block_name ); ?>)
+                                        <?php if ( $is_default ) : ?>
+                                            — <?php esc_html_e( 'Toujours actif', 'visi-bloc-jlg' ); ?>
+                                        <?php endif; ?>
+                                    </span>
+                                </label>
+                            <?php endforeach; ?>
+                            <p class="visibloc-supported-blocks-empty" data-visibloc-blocks-empty hidden>
+                                <?php esc_html_e( 'Aucun bloc ne correspond à votre recherche.', 'visi-bloc-jlg' ); ?>
+                            </p>
+                        </div>
                     </fieldset>
                 <?php endif; ?>
                 <?php wp_nonce_field( 'visibloc_save_supported_blocks', 'visibloc_nonce' ); ?>

--- a/visi-bloc-jlg/includes/assets.php
+++ b/visi-bloc-jlg/includes/assets.php
@@ -76,6 +76,35 @@ function visibloc_jlg_enqueue_admin_styles( $hook_suffix ) {
     );
 }
 
+add_action( 'admin_enqueue_scripts', 'visibloc_jlg_enqueue_admin_supported_blocks_script' );
+function visibloc_jlg_enqueue_admin_supported_blocks_script( $hook_suffix ) {
+    if ( 'toplevel_page_visi-bloc-jlg-help' !== $hook_suffix ) {
+        return;
+    }
+
+    $plugin_main_file      = __DIR__ . '/../visi-bloc-jlg.php';
+    $script_relative_path  = 'assets/admin-supported-blocks.js';
+    $script_path           = plugin_dir_path( $plugin_main_file ) . $script_relative_path;
+    $default_script_version = defined( 'VISIBLOC_JLG_VERSION' ) ? VISIBLOC_JLG_VERSION : '1.1';
+    $script_version        = $default_script_version;
+
+    if ( file_exists( $script_path ) ) {
+        $file_version = filemtime( $script_path );
+
+        if ( false !== $file_version ) {
+            $script_version = (string) $file_version;
+        }
+    }
+
+    wp_enqueue_script(
+        'visibloc-jlg-supported-blocks-search',
+        plugins_url( $script_relative_path, $plugin_main_file ),
+        [],
+        $script_version,
+        true
+    );
+}
+
 add_action( 'enqueue_block_editor_assets', 'visibloc_jlg_enqueue_editor_assets' );
 function visibloc_jlg_enqueue_editor_assets() {
     $plugin_main_file = __DIR__ . '/../visi-bloc-jlg.php';


### PR DESCRIPTION
## Summary
- add a searchable input to the supported blocks settings section so long block lists are easier to navigate
- enqueue a lightweight admin script that filters the supported blocks checkboxes without changing existing save logic

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de6696d864832ead291d9e4b39ae67