### PR TITLE
Support complex recurring schedules with multiple intervals

### DIFF
--- a/visi-bloc-jlg/tests/phpunit/bootstrap.php
+++ b/visi-bloc-jlg/tests/phpunit/bootstrap.php
@@ -128,6 +128,9 @@ function visibloc_test_reset_state() {
     ];
 
     visibloc_test_reset_request_environment();
+
+    $GLOBALS['visibloc_test_object_cache'] = [];
+    $GLOBALS['visibloc_test_transients']   = [];
 }
 
 function visibloc_test_set_timezone( $timezone_string ) {
@@ -360,6 +363,12 @@ function sanitize_key( $key ) {
 
 function wp_unslash( $value ) {
     return $value;
+}
+
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+    function wp_strip_all_tags( $string ) {
+        return trim( strip_tags( (string) $string ) );
+    }
 }
 
 function current_time( $type, $gmt = 0 ) {


### PR DESCRIPTION
## Summary
- extend the editor recurring schedule UI to manage multiple time intervals and new monthly/custom date frequencies
- normalize and evaluate recurring schedules in PHP with interval-aware logic and additional frequency support
- add unit coverage and bootstrap stubs for the expanded scheduling behaviours

## Testing
- `composer test:phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68e03aa5fc10832eb4db5e4e23c9a0f4