### PR TITLE
Add editor term query filter and expand integration coverage

### DIFF
--- a/visi-bloc-jlg/includes/assets.php
+++ b/visi-bloc-jlg/includes/assets.php
@@ -248,17 +248,27 @@ function visibloc_jlg_get_editor_taxonomies() {
         $term_options = [];
 
         if ( taxonomy_exists( $slug ) ) {
-            $terms = get_terms(
-                [
-                    'taxonomy'   => $slug,
-                    'hide_empty' => false,
-                    'number'     => 200,
-                    'orderby'    => 'name',
-                    'order'      => 'ASC',
-                ]
-            );
+            $term_query_args = [
+                'taxonomy'   => $slug,
+                'hide_empty' => false,
+                'number'     => 200, // Default limit for editor term suggestions.
+                'orderby'    => 'name',
+                'order'      => 'ASC',
+            ];
 
-            if ( ! is_wp_error( $terms ) ) {
+            /**
+             * Filter the query arguments used to retrieve taxonomy terms for the editor.
+             *
+             * The default arguments include a limit of 200 terms to avoid large responses.
+             *
+             * @param array  $term_query_args Query arguments passed to {@see get_terms()}.
+             * @param string $slug            Taxonomy slug being queried.
+             */
+            $term_query_args = apply_filters( 'visibloc_jlg_editor_terms_query_args', $term_query_args, $slug );
+
+            $terms = get_terms( $term_query_args );
+
+            if ( ! is_wp_error( $terms ) && is_array( $terms ) ) {
                 foreach ( $terms as $term ) {
                     if ( ! $term instanceof WP_Term ) {
                         continue;

--- a/visi-bloc-jlg/includes/visibility-logic.php
+++ b/visi-bloc-jlg/includes/visibility-logic.php
@@ -318,14 +318,20 @@ function visibloc_jlg_get_user_visibility_context( $preview_context, &$can_previ
             $applied_preview_role = 'guest';
         } elseif ( '' !== $preview_role ) {
             static $allowed_preview_roles_cache = null;
-
-            if ( null === $allowed_preview_roles_cache ) {
-                $allowed_preview_roles_cache = function_exists( 'visibloc_jlg_get_allowed_preview_roles' )
-                    ? (array) visibloc_jlg_get_allowed_preview_roles()
-                    : [];
-            }
-
+            static $allowed_preview_roles_key = null;
             static $role_exists_cache = [];
+
+            $current_allowed_roles = function_exists( 'visibloc_jlg_get_allowed_preview_roles' )
+                ? (array) visibloc_jlg_get_allowed_preview_roles()
+                : [];
+
+            $allowed_roles_key = md5( wp_json_encode( array_values( $current_allowed_roles ) ) );
+
+            if ( null === $allowed_preview_roles_key || $allowed_preview_roles_key !== $allowed_roles_key ) {
+                $allowed_preview_roles_cache = $current_allowed_roles;
+                $allowed_preview_roles_key   = $allowed_roles_key;
+                $role_exists_cache           = [];
+            }
 
             if ( ! array_key_exists( $preview_role, $role_exists_cache ) ) {
                 $role_exists_cache[ $preview_role ] = (bool) get_role( $preview_role );


### PR DESCRIPTION
## Summary
- allow `visibloc_jlg_get_editor_taxonomies()` to filter the `get_terms()` query args and document the default 200 term limit
- refresh cached preview role lookups when allowed roles change and add taxonomy/term stubs for the integration test environment
- add an integration test that raises the filtered term limit to expose the extra taxonomy term

## Testing
- composer test:phpunit

------
https://chatgpt.com/codex/tasks/task_e_68e27fb8a068832e9ec9d126ab557bc4