### PR TITLE
Add WP-CLI command to export plugin settings

### DIFF
--- a/visi-bloc-jlg/includes/cli.php
+++ b/visi-bloc-jlg/includes/cli.php
@@ -29,5 +29,63 @@ if ( ! function_exists( 'visibloc_jlg_cli_rebuild_index_command' ) ) {
     }
 }
 
+if ( ! function_exists( 'visibloc_jlg_cli_export_settings_command' ) ) {
+    /**
+     * Handle the `wp visibloc export-settings` command.
+     *
+     * @param array $args       Positional command arguments (unused).
+     * @param array $assoc_args Associative command arguments.
+     */
+    function visibloc_jlg_cli_export_settings_command( $args, $assoc_args ) {
+        if ( ! function_exists( 'visibloc_jlg_get_settings_snapshot' ) ) {
+            require_once __DIR__ . '/admin-settings.php';
+        }
+
+        if ( function_exists( 'visibloc_jlg_get_fallback_settings' ) ) {
+            visibloc_jlg_get_fallback_settings( true );
+        }
+
+        $snapshot = visibloc_jlg_get_settings_snapshot();
+        $json     = wp_json_encode( $snapshot );
+
+        if ( false === $json ) {
+            WP_CLI::error( 'Unable to encode the settings snapshot as JSON.' );
+        }
+
+        $decoded = json_decode( $json, true );
+        if ( JSON_ERROR_NONE === json_last_error() && is_array( $decoded ) ) {
+            $pretty = json_encode( $decoded, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+
+            if ( false !== $pretty ) {
+                $json = $pretty;
+            }
+        }
+
+        $output_path = isset( $assoc_args['output'] ) ? trim( (string) $assoc_args['output'] ) : '';
+
+        if ( '' !== $output_path ) {
+            $directory = dirname( $output_path );
+
+            if ( '' !== $directory && '.' !== $directory && ! is_dir( $directory ) ) {
+                WP_CLI::error( sprintf( 'Directory does not exist: %s', $directory ) );
+            }
+
+            $bytes_written = file_put_contents( $output_path, $json );
+
+            if ( false === $bytes_written ) {
+                WP_CLI::error( sprintf( 'Unable to write settings snapshot to %s.', $output_path ) );
+            }
+
+            WP_CLI::success( sprintf( 'Settings snapshot written to %s.', $output_path ) );
+
+            return;
+        }
+
+        WP_CLI::log( $json );
+        WP_CLI::success( 'Settings snapshot exported.' );
+    }
+}
+
 WP_CLI::add_command( 'visibloc rebuild-index', 'visibloc_jlg_cli_rebuild_index_command' );
+WP_CLI::add_command( 'visibloc export-settings', 'visibloc_jlg_cli_export_settings_command' );
 

--- a/visi-bloc-jlg/tests/phpunit/integration/CliExportSettingsTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/CliExportSettingsTest.php
@@ -1,0 +1,154 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @runTestsInSeparateProcesses
+ */
+class CliExportSettingsTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        if ( ! defined( 'WP_CLI' ) ) {
+            define( 'WP_CLI', true );
+        }
+
+        if ( ! class_exists( 'WP_CLI' ) ) {
+            eval(
+                'class WP_CLI {' .
+                '    public static $commands = [];' .
+                '    public static $log_messages = [];' .
+                '    public static $success_messages = [];' .
+                '    public static $error_messages = [];' .
+                '    public static function add_command( $name, $callable ) {' .
+                '        self::$commands[ $name ] = $callable;' .
+                '    }' .
+                '    public static function log( $message ) {' .
+                '        self::$log_messages[] = (string) $message;' .
+                '    }' .
+                '    public static function success( $message ) {' .
+                '        self::$success_messages[] = (string) $message;' .
+                '    }' .
+                '    public static function error( $message ) {' .
+                '        self::$error_messages[] = (string) $message;' .
+                '        throw new RuntimeException( (string) $message );' .
+                '    }' .
+                '}'
+            );
+        }
+
+        if ( ! function_exists( 'visibloc_jlg_get_settings_snapshot' ) ) {
+            require_once __DIR__ . '/../../../includes/admin-settings.php';
+        }
+
+        if ( empty( WP_CLI::$commands ) || ! isset( WP_CLI::$commands['visibloc export-settings'] ) ) {
+            require_once __DIR__ . '/../../../includes/cli.php';
+        }
+
+        visibloc_test_reset_state();
+
+        if ( ! defined( 'VISIBLOC_JLG_VERSION' ) ) {
+            define( 'VISIBLOC_JLG_VERSION', '9.9.9-test' );
+        }
+
+        WP_CLI::$log_messages     = [];
+        WP_CLI::$success_messages = [];
+        WP_CLI::$error_messages   = [];
+    }
+
+    protected function tearDown(): void {
+        $GLOBALS['visibloc_test_options']  = [];
+        WP_CLI::$commands                  = [];
+        WP_CLI::$log_messages              = [];
+        WP_CLI::$success_messages          = [];
+        WP_CLI::$error_messages            = [];
+
+        parent::tearDown();
+    }
+
+    public function test_export_settings_outputs_snapshot_to_stdout(): void {
+        $this->assertArrayHasKey( 'visibloc export-settings', WP_CLI::$commands );
+
+        $command = WP_CLI::$commands['visibloc export-settings'];
+        $this->assertIsCallable( $command );
+
+        $GLOBALS['visibloc_test_state']['allowed_preview_roles'] = [ 'administrator', 'editor' ];
+
+        update_option( 'visibloc_supported_blocks', [ 'core/group', 'core/paragraph' ] );
+        update_option( 'visibloc_breakpoint_mobile', 640 );
+        update_option( 'visibloc_breakpoint_tablet', 980 );
+        update_option( 'visibloc_debug_mode', 'on' );
+        update_option(
+            'visibloc_fallback_settings',
+            [
+                'mode'     => 'text',
+                'text'     => 'Bonjour <strong>monde</strong>!',
+                'block_id' => 0,
+            ]
+        );
+
+        call_user_func( $command, [], [] );
+
+        $this->assertNotEmpty( WP_CLI::$log_messages );
+        $json = end( WP_CLI::$log_messages );
+
+        $decoded = json_decode( $json, true );
+        $this->assertIsArray( $decoded );
+
+        $this->assertSame( [ 'core/group', 'core/paragraph' ], $decoded['supported_blocks'] );
+        $this->assertSame(
+            [
+                'mobile' => 640,
+                'tablet' => 980,
+            ],
+            $decoded['breakpoints']
+        );
+        $this->assertSame( [ 'administrator', 'editor' ], $decoded['preview_roles'] );
+        $this->assertSame( 'on', $decoded['debug_mode'] );
+        $this->assertSame(
+            [
+                'mode'     => 'text',
+                'text'     => 'Bonjour <strong>monde</strong>!',
+                'block_id' => 0,
+            ],
+            $decoded['fallback']
+        );
+        $this->assertArrayHasKey( 'exported_at', $decoded );
+        $this->assertArrayHasKey( 'version', $decoded );
+        $this->assertIsString( $decoded['version'] );
+        $this->assertNotSame( '', $decoded['version'] );
+
+        $this->assertSame( [ 'Settings snapshot exported.' ], WP_CLI::$success_messages );
+    }
+
+    public function test_export_settings_writes_snapshot_to_file(): void {
+        $command = WP_CLI::$commands['visibloc export-settings'];
+        $this->assertIsCallable( $command );
+
+        update_option( 'visibloc_supported_blocks', [ 'core/group' ] );
+
+        $output_file = tempnam( sys_get_temp_dir(), 'visibloc-settings-' );
+
+        try {
+            call_user_func( $command, [], [ 'output' => $output_file ] );
+        } catch ( RuntimeException $exception ) {
+            $this->fail( 'Export command threw an unexpected error: ' . $exception->getMessage() );
+        }
+
+        $this->assertFileExists( $output_file );
+
+        $contents = file_get_contents( $output_file );
+        $this->assertIsString( $contents );
+
+        $decoded = json_decode( $contents, true );
+        $this->assertIsArray( $decoded );
+        $this->assertSame( [ 'core/group' ], $decoded['supported_blocks'] );
+
+        $this->assertSame(
+            [ sprintf( 'Settings snapshot written to %s.', $output_file ) ],
+            WP_CLI::$success_messages
+        );
+
+        unlink( $output_file );
+    }
+}

