### PR TITLE
Respect locale when translating hidden block

### DIFF
--- a/visi-bloc-jlg/includes/i18n-inline.php
+++ b/visi-bloc-jlg/includes/i18n-inline.php
@@ -2,6 +2,9 @@
 if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 if ( ! function_exists( 'visibloc_jlg_inline_translate_hidden_block' ) ) {
+    // Ensure the "Hidden block" string is registered for translations.
+    __( 'Hidden block', 'visi-bloc-jlg' );
+
     /**
      * Provide inline translations for strings that are generated dynamically.
      *
@@ -16,7 +19,11 @@ if ( ! function_exists( 'visibloc_jlg_inline_translate_hidden_block' ) ) {
         }
 
         if ( 'Hidden block' === $text ) {
-            return 'Bloc caché';
+            $locale = function_exists( 'determine_locale' ) ? determine_locale() : get_locale();
+
+            if ( $locale && 0 === strpos( strtolower( $locale ), 'fr' ) ) {
+                return 'Bloc caché';
+            }
         }
 
         return $translation;


### PR DESCRIPTION
## Summary
- ensure the inline translation helper only overrides "Hidden block" when the locale is French
- register the "Hidden block" string with __() so it is available to translation tools

## Testing
- php -r 'function __($text,$domain){return $text;} function determine_locale(){return "en_US";} function add_filter(){} define("ABSPATH", true); require "visi-bloc-jlg/includes/i18n-inline.php"; echo visibloc_jlg_inline_translate_hidden_block("Hidden block","Hidden block","visi-bloc-jlg");'
- php -r 'function __($text,$domain){return $text;} function determine_locale(){return "fr_FR";} function add_filter(){} define("ABSPATH", true); require "visi-bloc-jlg/includes/i18n-inline.php"; echo visibloc_jlg_inline_translate_hidden_block("Hidden block","Hidden block","visi-bloc-jlg");'

------
https://chatgpt.com/codex/tasks/task_e_68e12d595338832eb62ae167d4743912