### PR TITLE
Adjust schedule badge contrast

### DIFF
--- a/visi-bloc-jlg/admin-styles.css
+++ b/visi-bloc-jlg/admin-styles.css
@@ -32,8 +32,8 @@
     position: absolute;
     top: -12px;
     right: 10px;
-    background-color: #4CAF50;
-    color: white;
+    background-color: #2E7D32;
+    color: #fff;
     padding: 2px 8px;
     font-size: 11px;
     border-radius: 4px;


### PR DESCRIPTION
## Summary
- darken the schedule badge background to #2E7D32
- keep white text to preserve readability against the new background

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfcca25458832ea5032acff68cdf70