### PR TITLE
Allow fallback block queries to be filtered

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,26 @@ The tests rely on [`@wordpress/env`](https://developer.wordpress.org/block-edito
 The "Visi-Bloc - JLG" administration screen paginates the internal queries in batches of 100 post IDs and caches the compiled
 results for an hour. This keeps memory usage low, but on very large sites the first load after the cache expires may still take a
 little longer while the plugin analyses the content library.
+
+## Filters
+
+### `visibloc_jlg_available_fallback_blocks_query_args`
+
+Reusable blocks exposed in the fallback selector are now loaded without a hard limit (the plugin passes `numberposts => -1` to
+`get_posts()` by default). The query arguments can be filtered to re-introduce pagination or otherwise scope the lookup for very
+large libraries:
+
+```php
+add_filter(
+    'visibloc_jlg_available_fallback_blocks_query_args',
+    static function ( array $args ) {
+        // Keep the ascending alphabetical order but only fetch the first 50 blocks.
+        $args['numberposts'] = 50;
+
+        return $args;
+    }
+);
+```
+
+When using pagination, make sure the fallback block stored in the global settings stays within the returned subset or adjust the
+selector UI accordingly.

--- a/visi-bloc-jlg/includes/fallback.php
+++ b/visi-bloc-jlg/includes/fallback.php
@@ -230,16 +230,35 @@ function visibloc_jlg_get_block_fallback_markup( $attrs ) {
  * @return array<int, array{value:int,label:string}>
  */
 function visibloc_jlg_get_available_fallback_blocks() {
-    $posts = get_posts(
-        [
-            'post_type'      => 'wp_block',
-            'post_status'    => 'publish',
-            'numberposts'    => 200,
-            'orderby'        => 'title',
-            'order'          => 'ASC',
-            'suppress_filters' => false,
-        ]
-    );
+    $default_args = [
+        'post_type'        => 'wp_block',
+        'post_status'      => 'publish',
+        'numberposts'      => -1,
+        'orderby'          => 'title',
+        'order'            => 'ASC',
+        'suppress_filters' => false,
+    ];
+
+    /**
+     * Filters the arguments used when looking up reusable blocks available as fallbacks.
+     *
+     * Allowing the query arguments to be filtered lets integrators re-introduce pagination
+     * or otherwise tailor the lookup to their needs when a site has an extremely large
+     * collection of reusable blocks.
+     *
+     * @since 1.1.1
+     *
+     * @param array $query_args Arguments forwarded to {@see get_posts()}.
+     */
+    $query_args = apply_filters( 'visibloc_jlg_available_fallback_blocks_query_args', $default_args );
+
+    if ( ! is_array( $query_args ) ) {
+        $query_args = $default_args;
+    } else {
+        $query_args = array_merge( $default_args, $query_args );
+    }
+
+    $posts = get_posts( $query_args );
 
     if ( empty( $posts ) ) {
         return [];

--- a/visi-bloc-jlg/tests/phpunit/integration/FallbackBlocksTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/FallbackBlocksTest.php
@@ -1,0 +1,82 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class FallbackBlocksTest extends TestCase {
+    protected function setUp(): void {
+        visibloc_test_reset_state();
+        $GLOBALS['visibloc_posts'] = [];
+        remove_all_filters( 'visibloc_jlg_available_fallback_blocks_query_args' );
+    }
+
+    public function test_all_reusable_blocks_are_returned_without_limit(): void {
+        for ( $index = 1; $index <= 205; $index++ ) {
+            $GLOBALS['visibloc_posts'][ $index ] = [
+                'post_title'   => sprintf( 'Reusable block %03d', $index ),
+                'post_content' => '<!-- wp:paragraph --><p>Fallback paragraph</p><!-- /wp:paragraph -->',
+                'post_type'    => 'wp_block',
+                'post_status'  => 'publish',
+            ];
+        }
+
+        $blocks = visibloc_jlg_get_available_fallback_blocks();
+
+        $this->assertCount(
+            205,
+            $blocks,
+            'All reusable blocks should be listed when no limit is applied.'
+        );
+
+        $values = array_column( $blocks, 'value' );
+
+        $this->assertSame(
+            range( 1, 205 ),
+            $values,
+            'The block IDs should cover the entire dataset.'
+        );
+
+        $labels = array_column( $blocks, 'label', 'value' );
+
+        $this->assertSame(
+            'Reusable block 205',
+            $labels[205] ?? null,
+            'The last block should be present with its title.'
+        );
+    }
+
+    public function test_filter_can_limit_the_number_of_available_blocks(): void {
+        for ( $index = 1; $index <= 30; $index++ ) {
+            $GLOBALS['visibloc_posts'][ $index ] = [
+                'post_title'   => sprintf( 'Reusable block %03d', $index ),
+                'post_content' => '<!-- wp:paragraph --><p>Fallback paragraph</p><!-- /wp:paragraph -->',
+                'post_type'    => 'wp_block',
+                'post_status'  => 'publish',
+            ];
+        }
+
+        add_filter(
+            'visibloc_jlg_available_fallback_blocks_query_args',
+            static function ( $args ) {
+                if ( ! is_array( $args ) ) {
+                    return $args;
+                }
+
+                $args['numberposts'] = 10;
+
+                return $args;
+            }
+        );
+
+        try {
+            $limited_blocks = visibloc_jlg_get_available_fallback_blocks();
+        } finally {
+            remove_all_filters( 'visibloc_jlg_available_fallback_blocks_query_args' );
+        }
+
+        $this->assertCount(
+            10,
+            $limited_blocks,
+            'Integrators should be able to narrow the query through the filter.'
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- remove the 200 item cap when listing fallback reusable blocks and expose a filter for the query arguments
- document the new filter so integrators can opt back into pagination if needed
- add integration coverage and lightweight stubs so additional reusable blocks become visible when the limit is raised

## Testing
- `vendor/bin/phpunit -c phpunit.xml.dist`


------
https://chatgpt.com/codex/tasks/task_e_68e12d59f228832ebd80b7d7430a2377