### PR TITLE
Fix desktop help nav link width

### DIFF
--- a/visi-bloc-jlg/assets/admin-responsive.css
+++ b/visi-bloc-jlg/assets/admin-responsive.css
@@ -274,7 +274,7 @@
 
     .visibloc-help-nav__link {
         min-width: unset;
-        width: 100%;
+        width: auto;
     }
 
     .visibloc-table-label {


### PR DESCRIPTION
## Summary
- adjust desktop help navigation link width to avoid stretching beyond its content

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2cff5d018832ea4e7a5bf62fc37a7