### PR TITLE
Add sticky navigation to help page sections

### DIFF
--- a/visi-bloc-jlg/assets/admin-responsive.css
+++ b/visi-bloc-jlg/assets/admin-responsive.css
@@ -45,6 +45,11 @@
 
 .visibloc-help-nav {
     position: relative;
+    background: #fff;
+    border: 1px solid #dcdcde;
+    border-radius: 8px;
+    padding: 12px;
+    box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
 }
 
 .visibloc-help-nav__list {
@@ -56,6 +61,7 @@
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
     scroll-snap-type: x proximity;
+    scroll-padding-inline: 12px;
 }
 
 .visibloc-help-nav__item {
@@ -65,6 +71,7 @@
 
 .visibloc-help-nav__link {
     display: block;
+    min-width: 180px;
     padding: 10px 16px;
     border-radius: 6px;
     border: 1px solid #dcdcde;
@@ -72,6 +79,7 @@
     color: #1d2327;
     text-decoration: none;
     font-weight: 600;
+    text-align: center;
     transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
@@ -87,7 +95,40 @@
     outline: none;
 }
 
+.visibloc-help-nav__list::-webkit-scrollbar {
+    height: 6px;
+}
+
+.visibloc-help-nav__list::-webkit-scrollbar-thumb {
+    background: rgba(0, 0, 0, 0.2);
+    border-radius: 999px;
+}
+
+.visibloc-help-nav__list::-webkit-scrollbar-track {
+    background: transparent;
+}
+
 @media (max-width: 782px) {
+    .visibloc-help-nav {
+        margin: 0 -12px;
+        border-radius: 0;
+        border-left: 0;
+        border-right: 0;
+        box-shadow: none;
+    }
+
+    .visibloc-help-nav__list {
+        padding: 4px 12px 12px;
+    }
+
+    .visibloc-help-nav__item {
+        min-width: 70%;
+    }
+
+    .visibloc-help-nav__link {
+        text-align: left;
+    }
+
     .visibloc-admin-post-list {
         list-style: none;
         padding-left: 0;
@@ -182,12 +223,14 @@
     .visibloc-help-nav {
         position: sticky;
         top: 32px;
+        align-self: start;
     }
 
     .visibloc-help-nav__list {
         display: grid;
         gap: 8px;
         overflow: visible;
+        grid-auto-rows: minmax(0, 1fr);
     }
 
     .visibloc-help-nav__item {
@@ -195,6 +238,7 @@
     }
 
     .visibloc-help-nav__link {
+        min-width: unset;
         width: 100%;
     }
 }

--- a/visi-bloc-jlg/includes/admin-settings.php
+++ b/visi-bloc-jlg/includes/admin-settings.php
@@ -426,40 +426,58 @@ function visibloc_jlg_render_help_page_content() {
 
     $sections = [
         [
-            'id'    => 'visibloc-section-blocks',
-            'label' => __( 'Blocs compatibles', 'visi-bloc-jlg' ),
+            'id'      => 'visibloc-section-blocks',
+            'label'   => __( 'Blocs compatibles', 'visi-bloc-jlg' ),
+            'render'  => 'visibloc_jlg_render_supported_blocks_section',
+            'args'    => [ $registered_block_types, $configured_blocks ],
         ],
         [
-            'id'    => 'visibloc-section-permissions',
-            'label' => __( "Permissions d'Aperçu", 'visi-bloc-jlg' ),
+            'id'      => 'visibloc-section-permissions',
+            'label'   => __( "Permissions d'Aperçu", 'visi-bloc-jlg' ),
+            'render'  => 'visibloc_jlg_render_permissions_section',
+            'args'    => [ $allowed_roles ],
         ],
         [
-            'id'    => 'visibloc-section-hidden',
-            'label' => __( 'Tableau de bord des blocs masqués (via Œil)', 'visi-bloc-jlg' ),
+            'id'      => 'visibloc-section-hidden',
+            'label'   => __( 'Tableau de bord des blocs masqués (via Œil)', 'visi-bloc-jlg' ),
+            'render'  => 'visibloc_jlg_render_hidden_blocks_section',
+            'args'    => [ $hidden_posts ],
         ],
         [
-            'id'    => 'visibloc-section-device',
-            'label' => __( 'Tableau de bord des blocs avec visibilité par appareil', 'visi-bloc-jlg' ),
+            'id'      => 'visibloc-section-device',
+            'label'   => __( 'Tableau de bord des blocs avec visibilité par appareil', 'visi-bloc-jlg' ),
+            'render'  => 'visibloc_jlg_render_device_visibility_section',
+            'args'    => [ $device_posts ],
         ],
         [
-            'id'    => 'visibloc-section-scheduled',
-            'label' => __( 'Tableau de bord des blocs programmés', 'visi-bloc-jlg' ),
+            'id'      => 'visibloc-section-scheduled',
+            'label'   => __( 'Tableau de bord des blocs programmés', 'visi-bloc-jlg' ),
+            'render'  => 'visibloc_jlg_render_scheduled_blocks_section',
+            'args'    => [ $scheduled_posts ],
         ],
         [
-            'id'    => 'visibloc-section-debug',
-            'label' => __( 'Mode de débogage', 'visi-bloc-jlg' ),
+            'id'      => 'visibloc-section-debug',
+            'label'   => __( 'Mode de débogage', 'visi-bloc-jlg' ),
+            'render'  => 'visibloc_jlg_render_debug_mode_section',
+            'args'    => [ $debug_status ],
         ],
         [
-            'id'    => 'visibloc-section-backup',
-            'label' => __( 'Export & sauvegarde', 'visi-bloc-jlg' ),
+            'id'      => 'visibloc-section-breakpoints',
+            'label'   => __( 'Réglage des points de rupture', 'visi-bloc-jlg' ),
+            'render'  => 'visibloc_jlg_render_breakpoints_section',
+            'args'    => [ $mobile_bp, $tablet_bp ],
         ],
         [
-            'id'    => 'visibloc-section-breakpoints',
-            'label' => __( 'Réglage des points de rupture', 'visi-bloc-jlg' ),
+            'id'      => 'visibloc-section-fallback',
+            'label'   => __( 'Contenu de repli global', 'visi-bloc-jlg' ),
+            'render'  => 'visibloc_jlg_render_fallback_section',
+            'args'    => [ $fallback_settings, $fallback_blocks ],
         ],
         [
-            'id'    => 'visibloc-section-fallback',
-            'label' => __( 'Contenu de repli global', 'visi-bloc-jlg' ),
+            'id'      => 'visibloc-section-backup',
+            'label'   => __( 'Export & sauvegarde', 'visi-bloc-jlg' ),
+            'render'  => 'visibloc_jlg_render_settings_backup_section',
+            'args'    => [],
         ],
     ];
 
@@ -500,17 +518,19 @@ function visibloc_jlg_render_help_page_content() {
                 </ul>
             </nav>
             <div id="poststuff" class="visibloc-help-layout__content">
-                <?php
-                visibloc_jlg_render_supported_blocks_section( $registered_block_types, $configured_blocks );
-                visibloc_jlg_render_permissions_section( $allowed_roles );
-                visibloc_jlg_render_hidden_blocks_section( $hidden_posts );
-                visibloc_jlg_render_device_visibility_section( $device_posts );
-                visibloc_jlg_render_scheduled_blocks_section( $scheduled_posts );
-                visibloc_jlg_render_debug_mode_section( $debug_status );
-                visibloc_jlg_render_breakpoints_section( $mobile_bp, $tablet_bp );
-                visibloc_jlg_render_fallback_section( $fallback_settings, $fallback_blocks );
-                visibloc_jlg_render_settings_backup_section();
-                ?>
+                <?php foreach ( $sections as $section ) :
+                    $callback = $section['render'] ?? null;
+
+                    if ( empty( $callback ) || ! is_callable( $callback ) ) {
+                        continue;
+                    }
+
+                    $args = isset( $section['args'] ) && is_array( $section['args'] )
+                        ? $section['args']
+                        : [];
+
+                    call_user_func_array( $callback, $args );
+                endforeach; ?>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- build a declarative list of help sections to render both the navigation and the content
- add a responsive, sticky navigation component with accessible styling for the help page

## Testing
- php -l visi-bloc-jlg/includes/admin-settings.php

------
https://chatgpt.com/codex/tasks/task_e_68df96350230832e88a35591232667dc