### PR TITLE
Ensure role switcher toggle regains focus after outside click close

### DIFF
--- a/visi-bloc-jlg/assets/role-switcher-frontend.js
+++ b/visi-bloc-jlg/assets/role-switcher-frontend.js
@@ -341,6 +341,9 @@
 
             if (!container.contains(event.target)) {
                 closePanel();
+                if (toggle && typeof toggle.focus === 'function') {
+                    toggle.focus();
+                }
             }
         });
 


### PR DESCRIPTION
## Summary
- return focus to the role switcher toggle when the panel closes via outside clicks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfc19ff960832e8559b1da4c0da9d1