### PR TITLE
Improve supported blocks search filtering

### DIFF
--- a/visi-bloc-jlg/assets/admin-supported-blocks.js
+++ b/visi-bloc-jlg/assets/admin-supported-blocks.js
@@ -1,6 +1,20 @@
 (function () {
     'use strict';
 
+    var normalizeText = function (value) {
+        if (value === null || value === undefined) {
+            return '';
+        }
+
+        var normalized = String(value).trim().toLowerCase();
+
+        if (normalized && typeof normalized.normalize === 'function') {
+            normalized = normalized.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+        }
+
+        return normalized;
+    };
+
     var initSearch = function (input) {
         var targetId = input.getAttribute('data-visibloc-blocks-target');
         if (!targetId) {
@@ -23,14 +37,27 @@
         var countMessage = container.querySelector('[data-visibloc-blocks-count]');
         var countTemplate = countMessage ? countMessage.getAttribute('data-visibloc-count-template') : '';
 
+        var getNormalizedSearchValue = function (item) {
+            var cached = item.getAttribute('data-visibloc-search-cache');
+
+            if (cached !== null) {
+                return cached;
+            }
+
+            var normalized = normalizeText(item.getAttribute('data-visibloc-search-value') || '');
+            item.setAttribute('data-visibloc-search-cache', normalized);
+
+            return normalized;
+        };
+
         var toggleItems = function () {
-            var query = input.value || '';
-            var normalizedQuery = query.trim().toLowerCase();
+            var normalizedQuery = normalizeText(input.value || '');
+            var hasQuery = normalizedQuery.length > 0;
             var visibleCount = 0;
 
             items.forEach(function (item) {
-                var searchValue = item.getAttribute('data-visibloc-search-value') || '';
-                var isVisible = !normalizedQuery || searchValue.indexOf(normalizedQuery) !== -1;
+                var searchValue = getNormalizedSearchValue(item);
+                var isVisible = !hasQuery || searchValue.indexOf(normalizedQuery) !== -1;
 
                 item.style.display = isVisible ? '' : 'none';
 

--- a/visi-bloc-jlg/includes/admin-settings.php
+++ b/visi-bloc-jlg/includes/admin-settings.php
@@ -257,6 +257,7 @@ function visibloc_jlg_render_supported_blocks_section( $registered_block_types, 
                                 aria-describedby="<?php echo esc_attr( $search_description_id ); ?>"
                                 data-visibloc-blocks-search
                                 data-visibloc-blocks-target="visibloc-supported-blocks-list"
+                                aria-controls="visibloc-supported-blocks-list"
                             />
                             <p id="<?php echo esc_attr( $search_description_id ); ?>" class="description" style="margin-top: 4px;">
                                 <?php esc_html_e( 'Saisissez un terme pour filtrer la liste des blocs disponibles.', 'visi-bloc-jlg' ); ?>
@@ -279,9 +280,13 @@ function visibloc_jlg_render_supported_blocks_section( $registered_block_types, 
                                 $is_checked  = $is_default || in_array( $block_name, $configured_blocks, true );
                                 $is_disabled = $is_default;
                                 $search_text = wp_strip_all_tags( $block_label . ' ' . $block_name );
+                                $search_value = function_exists( 'remove_accents' )
+                                    ? remove_accents( $search_text )
+                                    : $search_text;
+
                                 $search_value = function_exists( 'mb_strtolower' )
-                                    ? mb_strtolower( $search_text )
-                                    : strtolower( $search_text );
+                                    ? mb_strtolower( $search_value, 'UTF-8' )
+                                    : strtolower( $search_value );
                                 ?>
                                 <label
                                     class="visibloc-supported-blocks-item"


### PR DESCRIPTION
## Summary
- make the supported blocks search input reference the filtered list for accessibility
- normalize the server-provided search values to strip accents before comparison
- update the admin search script to reuse normalized values and perform accent-insensitive filtering

## Testing
- php -l visi-bloc-jlg/includes/admin-settings.php

------
https://chatgpt.com/codex/tasks/task_e_68de9f4dbac8832ebb38a3f0f3b70d37