### PR TITLE
Switch device visibility control to segmented toggle

### DIFF
--- a/visi-bloc-jlg/src/editor-styles.css
+++ b/visi-bloc-jlg/src/editor-styles.css
@@ -14,6 +14,10 @@
     gap: 8px;
 }
 
+.visi-bloc-device-toggle .components-segmented-control__button {
+    gap: 6px;
+}
+
 .visi-bloc-device-toggle-reset {
     align-self: flex-start;
 }

--- a/visi-bloc-jlg/src/index.js
+++ b/visi-bloc-jlg/src/index.js
@@ -7,6 +7,7 @@ import {
     ToolbarGroup,
     ToolbarButton,
     PanelBody,
+    SelectControl,
     ToggleGroupControl,
     ToggleGroupControlOptionIcon,
     ToggleControl,


### PR DESCRIPTION
## Summary
- replace the device visibility select with grouped segmented toggles using icons for desktop, tablet, and mobile
- adapt the device visibility options data and summary helper to work with grouped options while preserving saved class names
- add editor styling to space the new segmented buttons for better readability

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e034c0b2dc832e997cae4799b2b593