### PR TITLE
Ensure mobile role switcher toggle regains focus

### DIFF
--- a/visi-bloc-jlg/assets/role-switcher-frontend.js
+++ b/visi-bloc-jlg/assets/role-switcher-frontend.js
@@ -319,6 +319,12 @@
             toggle.setAttribute('aria-expanded', 'false');
         }
 
+        function focusToggle() {
+            if (toggle && typeof toggle.focus === 'function') {
+                toggle.focus();
+            }
+        }
+
         toggle.addEventListener('click', function () {
             if (container.classList.contains(openClass)) {
                 closePanel();
@@ -330,7 +336,7 @@
         Array.prototype.forEach.call(closeButtons, function (button) {
             button.addEventListener('click', function () {
                 closePanel();
-                toggle.focus();
+                focusToggle();
             });
         });
 
@@ -341,16 +347,14 @@
 
             if (!container.contains(event.target)) {
                 closePanel();
-                if (toggle && typeof toggle.focus === 'function') {
-                    toggle.focus();
-                }
+                focusToggle();
             }
         });
 
         container.addEventListener('keydown', function (event) {
             if ('Escape' === event.key || 'Esc' === event.key) {
                 closePanel();
-                toggle.focus();
+                focusToggle();
 
                 return;
             }


### PR DESCRIPTION
## Summary
- add a helper to safely restore focus to the role switcher toggle when closing the panel
- apply the helper to close interactions, including document click handlers, to avoid errors when the toggle is unavailable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfcc9ed6c4832eb5538d1e16d8b037