### PR TITLE
Handle fallback settings in snapshot import/export

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Visi-Bloc – JLG is a WordPress plugin that adds advanced visibility controls t
 - **Role-based visibility** – restrict blocks to selected roles or to logged-in/out visitors.
 - **Scheduling** – set start and end dates for blocks to appear.
 - **Manual hide** – hide blocks from the front end while still previewable to permitted roles.
+- **Global fallback content** – define the markup shown when a block is hidden and keep it in sync through settings export/import snapshots.
 - **Device visibility utilities** – apply classes like `vb-hide-on-mobile`, `vb-mobile-only`, `vb-tablet-only`, or `vb-desktop-only` to control display by screen width. The generated CSS now includes a `display` fallback to support browsers that lack `display: revert`.
 - **Role preview switcher** – administrators (or roles explicitly granted via the `visibloc_jlg_allowed_impersonator_roles` filter) can preview the site as another role from the toolbar.
 - **Accessible mobile role switcher** – the front-end dialog now traps keyboard focus, keeps the toggle expanded until dismissed, and marks the rest of the page with `inert`/`aria-hidden` while open to avoid accidental interactions.

--- a/visi-bloc-jlg/includes/admin-settings.php
+++ b/visi-bloc-jlg/includes/admin-settings.php
@@ -221,6 +221,7 @@ function visibloc_jlg_get_settings_snapshot() {
         ],
         'preview_roles'    => $preview_roles,
         'debug_mode'       => ( 'on' === $debug_mode ) ? 'on' : 'off',
+        'fallback'         => visibloc_jlg_get_fallback_settings(),
         'exported_at'      => gmdate( 'c' ),
         'version'          => defined( 'VISIBLOC_JLG_VERSION' ) ? VISIBLOC_JLG_VERSION : 'unknown',
     ];
@@ -284,6 +285,10 @@ function visibloc_jlg_import_settings_snapshot( $payload ) {
         update_option( 'visibloc_debug_mode', $sanitized['debug_mode'] );
     }
 
+    if ( isset( $sanitized['fallback'] ) ) {
+        update_option( 'visibloc_fallback_settings', $sanitized['fallback'] );
+    }
+
     visibloc_jlg_clear_caches();
 
     return true;
@@ -337,6 +342,14 @@ function visibloc_jlg_sanitize_import_settings( $data ) {
         $sanitized['debug_mode'] = $debug_mode;
     }
 
+    if ( array_key_exists( 'fallback', $data ) ) {
+        if ( ! is_array( $data['fallback'] ) ) {
+            return new WP_Error( 'visibloc_invalid_fallback_settings', __( 'Les réglages de repli sont invalides.', 'visi-bloc-jlg' ) );
+        }
+
+        $sanitized['fallback'] = visibloc_jlg_normalize_fallback_settings( $data['fallback'] );
+    }
+
     return $sanitized;
 }
 
@@ -348,6 +361,8 @@ function visibloc_jlg_get_import_error_message( $code ) {
             return __( 'Les données importées sont invalides.', 'visi-bloc-jlg' );
         case 'visibloc_invalid_breakpoints':
             return visibloc_jlg_get_breakpoints_requirement_message();
+        case 'visibloc_invalid_fallback_settings':
+            return __( 'Les réglages de repli sont invalides.', 'visi-bloc-jlg' );
         case 'visibloc_empty_payload':
             return __( 'Aucune donnée fournie pour l’import.', 'visi-bloc-jlg' );
     }

