### PR TITLE
Ensure uninstall clears fallback cache entries

### DIFF
--- a/visi-bloc-jlg/tests/phpunit/integration/UninstallCleanupTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/UninstallCleanupTest.php
@@ -79,6 +79,9 @@ class UninstallCleanupTest extends TestCase {
         update_option( 'visibloc_fallback_settings', [ 'mobile' => 'hidden' ] );
         update_option( 'visibloc_device_css_transients', $bucket_keys );
 
+        wp_cache_set( 'visibloc_fallback_settings', [ 'mobile' => 'hidden' ], 'visibloc_jlg' );
+        wp_cache_set( 'visibloc_device_css_transients', $bucket_keys, 'visibloc_jlg' );
+
         foreach ( $bucket_keys as $bucket_key ) {
             $transient_name = sprintf( 'visibloc_device_css_%s', $bucket_key );
 
@@ -94,6 +97,14 @@ class UninstallCleanupTest extends TestCase {
 
         $this->assertSame( [ 'mobile' => 'hidden' ], get_option( 'visibloc_fallback_settings' ) );
         $this->assertSame( $bucket_keys, get_option( 'visibloc_device_css_transients' ) );
+        $this->assertSame(
+            [ 'mobile' => 'hidden' ],
+            wp_cache_get( 'visibloc_fallback_settings', 'visibloc_jlg' )
+        );
+        $this->assertSame(
+            $bucket_keys,
+            wp_cache_get( 'visibloc_device_css_transients', 'visibloc_jlg' )
+        );
 
         if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
             define( 'WP_UNINSTALL_PLUGIN', true );
@@ -109,6 +120,8 @@ class UninstallCleanupTest extends TestCase {
             '__default__',
             get_option( 'visibloc_device_css_transients', '__default__' )
         );
+        $this->assertFalse( wp_cache_get( 'visibloc_fallback_settings', 'visibloc_jlg' ) );
+        $this->assertFalse( wp_cache_get( 'visibloc_device_css_transients', 'visibloc_jlg' ) );
 
         foreach ( $bucket_keys as $bucket_key ) {
             $transient_name = sprintf( 'visibloc_device_css_%s', $bucket_key );

--- a/visi-bloc-jlg/uninstall.php
+++ b/visi-bloc-jlg/uninstall.php
@@ -9,6 +9,7 @@ delete_option( 'visibloc_preview_roles' );
 delete_option( 'visibloc_group_block_summary' );
 delete_option( 'visibloc_supported_blocks' );
 delete_option( 'visibloc_fallback_settings' );
+wp_cache_delete( 'visibloc_fallback_settings', 'visibloc_jlg' );
 
 // Supprime les transients de cache du plugin
 delete_transient( 'visibloc_hidden_posts' );
@@ -33,5 +34,6 @@ if ( is_array( $registered_buckets ) ) {
 }
 
 delete_option( 'visibloc_device_css_transients' );
+wp_cache_delete( 'visibloc_device_css_transients', 'visibloc_jlg' );
 
 wp_cache_delete( 'visibloc_device_css_cache', 'visibloc_jlg' );


### PR DESCRIPTION
## Summary
- clear cached fallback settings and device CSS transient lists during uninstall
- extend uninstall integration test coverage for new cache cleanup behavior

## Testing
- vendor/bin/phpunit -c phpunit.xml.dist

------
https://chatgpt.com/codex/tasks/task_e_68e0ee96091c832e9f6d47a8005ea082