### PR TITLE
Replace device visibility select with segmented control

### DIFF
--- a/visi-bloc-jlg/src/editor-styles.css
+++ b/visi-bloc-jlg/src/editor-styles.css
@@ -2,6 +2,22 @@
     margin-bottom: 16px;
 }
 
+.visi-bloc-device-toggle-groups {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.visi-bloc-device-toggle-group {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.visi-bloc-device-toggle-reset {
+    align-self: flex-start;
+}
+
 .visi-bloc-datepicker-wrapper {
     margin-bottom: 16px;
     padding-left: 20px;

--- a/visi-bloc-jlg/tests/e2e/specs/visibility-controls.spec.js
+++ b/visi-bloc-jlg/tests/e2e/specs/visibility-controls.spec.js
@@ -91,8 +91,12 @@ async function exerciseVisibilityControls( { admin, editor, page }, blockName ) 
 
     await page.getByRole( 'button', { name: 'Settings' } ).click();
 
-    const deviceSelect = page.getByLabel( 'Visibilité par Appareil' );
-    await deviceSelect.selectOption( 'desktop-only' );
+    const deviceToggleGroups = page.locator( '.visi-bloc-device-toggle-group' );
+    await expect( deviceToggleGroups.first() ).toBeVisible();
+    await deviceToggleGroups
+        .first()
+        .getByRole( 'button', { name: 'Desktop' } )
+        .click();
 
     await page.getByRole( 'button', { name: 'Programmation' } ).click();
 
@@ -208,8 +212,12 @@ test.describe( 'Visi-Bloc group visibility controls', () => {
         const fallbackButton = getPanelButton( 'Contenu de repli' );
         await expect( fallbackButton.locator( '.components-panel__summary' ) ).not.toHaveText( 'Inactif' );
 
-        await page.getByLabel( 'Visibilité par Appareil' ).selectOption( 'desktop-only' );
-        await expectSummary( 'Contrôles de Visibilité', 'Desktop Uniquement' );
+        const visibilityGroups = page.locator( '.visi-bloc-device-toggle-group' );
+        await visibilityGroups
+            .first()
+            .getByRole( 'button', { name: 'Desktop' } )
+            .click();
+        await expectSummary( 'Contrôles de Visibilité', 'Afficher uniquement – Desktop' );
 
         const schedulingToggle = page.getByRole( 'checkbox', { name: 'Activer la programmation' } );
         await schedulingToggle.check();


### PR DESCRIPTION
## Summary
- replace the device visibility select in the inspector with segmented toggle groups and a reset action
- refactor device visibility option data and summaries to work with the new grouped structure
- add spacing styles for the segmented controls and update end-to-end tests to match the new UI

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dff7ebfae8832ead148a475d1546de