### PR TITLE
Improve scheduled blocks table accessibility

### DIFF
--- a/visi-bloc-jlg/assets/admin-responsive.css
+++ b/visi-bloc-jlg/assets/admin-responsive.css
@@ -175,7 +175,16 @@
     }
 
     .visibloc-admin-scheduled-table thead {
-        display: none;
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        margin: -1px;
+        padding: 0;
+        overflow: hidden;
+        clip: rect(0 0 0 0);
+        clip-path: inset(50%);
+        border: 0;
+        white-space: nowrap;
     }
 
     .visibloc-admin-scheduled-table tbody {
@@ -205,8 +214,7 @@
         margin-bottom: 0;
     }
 
-    .visibloc-admin-scheduled-table td::before {
-        content: attr(data-label);
+    .visibloc-table-label {
         display: block;
         font-weight: 600;
         margin-bottom: 4px;
@@ -240,5 +248,9 @@
     .visibloc-help-nav__link {
         min-width: unset;
         width: 100%;
+    }
+
+    .visibloc-table-label {
+        display: none;
     }
 }

--- a/visi-bloc-jlg/includes/admin-settings.php
+++ b/visi-bloc-jlg/includes/admin-settings.php
@@ -770,11 +770,18 @@ function visibloc_jlg_render_scheduled_blocks_section( $scheduled_posts ) {
                             $end_display   = null !== $end_datetime ? wp_date( $datetime_format, $end_datetime->getTimestamp() ) : '–';
                             ?>
                             <tr>
-                                <td data-label="<?php echo esc_attr( $title_column_label ); ?>">
+                                <td>
+                                    <span class="visibloc-table-label"><?php echo esc_html( $title_column_label ); ?></span>
                                     <a href="<?php echo esc_url( $scheduled_block['link'] ); ?>"><?php echo esc_html( $scheduled_block['title'] ); ?></a>
                                 </td>
-                                <td data-label="<?php echo esc_attr( $start_column_label ); ?>"><?php echo esc_html( $start_display ); ?></td>
-                                <td data-label="<?php echo esc_attr( $end_column_label ); ?>"><?php echo esc_html( $end_display ); ?></td>
+                                <td>
+                                    <span class="visibloc-table-label"><?php echo esc_html( $start_column_label ); ?></span>
+                                    <?php echo esc_html( $start_display ); ?>
+                                </td>
+                                <td>
+                                    <span class="visibloc-table-label"><?php echo esc_html( $end_column_label ); ?></span>
+                                    <?php echo esc_html( $end_display ); ?>
+                                </td>
                             </tr>
                         <?php endforeach; ?>
                         </tbody>


### PR DESCRIPTION
## Summary
- keep the scheduled blocks table header accessible on small screens instead of removing it from the DOM
- render column labels directly inside each table cell for the mobile layout and style them without pseudo-elements

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfc1a263c4832ea1cac72593e547e8