--- a/visi-bloc-jlg/includes/fallback.php
+++ b/visi-bloc-jlg/includes/fallback.php
@@ -60,14 +60,19 @@ function visibloc_jlg_normalize_fallback_settings( $value ) {
 /**
  * Retrieve the configured fallback settings.
  *
+ * @param bool $reset_cache Optional. Whether to reset the cached value.
  * @return array{
  *     mode: string,
  *     text: string,
  *     block_id: int,
  * }
  */
-function visibloc_jlg_get_fallback_settings() {
+function visibloc_jlg_get_fallback_settings( $reset_cache = false ) {
     static $cache = null;
+
+    if ( $reset_cache ) {
+        $cache = null;
+    }
 
     if ( null !== $cache ) {
         return $cache;
@@ -142,10 +147,15 @@ function visibloc_jlg_render_reusable_block_fallback( $block_id ) {
 /**
  * Retrieve the global fallback markup.
  *
+ * @param bool $reset_cache Optional. Whether to reset the cached markup.
  * @return string
  */
-function visibloc_jlg_get_global_fallback_markup() {
+function visibloc_jlg_get_global_fallback_markup( $reset_cache = false ) {
     static $cache = null;
+
+    if ( $reset_cache ) {
+        $cache = null;
+    }
 
     if ( null !== $cache ) {
         return $cache;

--- a/visi-bloc-jlg/tests/phpunit/integration/SettingsSnapshotImportExportTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/SettingsSnapshotImportExportTest.php
@@ -1,0 +1,77 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class SettingsSnapshotImportExportTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        if ( ! function_exists( 'visibloc_jlg_get_settings_snapshot' ) ) {
+            require_once dirname( __DIR__, 3 ) . '/includes/admin-settings.php';
+        }
+
+        visibloc_test_reset_state();
+
+        $GLOBALS['visibloc_posts']           = [];
+        $GLOBALS['visibloc_test_options']    = [];
+        $GLOBALS['visibloc_test_transients'] = [];
+
+        visibloc_jlg_get_fallback_settings( true );
+        visibloc_jlg_get_global_fallback_markup( true );
+    }
+
+    protected function tearDown(): void {
+        $GLOBALS['visibloc_posts']           = [];
+        $GLOBALS['visibloc_test_options']    = [];
+        $GLOBALS['visibloc_test_transients'] = [];
+
+        visibloc_test_reset_state();
+
+        visibloc_jlg_get_fallback_settings( true );
+        visibloc_jlg_get_global_fallback_markup( true );
+
+        parent::tearDown();
+    }
+
+    public function test_export_then_import_restores_fallback_settings(): void {
+        $initial_fallback = [
+            'mode'     => 'text',
+            'text'     => '<strong>Contenu de repli</strong>',
+            'block_id' => 0,
+        ];
+
+        update_option( 'visibloc_fallback_settings', $initial_fallback );
+        visibloc_jlg_get_fallback_settings( true );
+
+        $snapshot = visibloc_jlg_get_settings_snapshot();
+
+        $this->assertArrayHasKey( 'fallback', $snapshot, 'The snapshot should expose fallback settings.' );
+        $this->assertSame(
+            visibloc_jlg_normalize_fallback_settings( $initial_fallback ),
+            $snapshot['fallback'],
+            'Exported fallback settings should be normalized.'
+        );
+
+        update_option(
+            'visibloc_fallback_settings',
+            [
+                'mode'     => 'none',
+                'text'     => '',
+                'block_id' => 0,
+            ]
+        );
+        visibloc_jlg_get_fallback_settings( true );
+
+        $result = visibloc_jlg_import_settings_snapshot( wp_json_encode( $snapshot ) );
+
+        $this->assertTrue( $result, 'Importing a valid snapshot should succeed.' );
+
+        $restored = get_option( 'visibloc_fallback_settings', [] );
+
+        $this->assertSame(
+            visibloc_jlg_normalize_fallback_settings( $initial_fallback ),
+            visibloc_jlg_normalize_fallback_settings( $restored ),
+            'Fallback settings should be restored after an export/import round-trip.'
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- include fallback configuration in exported settings snapshots
- validate and persist fallback values when importing settings
- document the behaviour and add integration coverage for the export/import round-trip
- extend the PHPUnit bootstrap with missing WordPress helpers used by the new test

## Testing
- composer test:phpunit

------
https://chatgpt.com/codex/tasks/task_e_68e0e9d82870832ea49f01c633dfe2ac