### PR TITLE
Delay fallback initialization until visibility logic applies

### DIFF
--- a/visi-bloc-jlg/includes/visibility-logic.php
+++ b/visi-bloc-jlg/includes/visibility-logic.php
@@ -52,17 +52,6 @@ function visibloc_jlg_render_block_filter( $block_content, $block ) {
 
     $attrs = $block['attrs'];
 
-    $fallback_markup = null;
-    $fallback_initialized = false;
-    $get_fallback_markup = static function () use ( &$fallback_markup, &$fallback_initialized, $attrs ) {
-        if ( ! $fallback_initialized ) {
-            $fallback_markup     = visibloc_jlg_get_block_fallback_markup( $attrs );
-            $fallback_initialized = true;
-        }
-
-        return $fallback_markup;
-    };
-
     $visibility_roles = [];
 
     if ( array_key_exists( 'visibilityRoles', $attrs ) ) {
@@ -105,6 +94,17 @@ function visibloc_jlg_render_block_filter( $block_content, $block ) {
     if ( ! $has_hidden_flag && ! $has_schedule_enabled && empty( $visibility_roles ) && ! $has_advanced_rules ) {
         return $block_content;
     }
+
+    $fallback_markup = null;
+    $fallback_initialized = false;
+    $get_fallback_markup = static function () use ( &$fallback_markup, &$fallback_initialized, $attrs ) {
+        if ( ! $fallback_initialized ) {
+            $fallback_markup      = visibloc_jlg_get_block_fallback_markup( $attrs );
+            $fallback_initialized = true;
+        }
+
+        return $fallback_markup;
+    };
 
     $preview_context = function_exists( 'visibloc_jlg_get_preview_runtime_context' )
         ? visibloc_jlg_get_preview_runtime_context()

--- a/visi-bloc-jlg/tests/phpunit/integration/VisibilityLogicTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/VisibilityLogicTest.php
@@ -55,6 +55,53 @@ class VisibilityLogicTest extends TestCase {
         }
     }
 
+    public function test_blocks_with_irrelevant_attributes_do_not_initialize_fallback(): void {
+        $filter_calls = 0;
+        $hook = 'pre_option_visibloc_fallback_settings';
+
+        $previous_filters = $GLOBALS['visibloc_test_filters'][ $hook ] ?? null;
+
+        $callback = static function ( $pre_value ) use ( &$filter_calls ) {
+            $filter_calls++;
+
+            return $pre_value;
+        };
+
+        add_filter( $hook, $callback );
+
+        try {
+            $block = [
+                'blockName' => 'core/group',
+                'attrs'     => [
+                    'customAttribute'     => 'value',
+                    'fallbackBehavior'    => 'text',
+                    'fallbackEnabled'     => true,
+                    'irrelevantAttribute' => [ 'nested' => 'data' ],
+                ],
+            ];
+
+            $content = '<p>Visible block</p>';
+
+            $this->assertSame(
+                $content,
+                visibloc_jlg_render_block_filter( $content, $block ),
+                'Blocks without visibility rules should render as-is even when unrelated attributes are present.'
+            );
+
+            $this->assertSame(
+                0,
+                $filter_calls,
+                'Fallback settings should remain untouched when no visibility logic applies.'
+            );
+        } finally {
+            if ( null === $previous_filters ) {
+                unset( $GLOBALS['visibloc_test_filters'][ $hook ] );
+            } else {
+                $GLOBALS['visibloc_test_filters'][ $hook ] = $previous_filters;
+            }
+        }
+    }
+
     public function test_administrator_impersonating_editor_sees_editor_view_without_hidden_blocks(): void {
         global $visibloc_test_state;
 


### PR DESCRIPTION
## Summary
- avoid preparing fallback markup for blocks that do not enable any visibility controls
- add integration coverage to ensure fallback rendering is skipped when no visibility rules apply

## Testing
- composer test:phpunit

------
https://chatgpt.com/codex/tasks/task_e_68e0ee97f0b0832e9f92c699af2c4832