### PR TITLE
Adjust hidden block translation to respect locale

### DIFF
--- a/visi-bloc-jlg/includes/i18n-inline.php
+++ b/visi-bloc-jlg/includes/i18n-inline.php
@@ -1,6 +1,11 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) { exit; }
 
+if ( function_exists( '__' ) ) {
+    // Ensure the "Hidden block" string is available for translation tools.
+    __( 'Hidden block', 'visi-bloc-jlg' );
+}
+
 if ( ! function_exists( 'visibloc_jlg_inline_translate_hidden_block' ) ) {
     /**
      * Provide inline translations for strings that are generated dynamically.
@@ -16,7 +21,17 @@ if ( ! function_exists( 'visibloc_jlg_inline_translate_hidden_block' ) ) {
         }
 
         if ( 'Hidden block' === $text ) {
-            return 'Bloc caché';
+            $locale = '';
+
+            if ( function_exists( 'determine_locale' ) ) {
+                $locale = determine_locale();
+            } elseif ( function_exists( 'get_locale' ) ) {
+                $locale = get_locale();
+            }
+
+            if ( is_string( $locale ) && 0 === strpos( strtolower( $locale ), 'fr' ) ) {
+                return 'Bloc caché';
+            }
         }
 
         return $translation;


### PR DESCRIPTION
## Summary
- ensure the "Hidden block" string is registered for translation extraction
- limit the inline override to French locales by checking the active locale before returning the French string

## Testing
- php -l visi-bloc-jlg/includes/i18n-inline.php
- php -r 'define("ABSPATH", true); function __($text,$domain=null){return $text;} function determine_locale(){return "en_US";} function add_filter(){ } include "visi-bloc-jlg/includes/i18n-inline.php"; var_dump(visibloc_jlg_inline_translate_hidden_block("Hidden block","Hidden block","visi-bloc-jlg"));'
- php -r 'define("ABSPATH", true); function __($text,$domain=null){return $text;} function determine_locale(){return "fr_FR";} function add_filter(){ } include "visi-bloc-jlg/includes/i18n-inline.php"; var_dump(visibloc_jlg_inline_translate_hidden_block("Hidden block","Hidden block","visi-bloc-jlg"));'

------
https://chatgpt.com/codex/tasks/task_e_68e136b83fc4832e8460a7b08c0dac5e