### PR TITLE
Highlight admin help navigation by active section

### DIFF
--- a/visi-bloc-jlg/assets/admin-nav.js
+++ b/visi-bloc-jlg/assets/admin-nav.js
@@ -94,7 +94,7 @@
             }
 
             nextLink.classList.add(activeClass);
-            nextLink.setAttribute('aria-current', 'true');
+            nextLink.setAttribute('aria-current', 'page');
             currentActiveKey = sectionKey;
             currentActiveLink = nextLink;
         };
@@ -104,56 +104,117 @@
             setActiveLink(fallbackKey);
         }
 
-        if (typeof window.IntersectionObserver !== 'function') {
-            return;
-        }
+        navLinks.forEach(function (link) {
+            link.addEventListener('click', function () {
+                var hash = link.hash ? decodeURIComponent(link.hash.substring(1)) : '';
 
-        var updateActiveFromRatios = function () {
-            var bestKey = null;
-            var bestRatio = -1;
+                if (hash && Object.prototype.hasOwnProperty.call(linkBySection, hash)) {
+                    setActiveLink(hash);
+                }
+            });
+        });
+
+        if (typeof window.IntersectionObserver === 'function') {
+            var updateActiveFromRatios = function () {
+                var bestKey = null;
+                var bestRatio = -1;
+
+                observedSectionKeys.forEach(function (key) {
+                    var ratio = ratioBySection[key] || 0;
+
+                    if (ratio > bestRatio + 0.0001) {
+                        bestRatio = ratio;
+                        bestKey = key;
+                    }
+                });
+
+                if (bestKey && bestRatio > 0) {
+                    setActiveLink(bestKey);
+                }
+            };
+
+            var observer = new IntersectionObserver(
+                function (entries) {
+                    entries.forEach(function (entry) {
+                        var target = entry.target;
+                        var key = target.getAttribute('data-visibloc-section') || target.id;
+
+                        if (!key || !Object.prototype.hasOwnProperty.call(ratioBySection, key)) {
+                            return;
+                        }
+
+                        var ratio = entry.isIntersecting ? entry.intersectionRatio : 0;
+                        ratioBySection[key] = ratio;
+                    });
+
+                    updateActiveFromRatios();
+                },
+                {
+                    threshold: [0, 0.1, 0.25, 0.5, 0.75, 1],
+                    rootMargin: '0px 0px -40% 0px',
+                }
+            );
 
             observedSectionKeys.forEach(function (key) {
-                var ratio = ratioBySection[key] || 0;
+                var section = sectionByKey[key];
 
-                if (ratio > bestRatio + 0.0001) {
-                    bestRatio = ratio;
-                    bestKey = key;
+                if (section) {
+                    observer.observe(section);
                 }
             });
 
-            if (bestKey && bestRatio > 0) {
-                setActiveLink(bestKey);
+            return;
+        }
+
+        var fallbackAnimationId = null;
+        var requestFallbackUpdate = function () {
+            if (fallbackAnimationId) {
+                return;
             }
-        };
 
-        var observer = new IntersectionObserver(
-            function (entries) {
-                entries.forEach(function (entry) {
-                    var target = entry.target;
-                    var key = target.getAttribute('data-visibloc-section') || target.id;
+            var raf = window.requestAnimationFrame || function (callback) {
+                return window.setTimeout(callback, 16);
+            };
 
-                    if (!key || !Object.prototype.hasOwnProperty.call(ratioBySection, key)) {
+            fallbackAnimationId = raf(function () {
+                fallbackAnimationId = null;
+
+                var viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+                var bestKey = null;
+                var bestVisible = -1;
+
+                observedSectionKeys.forEach(function (key) {
+                    var section = sectionByKey[key];
+
+                    if (!section) {
                         return;
                     }
 
-                    var ratio = entry.isIntersecting ? entry.intersectionRatio : 0;
-                    ratioBySection[key] = ratio;
+                    var rect = section.getBoundingClientRect();
+                    var top = rect.top;
+                    var bottom = rect.bottom;
+
+                    if (viewportHeight <= 0) {
+                        return;
+                    }
+
+                    var visible = Math.min(bottom, viewportHeight) - Math.max(top, 0);
+                    visible = visible > 0 ? visible : 0;
+
+                    if (visible > bestVisible + 0.5) {
+                        bestVisible = visible;
+                        bestKey = key;
+                    }
                 });
 
-                updateActiveFromRatios();
-            },
-            {
-                threshold: [0, 0.1, 0.25, 0.5, 0.75, 1],
-                rootMargin: '0px 0px -40% 0px',
-            }
-        );
+                if (bestKey && bestVisible > 0) {
+                    setActiveLink(bestKey);
+                }
+            });
+        };
 
-        observedSectionKeys.forEach(function (key) {
-            var section = sectionByKey[key];
-
-            if (section) {
-                observer.observe(section);
-            }
-        });
+        requestFallbackUpdate();
+        window.addEventListener('scroll', requestFallbackUpdate, { passive: true });
+        window.addEventListener('resize', requestFallbackUpdate);
     });
 })();

--- a/visi-bloc-jlg/assets/admin-responsive.css
+++ b/visi-bloc-jlg/assets/admin-responsive.css
@@ -83,24 +83,10 @@
     transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-.visibloc-help-nav__link--active {
-    background: #135e96;
-    border-color: #135e96;
-    color: #fff;
-    cursor: default;
-}
-
 .visibloc-help-nav__link:hover,
 .visibloc-help-nav__link:focus {
     background: #2271b1;
     border-color: #2271b1;
-    color: #fff;
-}
-
-.visibloc-help-nav__link--active:hover,
-.visibloc-help-nav__link--active:focus {
-    background: #0a4b78;
-    border-color: #0a4b78;
     color: #fff;
 }
 
@@ -109,7 +95,30 @@
     outline: none;
 }
 
