### PR TITLE
Delay fallback initialization until needed

### DIFF
--- a/visi-bloc-jlg/includes/visibility-logic.php
+++ b/visi-bloc-jlg/includes/visibility-logic.php
@@ -51,7 +51,17 @@ function visibloc_jlg_render_block_filter( $block_content, $block ) {
     if ( empty( $block['attrs'] ) ) { return $block_content; }
 
     $attrs = $block['attrs'];
-    $fallback_markup = visibloc_jlg_get_block_fallback_markup( $attrs );
+
+    $fallback_markup = null;
+    $fallback_initialized = false;
+    $get_fallback_markup = static function () use ( &$fallback_markup, &$fallback_initialized, $attrs ) {
+        if ( ! $fallback_initialized ) {
+            $fallback_markup     = visibloc_jlg_get_block_fallback_markup( $attrs );
+            $fallback_initialized = true;
+        }
+
+        return $fallback_markup;
+    };
 
     $visibility_roles = [];
 
@@ -179,9 +189,9 @@ function visibloc_jlg_render_block_filter( $block_content, $block ) {
                         ) .
                     '</div>';
 
-                    return visibloc_jlg_wrap_preview_with_fallback_notice( $schedule_preview_markup, $fallback_markup );
+                    return visibloc_jlg_wrap_preview_with_fallback_notice( $schedule_preview_markup, $get_fallback_markup() );
                 }
-                return $fallback_markup;
+                return $get_fallback_markup();
             }
         }
     }
@@ -207,7 +217,7 @@ function visibloc_jlg_render_block_filter( $block_content, $block ) {
                 $hidden_preview_markup = $advanced_markup;
                 $has_preview_markup    = true;
             } else {
-                return $fallback_markup;
+                return $get_fallback_markup();
             }
         }
     }
@@ -277,23 +287,23 @@ function visibloc_jlg_render_block_filter( $block_content, $block ) {
         if ( ! $is_visible && ! empty( $user_roles ) && count( array_intersect( $user_roles, $visibility_roles ) ) > 0 ) { $is_visible = true; }
         if ( ! $is_visible ) {
             if ( $has_preview_markup && null !== $hidden_preview_markup ) {
-                return visibloc_jlg_wrap_preview_with_fallback_notice( $hidden_preview_markup, $fallback_markup );
+                return visibloc_jlg_wrap_preview_with_fallback_notice( $hidden_preview_markup, $get_fallback_markup() );
             }
 
-            return $fallback_markup;
+            return $get_fallback_markup();
         }
     }
 
     if ( $has_hidden_flag ) {
         if ( $has_preview_markup && null !== $hidden_preview_markup ) {
-            return visibloc_jlg_wrap_preview_with_fallback_notice( $hidden_preview_markup, $fallback_markup );
+            return visibloc_jlg_wrap_preview_with_fallback_notice( $hidden_preview_markup, $get_fallback_markup() );
         }
 
-        return $fallback_markup;
+        return $get_fallback_markup();
     }
 
     if ( $has_preview_markup && null !== $hidden_preview_markup ) {
-        return visibloc_jlg_wrap_preview_with_fallback_notice( $hidden_preview_markup, $fallback_markup );
+        return visibloc_jlg_wrap_preview_with_fallback_notice( $hidden_preview_markup, $get_fallback_markup() );
     }
 
     return $block_content;

--- a/visi-bloc-jlg/tests/phpunit/integration/VisibilityLogicTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/VisibilityLogicTest.php
@@ -13,6 +13,48 @@ class VisibilityLogicTest extends TestCase {
         }
     }
 
+    public function test_blocks_without_visibility_rules_do_not_initialize_fallback(): void {
+        $filter_calls = 0;
+        $hook = 'pre_option_visibloc_fallback_settings';
+
+        $previous_filters = $GLOBALS['visibloc_test_filters'][ $hook ] ?? null;
+
+        $callback = static function ( $pre_value ) use ( &$filter_calls ) {
+            $filter_calls++;
+
+            return $pre_value;
+        };
+
+        add_filter( $hook, $callback );
+
+        try {
+            $block = [
+                'blockName' => 'core/group',
+                'attrs'     => [],
+            ];
+
+            $content = '<p>Visible block</p>';
+
+            $this->assertSame(
+                $content,
+                visibloc_jlg_render_block_filter( $content, $block ),
+                'Blocks without visibility settings should render as-is.'
+            );
+
+            $this->assertSame(
+                0,
+                $filter_calls,
+                'Fallback settings should not be loaded when no visibility rules are present.'
+            );
+        } finally {
+            if ( null === $previous_filters ) {
+                unset( $GLOBALS['visibloc_test_filters'][ $hook ] );
+            } else {
+                $GLOBALS['visibloc_test_filters'][ $hook ] = $previous_filters;
+            }
+        }
+    }
+
     public function test_administrator_impersonating_editor_sees_editor_view_without_hidden_blocks(): void {
         global $visibloc_test_state;
 


### PR DESCRIPTION
## Summary
- lazily resolve fallback markup in the visibility logic only when required
- ensure all branches share the same fallback markup instance once computed
- add an integration test covering the absence of fallback rendering for blocks without visibility rules

## Testing
- composer test:phpunit

------
https://chatgpt.com/codex/tasks/task_e_68e0e9da8c70832e933851f87cc57f16