### PR TITLE
Refactor plugin metadata helpers for asset loading

### DIFF
--- a/visi-bloc-jlg/src/Plugin.php
+++ b/visi-bloc-jlg/src/Plugin.php
@@ -37,11 +37,21 @@ class Plugin {
      * @param string $plugin_file Absolute path to the main plugin file.
      */
     public function __construct( $plugin_file ) {
-        $this->plugin_file     = $plugin_file;
-        $this->plugin_dir      = dirname( $plugin_file );
-        $this->plugin_basename = function_exists( 'plugin_basename' )
-            ? plugin_basename( $plugin_file )
-            : basename( $plugin_file );
+        $this->plugin_file = $plugin_file;
+
+        if ( defined( 'VISIBLOC_JLG_PLUGIN_DIR' ) ) {
+            $this->plugin_dir = rtrim( VISIBLOC_JLG_PLUGIN_DIR, '/\\' );
+        } else {
+            $this->plugin_dir = dirname( $plugin_file );
+        }
+
+        if ( defined( 'VISIBLOC_JLG_PLUGIN_BASENAME' ) ) {
+            $this->plugin_basename = VISIBLOC_JLG_PLUGIN_BASENAME;
+        } else {
+            $this->plugin_basename = function_exists( 'plugin_basename' )
+                ? plugin_basename( $plugin_file )
+                : basename( $plugin_file );
+        }
     }
 
     /**

--- a/visi-bloc-jlg/visi-bloc-jlg.php
+++ b/visi-bloc-jlg/visi-bloc-jlg.php
@@ -12,6 +12,56 @@ if ( ! defined( 'WPINC' ) ) {
     exit;
 }
 
+if ( ! defined( 'VISIBLOC_JLG_PLUGIN_FILE' ) ) {
+    define( 'VISIBLOC_JLG_PLUGIN_FILE', __FILE__ );
+}
+
+if ( ! defined( 'VISIBLOC_JLG_PLUGIN_DIR' ) ) {
+    if ( function_exists( 'plugin_dir_path' ) ) {
+        define( 'VISIBLOC_JLG_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+    } else {
+        define( 'VISIBLOC_JLG_PLUGIN_DIR', dirname( __FILE__ ) . '/' );
+    }
+}
+
+if ( ! defined( 'VISIBLOC_JLG_PLUGIN_BASENAME' ) ) {
+    if ( function_exists( 'plugin_basename' ) ) {
+        define( 'VISIBLOC_JLG_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
+    } else {
+        define( 'VISIBLOC_JLG_PLUGIN_BASENAME', basename( __FILE__ ) );
+    }
+}
+
+if ( ! defined( 'VISIBLOC_JLG_PLUGIN_URL' ) ) {
+    if ( function_exists( 'plugin_dir_url' ) ) {
+        define( 'VISIBLOC_JLG_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+    } elseif ( function_exists( 'plugins_url' ) ) {
+        define( 'VISIBLOC_JLG_PLUGIN_URL', rtrim( plugins_url( '', __FILE__ ), '/' ) . '/' );
+    } else {
+        define( 'VISIBLOC_JLG_PLUGIN_URL', '' );
+    }
+}
+
+if ( ! defined( 'VISIBLOC_JLG_VERSION' ) ) {
+    $visibloc_version = '0.0.0';
+
+    if ( function_exists( 'get_file_data' ) ) {
+        $plugin_data = get_file_data( __FILE__, [ 'Version' => 'Version' ] );
+
+        if ( isset( $plugin_data['Version'] ) && '' !== $plugin_data['Version'] ) {
+            $visibloc_version = $plugin_data['Version'];
+        }
+    } else {
+        $plugin_contents = @file_get_contents( __FILE__ );
+
+        if ( false !== $plugin_contents && preg_match( '/^\s*\*\s*Version:\s*(.+)$/mi', $plugin_contents, $matches ) ) {
+            $visibloc_version = trim( $matches[1] );
+        }
+    }
+
+    define( 'VISIBLOC_JLG_VERSION', $visibloc_version );
+}
+
 require_once __DIR__ . '/autoload.php';
 require_once __DIR__ . '/includes/i18n-inline.php';
 


### PR DESCRIPTION
## Summary
- define plugin metadata constants during bootstrap so the values are reusable across the codebase
- add asset helper utilities to centralise plugin paths/URLs and reuse them throughout the enqueue logic
- harden device CSS caching by falling back to a default plugin version when the constant is missing

## Testing
- composer test:phpunit

------
https://chatgpt.com/codex/tasks/task_e_68e4481d7a68832e8bde4dd3760d7b73