### PR TITLE
Disable fallback block query pagination by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,16 +62,18 @@ little longer while the plugin analyses the content library.
 
 ### `visibloc_jlg_available_fallback_blocks_query_args`
 
-Reusable blocks exposed in the fallback selector are now loaded without a hard limit (the plugin passes `numberposts => -1` to
-`get_posts()` by default). The query arguments can be filtered to re-introduce pagination or otherwise scope the lookup for very
-large libraries:
+Reusable blocks exposed in the fallback selector are now loaded without a hard limit (the plugin passes `numberposts => -1`,
+`posts_per_page => -1`, and `nopaging => true` to `get_posts()` by default). The query arguments can be filtered to
+re-introduce pagination or otherwise scope the lookup for very large libraries:
 
 ```php
 add_filter(
     'visibloc_jlg_available_fallback_blocks_query_args',
     static function ( array $args ) {
         // Keep the ascending alphabetical order but only fetch the first 50 blocks.
-        $args['numberposts'] = 50;
+        $args['numberposts']    = 50;
+        $args['posts_per_page'] = 50;
+        $args['nopaging']       = false;
 
         return $args;
     }

--- a/visi-bloc-jlg/includes/fallback.php
+++ b/visi-bloc-jlg/includes/fallback.php
@@ -234,6 +234,8 @@ function visibloc_jlg_get_available_fallback_blocks() {
         'post_type'        => 'wp_block',
         'post_status'      => 'publish',
         'numberposts'      => -1,
+        'posts_per_page'   => -1,
+        'nopaging'         => true,
         'orderby'          => 'title',
         'order'            => 'ASC',
         'suppress_filters' => false,
@@ -242,9 +244,11 @@ function visibloc_jlg_get_available_fallback_blocks() {
     /**
      * Filters the arguments used when looking up reusable blocks available as fallbacks.
      *
-     * Allowing the query arguments to be filtered lets integrators re-introduce pagination
-     * or otherwise tailor the lookup to their needs when a site has an extremely large
-     * collection of reusable blocks.
+     * By default the plugin disables pagination completely (`numberposts` and
+     * `posts_per_page` are both set to `-1`, and `nopaging` to `true`) so that no reusable
+     * block is hidden from the selector. Allowing the query arguments to be filtered lets
+     * integrators re-introduce pagination or otherwise tailor the lookup to their needs when
+     * a site has an extremely large collection of reusable blocks.
      *
      * @since 1.1.1
      *

--- a/visi-bloc-jlg/tests/phpunit/integration/FallbackBlocksTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/FallbackBlocksTest.php
@@ -9,6 +9,33 @@ class FallbackBlocksTest extends TestCase {
         remove_all_filters( 'visibloc_jlg_available_fallback_blocks_query_args' );
     }
 
+    public function test_query_defaults_disable_pagination(): void {
+        $captured_args = null;
+
+        add_filter(
+            'visibloc_jlg_available_fallback_blocks_query_args',
+            static function ( $args ) use ( &$captured_args ) {
+                $captured_args = $args;
+
+                return $args;
+            }
+        );
+
+        try {
+            visibloc_jlg_get_available_fallback_blocks();
+        } finally {
+            remove_all_filters( 'visibloc_jlg_available_fallback_blocks_query_args' );
+        }
+
+        $this->assertIsArray( $captured_args, 'The filter should receive an array of query arguments.' );
+        $this->assertArrayHasKey( 'numberposts', $captured_args );
+        $this->assertSame( -1, $captured_args['numberposts'], 'The number of posts should be unlimited by default.' );
+        $this->assertArrayHasKey( 'posts_per_page', $captured_args );
+        $this->assertSame( -1, $captured_args['posts_per_page'], 'Pagination should remain disabled for WP_Query consumers.' );
+        $this->assertArrayHasKey( 'nopaging', $captured_args );
+        $this->assertTrue( (bool) $captured_args['nopaging'], 'The query should explicitly disable pagination.' );
+    }
+
     public function test_all_reusable_blocks_are_returned_without_limit(): void {
         for ( $index = 1; $index <= 205; $index++ ) {
             $GLOBALS['visibloc_posts'][ $index ] = [


### PR DESCRIPTION
## Summary
- set the fallback reusable block lookup to disable pagination by default and document the new defaults
- explain the filter arguments in the README so integrators can reintroduce pagination if desired
- add an integration test that captures the default query arguments alongside the existing unlimited-block coverage

## Testing
- composer run test:phpunit

------
https://chatgpt.com/codex/tasks/task_e_68e148e76f00832eb789c5543165eb9e