-.visibloc-help-nav__link--active:focus-visible {
+.visibloc-help-nav__link--active,
+.visibloc-help-nav__link[aria-current="page"],
+.visibloc-help-nav__link[aria-current="true"] {
+    background: #135e96;
+    border-color: #135e96;
+    color: #fff;
+    cursor: default;
+    font-weight: 700;
+}
+
+.visibloc-help-nav__link--active:hover,
+.visibloc-help-nav__link--active:focus,
+.visibloc-help-nav__link[aria-current="page"]:hover,
+.visibloc-help-nav__link[aria-current="page"]:focus,
+.visibloc-help-nav__link[aria-current="true"]:hover,
+.visibloc-help-nav__link[aria-current="true"]:focus {
+    background: #0a4b78;
+    border-color: #0a4b78;
+    color: #fff;
+}
+
+.visibloc-help-nav__link--active:focus-visible,
+.visibloc-help-nav__link[aria-current="page"]:focus-visible,
+.visibloc-help-nav__link[aria-current="true"]:focus-visible {
     box-shadow: 0 0 0 2px #fff, 0 0 0 4px #0a4b78;
 }
 

--- a/visi-bloc-jlg/includes/admin-settings.php
+++ b/visi-bloc-jlg/includes/admin-settings.php
@@ -559,8 +559,14 @@ function visibloc_jlg_render_supported_blocks_section( $registered_block_types, 
         ? (array) VISIBLOC_JLG_DEFAULT_SUPPORTED_BLOCKS
         : [ 'core/group' ];
 
+    $section_id = 'visibloc-section-blocks';
+
     ?>
-    <div id="visibloc-section-blocks" class="postbox" data-visibloc-section="visibloc-section-blocks">
+    <div
+        id="<?php echo esc_attr( $section_id ); ?>"
+        class="postbox"
+        data-visibloc-section="<?php echo esc_attr( $section_id ); ?>"
+    >
         <h2 class="hndle"><span><?php esc_html_e( 'Blocs compatibles', 'visi-bloc-jlg' ); ?></span></h2>
         <div class="inside">
             <form method="POST" action="">
@@ -669,8 +675,14 @@ function visibloc_jlg_render_permissions_section( $allowed_roles ) {
         return;
     }
 
+    $section_id = 'visibloc-section-permissions';
+
     ?>
-    <div id="visibloc-section-permissions" class="postbox" data-visibloc-section="visibloc-section-permissions">
+    <div
+        id="<?php echo esc_attr( $section_id ); ?>"
+        class="postbox"
+        data-visibloc-section="<?php echo esc_attr( $section_id ); ?>"
+    >
         <h2 class="hndle"><span><?php esc_html_e( "Permissions d'Aperçu", 'visi-bloc-jlg' ); ?></span></h2>
         <div class="inside">
             <form method="POST" action="">
@@ -698,8 +710,14 @@ function visibloc_jlg_render_permissions_section( $allowed_roles ) {
 function visibloc_jlg_render_hidden_blocks_section( $hidden_posts ) {
     $grouped_hidden_posts = visibloc_jlg_group_posts_by_id( $hidden_posts );
 
+    $section_id = 'visibloc-section-hidden';
+
     ?>
-    <div id="visibloc-section-hidden" class="postbox" data-visibloc-section="visibloc-section-hidden">
+    <div
+        id="<?php echo esc_attr( $section_id ); ?>"
+        class="postbox"
+        data-visibloc-section="<?php echo esc_attr( $section_id ); ?>"
+    >
         <h2 class="hndle"><span><?php esc_html_e( 'Tableau de bord des blocs masqués (via Œil)', 'visi-bloc-jlg' ); ?></span></h2>
         <div class="inside">
             <?php if ( empty( $grouped_hidden_posts ) ) : ?>
@@ -727,8 +745,14 @@ function visibloc_jlg_render_hidden_blocks_section( $hidden_posts ) {
 function visibloc_jlg_render_device_visibility_section( $device_posts ) {
     $grouped_device_posts = visibloc_jlg_group_posts_by_id( $device_posts );
 
+    $section_id = 'visibloc-section-device';
+
     ?>
-    <div id="visibloc-section-device" class="postbox" data-visibloc-section="visibloc-section-device">
+    <div
+        id="<?php echo esc_attr( $section_id ); ?>"
+        class="postbox"
+        data-visibloc-section="<?php echo esc_attr( $section_id ); ?>"
+    >
         <h2 class="hndle"><span><?php esc_html_e( 'Tableau de bord des blocs avec visibilité par appareil', 'visi-bloc-jlg' ); ?></span></h2>
         <div class="inside">
             <?php if ( empty( $grouped_device_posts ) ) : ?>
@@ -760,8 +784,14 @@ function visibloc_jlg_render_scheduled_blocks_section( $scheduled_posts ) {
     $start_column_label = __( 'Date de début', 'visi-bloc-jlg' );
     $end_column_label   = __( 'Date de fin', 'visi-bloc-jlg' );
 
+    $section_id = 'visibloc-section-scheduled';
+
     ?>
-    <div id="visibloc-section-scheduled" class="postbox" data-visibloc-section="visibloc-section-scheduled">
+    <div
+        id="<?php echo esc_attr( $section_id ); ?>"
+        class="postbox"
+        data-visibloc-section="<?php echo esc_attr( $section_id ); ?>"
+    >
         <h2 class="hndle"><span><?php esc_html_e( 'Tableau de bord des blocs programmés', 'visi-bloc-jlg' ); ?></span></h2>
         <div class="inside">
             <?php if ( empty( $scheduled_posts ) ) : ?>
@@ -809,8 +839,14 @@ function visibloc_jlg_render_scheduled_blocks_section( $scheduled_posts ) {
 }
 
 function visibloc_jlg_render_debug_mode_section( $debug_status ) {
+    $section_id = 'visibloc-section-debug';
+
     ?>
-    <div id="visibloc-section-debug" class="postbox" data-visibloc-section="visibloc-section-debug">
+    <div
+        id="<?php echo esc_attr( $section_id ); ?>"
+        class="postbox"
+        data-visibloc-section="<?php echo esc_attr( $section_id ); ?>"
+    >
         <h2 class="hndle"><span><?php esc_html_e( 'Mode de débogage', 'visi-bloc-jlg' ); ?></span></h2>
         <div class="inside">
             <form method="POST" action="">
@@ -828,8 +864,14 @@ function visibloc_jlg_render_debug_mode_section( $debug_status ) {
 }
 
 function visibloc_jlg_render_settings_backup_section() {
+    $section_id = 'visibloc-section-backup';
+
     ?>
-    <div id="visibloc-section-backup" class="postbox" data-visibloc-section="visibloc-section-backup">
+    <div
+        id="<?php echo esc_attr( $section_id ); ?>"
+        class="postbox"
+        data-visibloc-section="<?php echo esc_attr( $section_id ); ?>"
+    >
         <h2 class="hndle"><span><?php esc_html_e( 'Export & sauvegarde', 'visi-bloc-jlg' ); ?></span></h2>
         <div class="inside">
             <p><?php esc_html_e( 'Exportez vos réglages pour les sauvegarder ou les transférer vers un autre site.', 'visi-bloc-jlg' ); ?></p>
@@ -858,8 +900,14 @@ function visibloc_jlg_render_breakpoints_section( $mobile_bp, $tablet_bp ) {
     $breakpoints_requirement_message = visibloc_jlg_get_breakpoints_requirement_message();
     $breakpoints_help_id             = 'visibloc_breakpoints_help';
 
+    $section_id = 'visibloc-section-breakpoints';
+
     ?>
-    <div id="visibloc-section-breakpoints" class="postbox" data-visibloc-section="visibloc-section-breakpoints">
+    <div
+        id="<?php echo esc_attr( $section_id ); ?>"
+        class="postbox"
+        data-visibloc-section="<?php echo esc_attr( $section_id ); ?>"
+    >
         <h2 class="hndle"><span><?php esc_html_e( 'Réglage des points de rupture', 'visi-bloc-jlg' ); ?></span></h2>
         <div class="inside">
             <form method="POST" action="">
@@ -894,8 +942,14 @@ function visibloc_jlg_render_fallback_section( $fallback_settings, $fallback_blo
     $fallback_text_help_id  = 'visibloc_fallback_text_help';
     $fallback_block_help_id = 'visibloc_fallback_block_help';
 
+    $section_id = 'visibloc-section-fallback';
+
     ?>
-    <div id="visibloc-section-fallback" class="postbox" data-visibloc-section="visibloc-section-fallback">
+    <div
+        id="<?php echo esc_attr( $section_id ); ?>"
+        class="postbox"
+        data-visibloc-section="<?php echo esc_attr( $section_id ); ?>"
+    >
         <h2 class="hndle"><span><?php esc_html_e( 'Contenu de repli global', 'visi-bloc-jlg' ); ?></span></h2>
         <div class="inside">
             <form method="POST" action="">


### PR DESCRIPTION
## Summary
- add explicit `data-visibloc-section` attributes to each help section container for reliable navigation targeting
- implement an admin navigation script that highlights the link of the section in view, with click and non-IntersectionObserver fallbacks
- style the active navigation link state for accessible color, weight, and focus treatments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e24df5f200832ebd0157780dcf0f38