### PR TITLE
Highlight admin settings nav based on visible section

### DIFF
--- a/visi-bloc-jlg/assets/admin-nav.js
+++ b/visi-bloc-jlg/assets/admin-nav.js
@@ -1,0 +1,159 @@
+( function () {
+    var ready = function (callback) {
+        if (window.wp && typeof window.wp.domReady === 'function') {
+            window.wp.domReady(callback);
+            return;
+        }
+
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', callback);
+        } else {
+            callback();
+        }
+    };
+
+    ready(function () {
+        var sectionElements = Array.prototype.slice.call(
+            document.querySelectorAll('[data-visibloc-section]')
+        );
+        var navLinks = Array.prototype.slice.call(
+            document.querySelectorAll('.visibloc-help-nav__link')
+        );
+
+        if (!sectionElements.length || !navLinks.length) {
+            return;
+        }
+
+        var sectionByKey = {};
+        var sectionOrder = [];
+
+        sectionElements.forEach(function (section) {
+            var key = section.getAttribute('data-visibloc-section') || section.id;
+
+            if (!key || Object.prototype.hasOwnProperty.call(sectionByKey, key)) {
+                return;
+            }
+
+            sectionByKey[key] = section;
+            sectionOrder.push(key);
+        });
+
+        if (!sectionOrder.length) {
+            return;
+        }
+
+        var linkBySection = {};
+
+        navLinks.forEach(function (link) {
+            var hash = link.hash ? decodeURIComponent(link.hash.substring(1)) : '';
+
+            if (
+                !hash ||
+                !Object.prototype.hasOwnProperty.call(sectionByKey, hash) ||
+                Object.prototype.hasOwnProperty.call(linkBySection, hash)
+            ) {
+                return;
+            }
+
+            linkBySection[hash] = link;
+        });
+
+        var observedSectionKeys = sectionOrder.filter(function (key) {
+            return Object.prototype.hasOwnProperty.call(linkBySection, key);
+        });
+
+        if (!observedSectionKeys.length) {
+            return;
+        }
+
+        var ratioBySection = {};
+        observedSectionKeys.forEach(function (key) {
+            ratioBySection[key] = 0;
+        });
+
+        var activeClass = 'visibloc-help-nav__link--active';
+        var currentActiveKey = null;
+        var currentActiveLink = null;
+
+        var setActiveLink = function (sectionKey) {
+            if (currentActiveKey === sectionKey) {
+                return;
+            }
+
+            if (currentActiveLink) {
+                currentActiveLink.classList.remove(activeClass);
+                currentActiveLink.removeAttribute('aria-current');
+            }
+
+            var nextLink = linkBySection[sectionKey];
+
+            if (!nextLink) {
+                currentActiveKey = null;
+                currentActiveLink = null;
+                return;
+            }
+
+            nextLink.classList.add(activeClass);
+            nextLink.setAttribute('aria-current', 'true');
+            currentActiveKey = sectionKey;
+            currentActiveLink = nextLink;
+        };
+
+        var fallbackKey = observedSectionKeys[0];
+        if (fallbackKey) {
+            setActiveLink(fallbackKey);
+        }
+
+        if (typeof window.IntersectionObserver !== 'function') {
+            return;
+        }
+
+        var updateActiveFromRatios = function () {
+            var bestKey = null;
+            var bestRatio = -1;
+
+            observedSectionKeys.forEach(function (key) {
+                var ratio = ratioBySection[key] || 0;
+
+                if (ratio > bestRatio + 0.0001) {
+                    bestRatio = ratio;
+                    bestKey = key;
+                }
+            });
+
+            if (bestKey && bestRatio > 0) {
+                setActiveLink(bestKey);
+            }
+        };
+
+        var observer = new IntersectionObserver(
+            function (entries) {
+                entries.forEach(function (entry) {
+                    var target = entry.target;
+                    var key = target.getAttribute('data-visibloc-section') || target.id;
+
+                    if (!key || !Object.prototype.hasOwnProperty.call(ratioBySection, key)) {
+                        return;
+                    }
+
+                    var ratio = entry.isIntersecting ? entry.intersectionRatio : 0;
+                    ratioBySection[key] = ratio;
+                });
+
+                updateActiveFromRatios();
+            },
+            {
+                threshold: [0, 0.1, 0.25, 0.5, 0.75, 1],
+                rootMargin: '0px 0px -40% 0px',
+            }
+        );
+
+        observedSectionKeys.forEach(function (key) {
+            var section = sectionByKey[key];
+
+            if (section) {
+                observer.observe(section);
+            }
+        });
+    });
+})();

