### PR TITLE
Add caching and pagination support for fallback block lookup

### DIFF
--- a/visi-bloc-jlg/includes/admin-settings.php
+++ b/visi-bloc-jlg/includes/admin-settings.php
@@ -1525,6 +1525,10 @@ function visibloc_jlg_get_scheduled_posts() {
 }
 
 function visibloc_jlg_clear_caches( $unused_post_id = null ) {
+    if ( function_exists( 'visibloc_jlg_invalidate_fallback_blocks_cache' ) ) {
+        visibloc_jlg_invalidate_fallback_blocks_cache();
+    }
+
     delete_transient( 'visibloc_hidden_posts' );
     delete_transient( 'visibloc_device_posts' );
     delete_transient( 'visibloc_scheduled_posts' );

--- a/visi-bloc-jlg/includes/visibility-logic.php
+++ b/visi-bloc-jlg/includes/visibility-logic.php
@@ -283,10 +283,20 @@ function visibloc_jlg_wrap_preview_with_fallback_notice( $preview_markup, $fallb
     );
 }
 
-function visibloc_jlg_get_user_visibility_context( $preview_context, &$can_preview_hidden_blocks ) {
-    static $cached_user_ref = null;
-    static $cached_user_logged_in = null;
-    static $cached_user_roles = null;
+function visibloc_jlg_get_user_visibility_context( $preview_context, &$can_preview_hidden_blocks, $reset_cache = false ) {
+    static $cached_user_ref            = null;
+    static $cached_user_logged_in      = null;
+    static $cached_user_roles          = null;
+    static $allowed_preview_roles_cache = null;
+    static $role_exists_cache          = [];
+
+    if ( $reset_cache ) {
+        $cached_user_ref             = null;
+        $cached_user_logged_in       = null;
+        $cached_user_roles           = null;
+        $allowed_preview_roles_cache = null;
+        $role_exists_cache           = [];
+    }
 
     $current_user = wp_get_current_user();
     $current_roles = (array) $current_user->roles;
@@ -317,15 +327,11 @@ function visibloc_jlg_get_user_visibility_context( $preview_context, &$can_previ
             $user_roles   = [];
             $applied_preview_role = 'guest';
         } elseif ( '' !== $preview_role ) {
-            static $allowed_preview_roles_cache = null;
-
             if ( null === $allowed_preview_roles_cache ) {
                 $allowed_preview_roles_cache = function_exists( 'visibloc_jlg_get_allowed_preview_roles' )
                     ? (array) visibloc_jlg_get_allowed_preview_roles()
                     : [];
             }
-
-            static $role_exists_cache = [];
 
             if ( ! array_key_exists( $preview_role, $role_exists_cache ) ) {
                 $role_exists_cache[ $preview_role ] = (bool) get_role( $preview_role );

--- a/visi-bloc-jlg/uninstall.php
+++ b/visi-bloc-jlg/uninstall.php
@@ -11,6 +11,22 @@ delete_option( 'visibloc_supported_blocks' );
 delete_option( 'visibloc_fallback_settings' );
 wp_cache_delete( 'visibloc_fallback_settings', 'visibloc_jlg' );
 
+$fallback_transients = get_option( 'visibloc_fallback_blocks_transients', [] );
+
+if ( is_array( $fallback_transients ) ) {
+    foreach ( array_unique( array_map( 'strval', $fallback_transients ) ) as $transient_key ) {
+        if ( '' === $transient_key ) {
+            continue;
+        }
+
+        delete_transient( $transient_key );
+    }
+}
+
+delete_option( 'visibloc_fallback_blocks_transients' );
+delete_option( 'visibloc_fallback_blocks_cache_version' );
+wp_cache_delete( 'visibloc_fallback_blocks_version', 'visibloc_jlg' );
+
 // Supprime les transients de cache du plugin
 delete_transient( 'visibloc_hidden_posts' );
 delete_transient( 'visibloc_device_posts' );


### PR DESCRIPTION
## Summary
- add cache management helpers and search/pagination awareness to the fallback block lookup, including hooks to invalidate per site/locale caches
- clear the new fallback caches during admin cache flushes and uninstall while resetting preview context caches when resetting test state
- extend integration tests and fixtures to cover caching behaviour, server-driven pagination/search, and keep the get_posts stub in sync

## Testing
- composer test:phpunit

------
https://chatgpt.com/codex/tasks/task_e_68e27fc98ff8832e92b0431fb6c64acd