### PR TITLE
Add filtering UI to visibility dashboards

### DIFF
--- a/visi-bloc-jlg/assets/admin-responsive.css
+++ b/visi-bloc-jlg/assets/admin-responsive.css
@@ -1,17 +1,3 @@
-.visibloc-admin-post-list {
-    list-style: disc;
-    padding-left: 20px;
-    margin: 0 0 1em;
-}
-
-.visibloc-admin-post-list li {
-    margin-bottom: 0.5em;
-}
-
-.visibloc-admin-post-list li:last-child {
-    margin-bottom: 0;
-}
-
 .visibloc-supported-blocks-fieldset {
     border: 0;
     margin: 0;
@@ -30,8 +16,46 @@
     overflow-x: auto;
 }
 
-.visibloc-admin-scheduled-table a {
+.visibloc-admin-dashboard-table {
+    min-width: 640px;
+}
+
+.visibloc-admin-dashboard-table a {
     word-break: break-word;
+}
+
+.visibloc-dashboard-controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    align-items: flex-end;
+    margin-bottom: 16px;
+}
+
+.visibloc-dashboard-controls__group {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.visibloc-dashboard-controls__label {
+    font-weight: 600;
+    color: #1d2327;
+}
+
+.visibloc-dashboard-controls__field {
+    min-width: 220px;
+}
+
+.visibloc-dashboard-controls__count {
+    margin-left: auto;
+    font-weight: 600;
+    color: #1d2327;
+}
+
+.visibloc-dashboard-empty {
+    margin-top: 12px;
+    font-style: italic;
 }
 
 .visibloc-help-layout {
@@ -129,52 +153,41 @@
         text-align: left;
     }
 
-    .visibloc-admin-post-list {
-        list-style: none;
-        padding-left: 0;
-        margin: 0;
-    }
-
-    .visibloc-admin-post-list li {
-        display: block;
-        margin-bottom: 12px;
-        padding: 12px 14px;
-        border: 1px solid #dcdcde;
-        border-radius: 4px;
-        background: #fff;
-    }
-
-    .visibloc-admin-post-list li:last-child {
-        margin-bottom: 0;
-    }
-
-    .visibloc-admin-post-list a {
-        display: block;
-        text-decoration: none;
-        color: inherit;
-        word-break: break-word;
-    }
-
     .visibloc-admin-table-wrapper {
         overflow: visible;
     }
 
-    .visibloc-admin-scheduled-table,
-    .visibloc-admin-scheduled-table thead,
-    .visibloc-admin-scheduled-table tbody,
-    .visibloc-admin-scheduled-table tr,
-    .visibloc-admin-scheduled-table th,
-    .visibloc-admin-scheduled-table td {
+    .visibloc-dashboard-controls {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .visibloc-dashboard-controls__field {
+        width: 100%;
+        min-width: 0;
+    }
+
+    .visibloc-dashboard-controls__count {
+        margin-left: 0;
+    }
+
+    .visibloc-admin-dashboard-table,
+    .visibloc-admin-dashboard-table thead,
+    .visibloc-admin-dashboard-table tbody,
+    .visibloc-admin-dashboard-table tr,
+    .visibloc-admin-dashboard-table th,
+    .visibloc-admin-dashboard-table td {
         display: block;
         width: 100%;
     }
 
-    .visibloc-admin-scheduled-table {
+    .visibloc-admin-dashboard-table {
         border: 0;
         box-shadow: none;
+        min-width: 0;
     }
 
-    .visibloc-admin-scheduled-table thead {
+    .visibloc-admin-dashboard-table thead {
         position: absolute;
         width: 1px;
         height: 1px;
@@ -187,11 +200,11 @@
         white-space: nowrap;
     }
 
-    .visibloc-admin-scheduled-table tbody {
+    .visibloc-admin-dashboard-table tbody {
         display: block;
     }
 
-    .visibloc-admin-scheduled-table tr {
+    .visibloc-admin-dashboard-table tr {
         margin-bottom: 12px;
         border: 1px solid #dcdcde;
         border-radius: 4px;
@@ -200,18 +213,17 @@
         box-sizing: border-box;
     }
 
-    .visibloc-admin-scheduled-table tr:last-child {
+    .visibloc-admin-dashboard-table tr:last-child {
         margin-bottom: 0;
     }
 
-    .visibloc-admin-scheduled-table td {
-        padding: 0;
-        margin: 0 0 10px;
-        border-bottom: 0;
+    .visibloc-admin-dashboard-table td {
+        padding: 8px 0;
+        border: 0;
     }
 
-    .visibloc-admin-scheduled-table td:last-child {
-        margin-bottom: 0;
+    .visibloc-admin-dashboard-table td + td {
+        border-top: 1px solid #dcdcde;
     }
 
     .visibloc-table-label {

--- a/visi-bloc-jlg/assets/admin-visibility-dashboards.js
+++ b/visi-bloc-jlg/assets/admin-visibility-dashboards.js
@@ -1,0 +1,209 @@
+(function () {
+    'use strict';
+
+    var normalizeText = function (value) {
+        if (value === null || value === undefined) {
+            return '';
+        }
+
+        var normalized = String(value).trim().toLowerCase();
+
+        if (normalized && typeof normalized.normalize === 'function') {
+            normalized = normalized.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+        }
+
+        return normalized;
+    };
+
+    var getRowSearchValue = function (row) {
+        var cached = row.getAttribute('data-search-cache');
+
+        if (cached !== null) {
+            return cached;
+        }
+
+        var raw = row.getAttribute('data-search-value');
+
+        if (!raw) {
+            raw = row.textContent || '';
+        }
+
+        var normalized = normalizeText(raw);
+        row.setAttribute('data-search-cache', normalized);
+
+        return normalized;
+    };
+
+    var getRowTitleValue = function (row) {
+        var title = row.getAttribute('data-title');
+
+        if (!title) {
+            title = row.textContent || '';
+        }
+
+        return normalizeText(title);
+    };
+
+    var getRowBlockCount = function (row) {
+        var value = parseInt(row.getAttribute('data-block-count') || '', 10);
+
+        return isNaN(value) ? 0 : value;
+    };
+
+    var getRowDeadline = function (row) {
+        var value = parseInt(row.getAttribute('data-next-deadline') || '', 10);
+
+        return isNaN(value) ? Number.POSITIVE_INFINITY : value;
+    };
+
+    var updateCount = function (countNode, count) {
+        if (!countNode) {
+            return;
+        }
+
+        var template = countNode.getAttribute('data-count-template') || '';
+
+        if (template) {
+            countNode.textContent = template.replace('%d', String(count));
+        } else {
+            countNode.textContent = String(count);
+        }
+    };
+
+    var initDashboard = function (container) {
+        var rows = Array.prototype.slice.call(
+            container.querySelectorAll('[data-visibloc-dashboard-row]')
+        );
+
+        if (!rows.length) {
+            return;
+        }
+
+        var controls = container.querySelector('[data-visibloc-dashboard-controls]');
+        var typeSelect = controls ? controls.querySelector('[data-visibloc-filter="post-type"]') : null;
+        var searchInput = controls ? controls.querySelector('[data-visibloc-filter="search"]') : null;
+        var sortSelect = controls ? controls.querySelector('[data-visibloc-filter="sort"]') : null;
+        var countNode = controls ? controls.querySelector('[data-visibloc-dashboard-count]') : null;
+        var tbody = container.querySelector('tbody');
+        var emptyMessage = container.querySelector('[data-visibloc-dashboard-empty]');
+
+        if (!tbody) {
+            return;
+        }
+
+        var applyFilters = function () {
+            var selectedType = typeSelect ? typeSelect.value : '';
+            var normalizedSearch = searchInput ? normalizeText(searchInput.value || '') : '';
+            var sortValue = sortSelect ? sortSelect.value : 'title';
+
+            var visibleRows = [];
+
+            rows.forEach(function (row) {
+                var matchesType = true;
+
+                if (selectedType) {
+                    matchesType = row.getAttribute('data-post-type') === selectedType;
+                }
+
+                var matchesSearch = true;
+
+                if (matchesType && normalizedSearch) {
+                    matchesSearch = getRowSearchValue(row).indexOf(normalizedSearch) !== -1;
+                }
+
+                var isVisible = matchesType && matchesSearch;
+                row.hidden = !isVisible;
+
+                if (isVisible) {
+                    visibleRows.push(row);
+                }
+            });
+
+            var compareTitle = function (a, b) {
+                var titleA = getRowTitleValue(a);
+                var titleB = getRowTitleValue(b);
+
+                if (titleA < titleB) {
+                    return -1;
+                }
+
+                if (titleA > titleB) {
+                    return 1;
+                }
+
+                return 0;
+            };
+
+            if ('blocks-desc' === sortValue) {
+                visibleRows.sort(function (a, b) {
+                    var diff = getRowBlockCount(b) - getRowBlockCount(a);
+
+                    if (diff !== 0) {
+                        return diff;
+                    }
+
+                    return compareTitle(a, b);
+                });
+            } else if ('deadline' === sortValue) {
+                visibleRows.sort(function (a, b) {
+                    var deadlineDiff = getRowDeadline(a) - getRowDeadline(b);
+
+                    if (deadlineDiff !== 0) {
+                        return deadlineDiff;
+                    }
+
+                    return compareTitle(a, b);
+                });
+            } else {
+                visibleRows.sort(compareTitle);
+            }
+
+            var fragment = document.createDocumentFragment();
+
+            visibleRows.forEach(function (row) {
+                fragment.appendChild(row);
+            });
+
+            tbody.appendChild(fragment);
+
+            updateCount(countNode, visibleRows.length);
+
+            if (emptyMessage) {
+                emptyMessage.hidden = visibleRows.length > 0;
+            }
+        };
+
+        if (typeSelect) {
+            typeSelect.addEventListener('change', applyFilters);
+        }
+
+        if (sortSelect) {
+            sortSelect.addEventListener('change', applyFilters);
+        }
+
+        if (searchInput) {
+            searchInput.addEventListener('input', applyFilters);
+            searchInput.addEventListener('search', applyFilters);
+        }
+
+        applyFilters();
+    };
+
+    var onReady = function () {
+        var dashboards = document.querySelectorAll('[data-visibloc-dashboard]');
+
+        if (!dashboards.length) {
+            return;
+        }
+
+        Array.prototype.forEach.call(dashboards, function (dashboard) {
+            initDashboard(dashboard);
+        });
+    };
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', onReady);
+    } else {
+        onReady();
+    }
+})();

--- a/visi-bloc-jlg/includes/assets.php
+++ b/visi-bloc-jlg/includes/assets.php
@@ -107,6 +107,35 @@ function visibloc_jlg_enqueue_admin_supported_blocks_script( $hook_suffix ) {
     );
 }
 
+add_action( 'admin_enqueue_scripts', 'visibloc_jlg_enqueue_admin_visibility_dashboards_script' );
+function visibloc_jlg_enqueue_admin_visibility_dashboards_script( $hook_suffix ) {
+    if ( 'toplevel_page_visi-bloc-jlg-help' !== $hook_suffix ) {
+        return;
+    }
+
+    $plugin_main_file      = __DIR__ . '/../visi-bloc-jlg.php';
+    $script_relative_path  = 'assets/admin-visibility-dashboards.js';
+    $script_path           = plugin_dir_path( $plugin_main_file ) . $script_relative_path;
+    $default_script_version = defined( 'VISIBLOC_JLG_VERSION' ) ? VISIBLOC_JLG_VERSION : '1.1';
+    $script_version        = $default_script_version;
+
+    if ( file_exists( $script_path ) ) {
+        $file_version = filemtime( $script_path );
+
+        if ( false !== $file_version ) {
+            $script_version = (string) $file_version;
+        }
+    }
+
+    wp_enqueue_script(
+        'visibloc-jlg-visibility-dashboards',
+        plugins_url( $script_relative_path, $plugin_main_file ),
+        [],
+        $script_version,
+        true
+    );
+}
+
 add_action( 'enqueue_block_editor_assets', 'visibloc_jlg_enqueue_editor_assets' );
 function visibloc_jlg_enqueue_editor_assets() {
     $plugin_main_file = __DIR__ . '/../visi-bloc-jlg.php';


### PR DESCRIPTION
## Summary
- add unified dashboard tables for hidden, device-specific, and scheduled block sections with filtering controls
- enrich collected metadata with post type, editor role, and schedule details for new table columns
- add an admin dashboard filtering script and responsive styling updates, enqueued only on the plugin help page

## Testing
- `composer test:phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68e1a3d7b980832e9dd1e8048f8a176e