### PR TITLE
Adapt mobile role switcher breakpoint to site options

### DIFF
--- a/visi-bloc-jlg/assets/role-switcher-frontend.css
+++ b/visi-bloc-jlg/assets/role-switcher-frontend.css
@@ -1,3 +1,7 @@
+:root {
+    --visibloc-role-switcher-max-width: 900px;
+}
+
 .visibloc-mobile-role-switcher {
     position: fixed;
     left: 0;
@@ -146,12 +150,6 @@
 @media (max-width: 900px) {
     .visibloc-mobile-role-switcher {
         display: flex;
-    }
-}
-
-@media (min-width: 901px) {
-    .visibloc-mobile-role-switcher {
-        display: none;
     }
 }
 


### PR DESCRIPTION
## Summary
- expose the saved mobile/tablet breakpoints in the mobile role switcher model and compute a toggle threshold used across PHP, CSS, and JS
- inject inline CSS that sets the `--visibloc-role-switcher-max-width` variable and media queries so the toggle honours customised breakpoints
- add integration coverage to confirm the frontend model reflects default and custom breakpoint configurations

## Testing
- composer run test:phpunit

------
https://chatgpt.com/codex/tasks/task_e_68de6d4e9840832ead1d8a56e4718158