### PR TITLE
Add overlay for device-specific block visibility in editor

### DIFF
--- a/visi-bloc-jlg/src/editor-styles.css
+++ b/visi-bloc-jlg/src/editor-styles.css
@@ -117,6 +117,75 @@
     border-left: 4px solid rgba(30, 64, 175, 0.5);
 }
 
+.visibloc-block-edit-wrapper {
+    position: relative;
+}
+
+.visibloc-block-edit-wrapper--has-overlay {
+    position: relative;
+}
+
+.visibloc-device-visibility-overlay {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    z-index: 10;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    max-width: min(280px, calc(100% - 24px));
+    padding: 12px 16px;
+    border-radius: 8px;
+    background: rgba(15, 23, 42, 0.82);
+    color: #fff;
+    box-shadow: 0 6px 16px rgba(15, 23, 42, 0.4);
+    pointer-events: none;
+}
+
+.visibloc-device-visibility-overlay__message {
+    margin: 0;
+    font-size: 13px;
+    line-height: 1.4;
+    font-weight: 600;
+    word-break: break-word;
+    overflow-wrap: anywhere;
+}
+
+.visibloc-device-visibility-overlay__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.visibloc-device-visibility-overlay__reset {
+    pointer-events: auto;
+}
+
+.visibloc-device-visibility-overlay__reset.components-button.is-secondary.is-small {
+    border-color: rgba(255, 255, 255, 0.75);
+    color: #fff;
+    background: rgba(15, 23, 42, 0.15);
+}
+
+.visibloc-device-visibility-overlay__reset.components-button.is-secondary.is-small:hover,
+.visibloc-device-visibility-overlay__reset.components-button.is-secondary.is-small:focus {
+    border-color: rgba(255, 255, 255, 0.9);
+    color: #fff;
+}
+
+.visibloc-device-visibility-overlay__reset.components-button.is-secondary.is-small:focus-visible {
+    box-shadow: 0 0 0 2px #fff, 0 0 0 4px rgba(15, 23, 42, 0.75);
+}
+
+@media (max-width: 782px) {
+    .visibloc-device-visibility-overlay {
+        top: 8px;
+        right: 8px;
+        left: 8px;
+        max-width: unset;
+    }
+}
+
 @media (max-width: 782px) {
     .block-editor-block-list__block.bloc-editeur-cache > .visibloc-status-badge,
     .block-editor-block-list__block.bloc-editeur-repli > .visibloc-status-badge.visibloc-status-badge--fallback {


### PR DESCRIPTION
## Summary
- detect the current preview device via the core/edit-post store and compute visibility restrictions for supported blocks
- surface a translucent overlay with reset controls when device visibility hides the block and style it for clarity and accessibility

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e26d6f86a4832e9682cce29bb22833