--- a/visi-bloc-jlg/assets/admin-responsive.css
+++ b/visi-bloc-jlg/assets/admin-responsive.css
@@ -83,6 +83,13 @@
     transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
+.visibloc-help-nav__link--active {
+    background: #135e96;
+    border-color: #135e96;
+    color: #fff;
+    cursor: default;
+}
+
 .visibloc-help-nav__link:hover,
 .visibloc-help-nav__link:focus {
     background: #2271b1;
@@ -90,9 +97,20 @@
     color: #fff;
 }
 
+.visibloc-help-nav__link--active:hover,
+.visibloc-help-nav__link--active:focus {
+    background: #0a4b78;
+    border-color: #0a4b78;
+    color: #fff;
+}
+
 .visibloc-help-nav__link:focus-visible {
     box-shadow: 0 0 0 2px #fff, 0 0 0 4px #2271b1;
     outline: none;
+}
+
+.visibloc-help-nav__link--active:focus-visible {
+    box-shadow: 0 0 0 2px #fff, 0 0 0 4px #0a4b78;
 }
 
 .visibloc-help-nav__list::-webkit-scrollbar {

--- a/visi-bloc-jlg/includes/admin-settings.php
+++ b/visi-bloc-jlg/includes/admin-settings.php
@@ -560,7 +560,7 @@ function visibloc_jlg_render_supported_blocks_section( $registered_block_types, 
         : [ 'core/group' ];
 
     ?>
-    <div id="visibloc-section-blocks" class="postbox">
+    <div id="visibloc-section-blocks" class="postbox" data-visibloc-section="visibloc-section-blocks">
         <h2 class="hndle"><span><?php esc_html_e( 'Blocs compatibles', 'visi-bloc-jlg' ); ?></span></h2>
         <div class="inside">
             <form method="POST" action="">
@@ -670,7 +670,7 @@ function visibloc_jlg_render_permissions_section( $allowed_roles ) {
     }
 
     ?>
-    <div id="visibloc-section-permissions" class="postbox">
+    <div id="visibloc-section-permissions" class="postbox" data-visibloc-section="visibloc-section-permissions">
         <h2 class="hndle"><span><?php esc_html_e( "Permissions d'Aperçu", 'visi-bloc-jlg' ); ?></span></h2>
         <div class="inside">
             <form method="POST" action="">
@@ -699,7 +699,7 @@ function visibloc_jlg_render_hidden_blocks_section( $hidden_posts ) {
     $grouped_hidden_posts = visibloc_jlg_group_posts_by_id( $hidden_posts );
 
     ?>
-    <div id="visibloc-section-hidden" class="postbox">
+    <div id="visibloc-section-hidden" class="postbox" data-visibloc-section="visibloc-section-hidden">
         <h2 class="hndle"><span><?php esc_html_e( 'Tableau de bord des blocs masqués (via Œil)', 'visi-bloc-jlg' ); ?></span></h2>
         <div class="inside">
             <?php if ( empty( $grouped_hidden_posts ) ) : ?>
@@ -728,7 +728,7 @@ function visibloc_jlg_render_device_visibility_section( $device_posts ) {
     $grouped_device_posts = visibloc_jlg_group_posts_by_id( $device_posts );
 
     ?>
-    <div id="visibloc-section-device" class="postbox">
+    <div id="visibloc-section-device" class="postbox" data-visibloc-section="visibloc-section-device">
         <h2 class="hndle"><span><?php esc_html_e( 'Tableau de bord des blocs avec visibilité par appareil', 'visi-bloc-jlg' ); ?></span></h2>
         <div class="inside">
             <?php if ( empty( $grouped_device_posts ) ) : ?>
@@ -761,7 +761,7 @@ function visibloc_jlg_render_scheduled_blocks_section( $scheduled_posts ) {
     $end_column_label   = __( 'Date de fin', 'visi-bloc-jlg' );
 
     ?>
-    <div id="visibloc-section-scheduled" class="postbox">
+    <div id="visibloc-section-scheduled" class="postbox" data-visibloc-section="visibloc-section-scheduled">
         <h2 class="hndle"><span><?php esc_html_e( 'Tableau de bord des blocs programmés', 'visi-bloc-jlg' ); ?></span></h2>
         <div class="inside">
             <?php if ( empty( $scheduled_posts ) ) : ?>
@@ -810,7 +810,7 @@ function visibloc_jlg_render_scheduled_blocks_section( $scheduled_posts ) {
 
 function visibloc_jlg_render_debug_mode_section( $debug_status ) {
     ?>
-    <div id="visibloc-section-debug" class="postbox">
+    <div id="visibloc-section-debug" class="postbox" data-visibloc-section="visibloc-section-debug">
         <h2 class="hndle"><span><?php esc_html_e( 'Mode de débogage', 'visi-bloc-jlg' ); ?></span></h2>
         <div class="inside">
             <form method="POST" action="">
@@ -829,7 +829,7 @@ function visibloc_jlg_render_debug_mode_section( $debug_status ) {
 
 function visibloc_jlg_render_settings_backup_section() {
     ?>
-    <div id="visibloc-section-backup" class="postbox">
+    <div id="visibloc-section-backup" class="postbox" data-visibloc-section="visibloc-section-backup">
         <h2 class="hndle"><span><?php esc_html_e( 'Export & sauvegarde', 'visi-bloc-jlg' ); ?></span></h2>
         <div class="inside">
             <p><?php esc_html_e( 'Exportez vos réglages pour les sauvegarder ou les transférer vers un autre site.', 'visi-bloc-jlg' ); ?></p>
@@ -859,7 +859,7 @@ function visibloc_jlg_render_breakpoints_section( $mobile_bp, $tablet_bp ) {
     $breakpoints_help_id             = 'visibloc_breakpoints_help';
 
     ?>
-    <div id="visibloc-section-breakpoints" class="postbox">
+    <div id="visibloc-section-breakpoints" class="postbox" data-visibloc-section="visibloc-section-breakpoints">
         <h2 class="hndle"><span><?php esc_html_e( 'Réglage des points de rupture', 'visi-bloc-jlg' ); ?></span></h2>
         <div class="inside">
             <form method="POST" action="">
@@ -895,7 +895,7 @@ function visibloc_jlg_render_fallback_section( $fallback_settings, $fallback_blo
     $fallback_block_help_id = 'visibloc_fallback_block_help';
 
     ?>
-    <div id="visibloc-section-fallback" class="postbox">
+    <div id="visibloc-section-fallback" class="postbox" data-visibloc-section="visibloc-section-fallback">
         <h2 class="hndle"><span><?php esc_html_e( 'Contenu de repli global', 'visi-bloc-jlg' ); ?></span></h2>
         <div class="inside">
             <form method="POST" action="">

--- a/visi-bloc-jlg/includes/assets.php
+++ b/visi-bloc-jlg/includes/assets.php
@@ -107,6 +107,35 @@ function visibloc_jlg_enqueue_admin_supported_blocks_script( $hook_suffix ) {
     );
 }
 
+add_action( 'admin_enqueue_scripts', 'visibloc_jlg_enqueue_admin_navigation_script' );
+function visibloc_jlg_enqueue_admin_navigation_script( $hook_suffix ) {
+    if ( 'toplevel_page_visi-bloc-jlg-help' !== $hook_suffix ) {
+        return;
+    }
+
+    $plugin_main_file       = __DIR__ . '/../visi-bloc-jlg.php';
+    $script_relative_path   = 'assets/admin-nav.js';
+    $script_path            = plugin_dir_path( $plugin_main_file ) . $script_relative_path;
+    $default_script_version = defined( 'VISIBLOC_JLG_VERSION' ) ? VISIBLOC_JLG_VERSION : '1.1';
+    $script_version         = $default_script_version;
+
+    if ( file_exists( $script_path ) ) {
+        $file_version = filemtime( $script_path );
+
+        if ( false !== $file_version ) {
+            $script_version = (string) $file_version;
+        }
+    }
+
+    wp_enqueue_script(
+        'visibloc-jlg-admin-navigation',
+        plugins_url( $script_relative_path, $plugin_main_file ),
+        [ 'wp-dom-ready' ],
+        $script_version,
+        true
+    );
+}
+
 add_action( 'enqueue_block_editor_assets', 'visibloc_jlg_enqueue_editor_assets' );
 function visibloc_jlg_enqueue_editor_assets() {
     $plugin_main_file = __DIR__ . '/../visi-bloc-jlg.php';


### PR DESCRIPTION
## Summary
- add section data attributes to admin settings containers for reliable JS targeting
- introduce an IntersectionObserver-based navigation script that marks the visible section link as active
- style the active navigation state to meet accessibility contrast requirements and enqueue the script in the admin

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1a3cd8c90832e9924ef8b154c81c8