### PR TITLE
Clean uninstall fallback and device CSS caches

### DIFF
--- a/visi-bloc-jlg/tests/phpunit/integration/UninstallCleanupTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/UninstallCleanupTest.php
@@ -68,4 +68,53 @@ class UninstallCleanupTest extends TestCase {
         $this->assertFalse( get_transient( 'visibloc_jlg_missing_editor_assets' ) );
         $this->assertFalse( wp_cache_get( 'visibloc_device_css_cache', 'visibloc_jlg' ) );
     }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_uninstall_removes_fallback_settings_and_device_css_transients(): void {
+        $bucket_keys = [ 'bucket-one', 'bucket-two' ];
+
+        update_option( 'visibloc_fallback_settings', [ 'mobile' => 'hidden' ] );
+        update_option( 'visibloc_device_css_transients', $bucket_keys );
+
+        foreach ( $bucket_keys as $bucket_key ) {
+            $transient_name = sprintf( 'visibloc_device_css_%s', $bucket_key );
+
+            set_transient( $transient_name, 'css-' . $bucket_key, 0 );
+            wp_cache_set( $transient_name, [ 'cached' => true ], 'visibloc_jlg' );
+
+            $this->assertSame( 'css-' . $bucket_key, get_transient( $transient_name ) );
+            $this->assertSame(
+                [ 'cached' => true ],
+                wp_cache_get( $transient_name, 'visibloc_jlg' )
+            );
+        }
+
+        $this->assertSame( [ 'mobile' => 'hidden' ], get_option( 'visibloc_fallback_settings' ) );
+        $this->assertSame( $bucket_keys, get_option( 'visibloc_device_css_transients' ) );
+
+        if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+            define( 'WP_UNINSTALL_PLUGIN', true );
+        }
+
+        require dirname( __DIR__, 3 ) . '/uninstall.php';
+
+        $this->assertSame(
+            '__default__',
+            get_option( 'visibloc_fallback_settings', '__default__' )
+        );
+        $this->assertSame(
+            '__default__',
+            get_option( 'visibloc_device_css_transients', '__default__' )
+        );
+
+        foreach ( $bucket_keys as $bucket_key ) {
+            $transient_name = sprintf( 'visibloc_device_css_%s', $bucket_key );
+
+            $this->assertFalse( get_transient( $transient_name ) );
+            $this->assertFalse( wp_cache_get( $transient_name, 'visibloc_jlg' ) );
+        }
+    }
 }

--- a/visi-bloc-jlg/uninstall.php
+++ b/visi-bloc-jlg/uninstall.php
@@ -8,6 +8,7 @@ delete_option( 'visibloc_breakpoint_tablet' );
 delete_option( 'visibloc_preview_roles' );
 delete_option( 'visibloc_group_block_summary' );
 delete_option( 'visibloc_supported_blocks' );
+delete_option( 'visibloc_fallback_settings' );
 
 // Supprime les transients de cache du plugin
 delete_transient( 'visibloc_hidden_posts' );
@@ -15,5 +16,22 @@ delete_transient( 'visibloc_device_posts' );
 delete_transient( 'visibloc_scheduled_posts' );
 delete_transient( 'visibloc_group_block_metadata' );
 delete_transient( 'visibloc_jlg_missing_editor_assets' );
+
+$registered_buckets = get_option( 'visibloc_device_css_transients', [] );
+
+if ( is_array( $registered_buckets ) ) {
+    foreach ( array_unique( array_map( 'strval', $registered_buckets ) ) as $bucket_key ) {
+        if ( '' === $bucket_key ) {
+            continue;
+        }
+
+        $transient_name = sprintf( 'visibloc_device_css_%s', $bucket_key );
+
+        delete_transient( $transient_name );
+        wp_cache_delete( $transient_name, 'visibloc_jlg' );
+    }
+}
+
+delete_option( 'visibloc_device_css_transients' );
 
 wp_cache_delete( 'visibloc_device_css_cache', 'visibloc_jlg' );


### PR DESCRIPTION
## Summary
- delete the fallback settings option during plugin uninstall
- remove registered device CSS transients and their object cache entries when uninstalling
- expand uninstall cleanup integration coverage to prevent regressions

## Testing
- composer test:phpunit

------
https://chatgpt.com/codex/tasks/task_e_68e0e9d930c8832e9994f38f45435775