--- a/visi-bloc-jlg/tests/phpunit/integration/CliRebuildIndexTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/CliRebuildIndexTest.php
@@ -19,6 +19,7 @@ class CliRebuildIndexTest extends TestCase {
                 '    public static $commands = [];' .
                 '    public static $log_messages = [];' .
                 '    public static $success_messages = [];' .
+                '    public static $error_messages = [];' .
                 '    public static function add_command( $name, $callable ) {' .
                 '        self::$commands[ $name ] = $callable;' .
                 '    }' .
@@ -27,6 +28,10 @@ class CliRebuildIndexTest extends TestCase {
                 '    }' .
                 '    public static function success( $message ) {' .
                 '        self::$success_messages[] = (string) $message;' .
+                '    }' .
+                '    public static function error( $message ) {' .
+                '        self::$error_messages[] = (string) $message;' .
+                '        throw new RuntimeException( (string) $message );' .
                 '    }' .
                 '}'
             );
@@ -56,6 +61,7 @@ class CliRebuildIndexTest extends TestCase {
 
         WP_CLI::$log_messages     = [];
         WP_CLI::$success_messages = [];
+        WP_CLI::$error_messages   = [];
     }
 
     protected function tearDown(): void {


### PR DESCRIPTION
## Summary
- add a `wp visibloc export-settings` command that prints or writes the settings snapshot as JSON
- refresh fallback caches before exporting so the snapshot reflects the latest option values
- cover the new command with integration tests and extend the CLI test double

## Testing
- composer test:phpunit

------
https://chatgpt.com/codex/tasks/task_e_68e433247f18832e853712b148c2554f