### PR TITLE
Validate fallback fallback blocks before using them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 vendor/
 visi-bloc-jlg/languages/*.mo
+.phpunit.result.cache

--- a/visi-bloc-jlg/includes/fallback.php
+++ b/visi-bloc-jlg/includes/fallback.php
@@ -103,7 +103,19 @@ function visibloc_jlg_fallback_has_content( $settings ) {
     }
 
     if ( 'block' === $mode ) {
-        return ! empty( $settings['block_id'] );
+        $block_id = isset( $settings['block_id'] ) ? absint( $settings['block_id'] ) : 0;
+
+        if ( $block_id <= 0 || ! function_exists( 'get_post' ) ) {
+            return false;
+        }
+
+        $block = get_post( $block_id );
+
+        if ( ! ( $block instanceof WP_Post ) ) {
+            return false;
+        }
+
+        return 'wp_block' === $block->post_type && 'publish' === $block->post_status;
     }
 
     return false;

--- a/visi-bloc-jlg/tests/phpunit/integration/FallbackSettingsTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/FallbackSettingsTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class FallbackSettingsTest extends TestCase {
+    protected function setUp(): void {
+        visibloc_test_reset_state();
+        $GLOBALS['visibloc_posts'] = [];
+    }
+
+    public function test_block_mode_without_existing_post_is_not_considered_content(): void {
+        $settings = [
+            'mode'     => 'block',
+            'block_id' => 42,
+        ];
+
+        $this->assertFalse(
+            visibloc_jlg_fallback_has_content( $settings ),
+            'Missing reusable blocks should not be treated as usable fallback content.'
+        );
+    }
+
+    public function test_block_mode_requires_published_reusable_block(): void {
+        $GLOBALS['visibloc_posts'][7] = [
+            'post_title'   => 'Draft reusable block',
+            'post_content' => '<!-- wp:paragraph --><p>Fallback draft</p><!-- /wp:paragraph -->',
+            'post_type'    => 'wp_block',
+            'post_status'  => 'draft',
+        ];
+
+        $draft_settings = [
+            'mode'     => 'block',
+            'block_id' => 7,
+        ];
+
+        $this->assertFalse(
+            visibloc_jlg_fallback_has_content( $draft_settings ),
+            'Draft reusable blocks should not be used as published fallback content.'
+        );
+
+        $GLOBALS['visibloc_posts'][7]['post_status'] = 'publish';
+
+        $this->assertTrue(
+            visibloc_jlg_fallback_has_content( $draft_settings ),
+            'Published reusable blocks should be considered valid fallback content.'
+        );
+    }
+
+    public function test_block_mode_rejects_non_reusable_post_types(): void {
+        $GLOBALS['visibloc_posts'][9] = [
+            'post_title'   => 'Regular post',
+            'post_content' => 'Content',
+            'post_type'    => 'post',
+            'post_status'  => 'publish',
+        ];
+
+        $settings = [
+            'mode'     => 'block',
+            'block_id' => 9,
+        ];
+
+        $this->assertFalse(
+            visibloc_jlg_fallback_has_content( $settings ),
+            'Only reusable blocks should be accepted when fallback mode targets a block.'
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- ensure the fallback block mode only reports content when the referenced reusable block exists and is published
- cover the stricter validation with integration tests
- ignore PHPUnit's result cache artefact

## Testing
- composer test:phpunit

------
https://chatgpt.com/codex/tasks/task_e_68e39cb11674832ebc6f86037e9426ce