### PR TITLE
Centralize version resolution and normalize preview cookie handling

### DIFF
--- a/visi-bloc-jlg/includes/assets.php
+++ b/visi-bloc-jlg/includes/assets.php
@@ -5,6 +5,7 @@ if ( ! defined( 'VISIBLOC_JLG_MISSING_EDITOR_ASSETS_TRANSIENT' ) ) {
     define( 'VISIBLOC_JLG_MISSING_EDITOR_ASSETS_TRANSIENT', 'visibloc_jlg_missing_editor_assets' );
 }
 
+require_once __DIR__ . '/plugin-meta.php';
 require_once __DIR__ . '/cache-constants.php';
 require_once __DIR__ . '/datetime-utils.php';
 require_once __DIR__ . '/fallback.php';
@@ -30,36 +31,6 @@ if ( ! function_exists( 'visibloc_jlg_path_join' ) ) {
         }
 
         return $base . '/' . $path;
-    }
-}
-
-if ( ! function_exists( 'visibloc_jlg_get_plugin_main_file' ) ) {
-    /**
-     * Retrieve the absolute path to the main plugin file.
-     *
-     * @return string
-     */
-    function visibloc_jlg_get_plugin_main_file() {
-        if ( defined( 'VISIBLOC_JLG_PLUGIN_FILE' ) && '' !== VISIBLOC_JLG_PLUGIN_FILE ) {
-            return VISIBLOC_JLG_PLUGIN_FILE;
-        }
-
-        return __DIR__ . '/../visi-bloc-jlg.php';
-    }
-}
-
-if ( ! function_exists( 'visibloc_jlg_get_plugin_dir_path' ) ) {
-    /**
-     * Retrieve the absolute plugin directory path.
-     *
-     * @return string
-     */
-    function visibloc_jlg_get_plugin_dir_path() {
-        if ( defined( 'VISIBLOC_JLG_PLUGIN_DIR' ) && '' !== VISIBLOC_JLG_PLUGIN_DIR ) {
-            return rtrim( VISIBLOC_JLG_PLUGIN_DIR, '/\\' ) . '/';
-        }
-
-        return rtrim( dirname( visibloc_jlg_get_plugin_main_file() ), '/\\' ) . '/';
     }
 }
 
@@ -90,7 +61,7 @@ if ( ! function_exists( 'visibloc_jlg_get_asset_url' ) ) {
             return plugins_url( $relative_path, $plugin_main_file );
         }
 
-        return visibloc_jlg_path_join( visibloc_jlg_get_plugin_dir_path(), $relative_path );
+        return '';
     }
 }
 
@@ -121,20 +92,7 @@ if ( ! function_exists( 'visibloc_jlg_get_asset_version' ) ) {
     }
 }
 
-if ( ! defined( 'VISIBLOC_JLG_VERSION' ) ) {
-    $visibloc_version = '0.0.0';
-    $plugin_main_file = visibloc_jlg_get_plugin_main_file();
-
-    if ( is_readable( $plugin_main_file ) ) {
-        $plugin_contents = file_get_contents( $plugin_main_file );
-
-        if ( false !== $plugin_contents && preg_match( '/^\s*\*\s*Version:\s*(.+)$/mi', $plugin_contents, $matches ) ) {
-            $visibloc_version = trim( $matches[1] );
-        }
-    }
-
-    define( 'VISIBLOC_JLG_VERSION', $visibloc_version );
-}
+visibloc_jlg_define_version_constant();
 
 if ( ! defined( 'VISIBLOC_JLG_EDITOR_DATA_CACHE_GROUP' ) ) {
     define( 'VISIBLOC_JLG_EDITOR_DATA_CACHE_GROUP', 'visibloc_jlg_editor_data' );

--- a/visi-bloc-jlg/includes/plugin-meta.php
+++ b/visi-bloc-jlg/includes/plugin-meta.php
@@ -1,0 +1,86 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+if ( ! function_exists( 'visibloc_jlg_get_plugin_main_file' ) ) {
+    /**
+     * Retrieve the absolute path to the main plugin file.
+     *
+     * @return string
+     */
+    function visibloc_jlg_get_plugin_main_file() {
+        if ( defined( 'VISIBLOC_JLG_PLUGIN_FILE' ) && '' !== VISIBLOC_JLG_PLUGIN_FILE ) {
+            return VISIBLOC_JLG_PLUGIN_FILE;
+        }
+
+        return __DIR__ . '/../visi-bloc-jlg.php';
+    }
+}
+
+if ( ! function_exists( 'visibloc_jlg_get_plugin_dir_path' ) ) {
+    /**
+     * Retrieve the absolute plugin directory path.
+     *
+     * @return string
+     */
+    function visibloc_jlg_get_plugin_dir_path() {
+        if ( defined( 'VISIBLOC_JLG_PLUGIN_DIR' ) && '' !== VISIBLOC_JLG_PLUGIN_DIR ) {
+            return rtrim( VISIBLOC_JLG_PLUGIN_DIR, '/\\' ) . '/';
+        }
+
+        return rtrim( dirname( visibloc_jlg_get_plugin_main_file() ), '/\\' ) . '/';
+    }
+}
+
+if ( ! function_exists( 'visibloc_jlg_resolve_plugin_version' ) ) {
+    /**
+     * Resolve the plugin version from the file header.
+     *
+     * @return string
+     */
+    function visibloc_jlg_resolve_plugin_version() {
+        static $cached_version = null;
+
+        if ( null !== $cached_version ) {
+            return $cached_version;
+        }
+
+        $cached_version   = '0.0.0';
+        $plugin_main_file = visibloc_jlg_get_plugin_main_file();
+
+        if ( function_exists( 'get_file_data' ) ) {
+            $plugin_data = get_file_data( $plugin_main_file, [ 'Version' => 'Version' ] );
+
+            if ( isset( $plugin_data['Version'] ) && '' !== $plugin_data['Version'] ) {
+                $cached_version = $plugin_data['Version'];
+            }
+
+            return $cached_version;
+        }
+
+        if ( is_readable( $plugin_main_file ) ) {
+            $plugin_contents = file_get_contents( $plugin_main_file );
+
+            if ( false !== $plugin_contents && preg_match( '/^\s*\*\s*Version:\s*(.+)$/mi', $plugin_contents, $matches ) ) {
+                $cached_version = trim( $matches[1] );
+            }
+        }
+
+        return $cached_version;
+    }
+}
+
+if ( ! function_exists( 'visibloc_jlg_define_version_constant' ) ) {
+    /**
+     * Ensure the global version constant exists.
+     *
+     * @return string The defined version.
+     */
+    function visibloc_jlg_define_version_constant() {
+        if ( ! defined( 'VISIBLOC_JLG_VERSION' ) ) {
+            define( 'VISIBLOC_JLG_VERSION', visibloc_jlg_resolve_plugin_version() );
+        }
+
+        return VISIBLOC_JLG_VERSION;
+    }
+}
+

--- a/visi-bloc-jlg/includes/role-switcher.php
+++ b/visi-bloc-jlg/includes/role-switcher.php
@@ -17,7 +17,7 @@ if ( ! function_exists( 'visibloc_jlg_get_preview_role_from_cookie' ) ) {
         $cookie_value = $_COOKIE[ $cookie_name ];
 
         if ( ! is_string( $cookie_value ) ) {
-            return '';
+            return null;
         }
 
         return sanitize_key( wp_unslash( $cookie_value ) );

--- a/visi-bloc-jlg/src/Plugin.php
+++ b/visi-bloc-jlg/src/Plugin.php
@@ -222,26 +222,9 @@ class Plugin {
      * Ensure the plugin version constant is defined.
      */
     protected function define_version_constant() {
-        if ( defined( 'VISIBLOC_JLG_VERSION' ) ) {
-            return;
-        }
+        require_once $this->plugin_dir . '/includes/plugin-meta.php';
 
-        $version = '0.0.0';
-
-        if ( function_exists( 'get_file_data' ) ) {
-            $plugin_data = get_file_data( $this->plugin_file, [ 'Version' => 'Version' ] );
-            $version     = isset( $plugin_data['Version'] ) && '' !== $plugin_data['Version']
-                ? $plugin_data['Version']
-                : $version;
-        } else {
-            $plugin_contents = @file_get_contents( $this->plugin_file );
-
-            if ( false !== $plugin_contents && preg_match( '/^\s*\*\s*Version:\s*(.+)$/mi', $plugin_contents, $matches ) ) {
-                $version = trim( $matches[1] );
-            }
-        }
-
-        define( 'VISIBLOC_JLG_VERSION', $version );
+        visibloc_jlg_define_version_constant();
     }
 
     /**

--- a/visi-bloc-jlg/tests/phpunit/bootstrap.php
+++ b/visi-bloc-jlg/tests/phpunit/bootstrap.php
@@ -578,13 +578,19 @@ function visibloc_jlg_get_preview_role_from_cookie() {
         $cookie_value = $_COOKIE['visibloc_preview_role'];
 
         if ( ! is_string( $cookie_value ) ) {
-            return '';
+            return null;
         }
 
         return sanitize_key( $cookie_value );
     }
 
-    return $GLOBALS['visibloc_test_state']['preview_role'];
+    $state_preview_role = $GLOBALS['visibloc_test_state']['preview_role'];
+
+    if ( ! is_string( $state_preview_role ) || '' === $state_preview_role ) {
+        return null;
+    }
+
+    return sanitize_key( $state_preview_role );
 }
 
 function visibloc_jlg_get_preview_runtime_context( $reset_cache = false ) {

--- a/visi-bloc-jlg/tests/phpunit/integration/RoleSwitcherRequestTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/RoleSwitcherRequestTest.php
@@ -329,7 +329,7 @@ class RoleSwitcherRequestTest extends TestCase {
         visibloc_jlg_purge_preview_cookie();
 
         $this->assertArrayNotHasKey( 'visibloc_preview_role', $_COOKIE, 'Preview cookie should be removed from the request.' );
-        $this->assertSame( '', visibloc_jlg_get_preview_role_from_cookie(), 'Preview cookie helper should return an empty string after purge.' );
+        $this->assertNull( visibloc_jlg_get_preview_role_from_cookie(), 'Preview cookie helper should return null after purge.' );
 
         $refreshed_context = visibloc_jlg_get_preview_runtime_context( true );
 

--- a/visi-bloc-jlg/visi-bloc-jlg.php
+++ b/visi-bloc-jlg/visi-bloc-jlg.php
@@ -42,25 +42,9 @@ if ( ! defined( 'VISIBLOC_JLG_PLUGIN_URL' ) ) {
     }
 }
 
-if ( ! defined( 'VISIBLOC_JLG_VERSION' ) ) {
-    $visibloc_version = '0.0.0';
+require_once __DIR__ . '/includes/plugin-meta.php';
 
-    if ( function_exists( 'get_file_data' ) ) {
-        $plugin_data = get_file_data( __FILE__, [ 'Version' => 'Version' ] );
-
-        if ( isset( $plugin_data['Version'] ) && '' !== $plugin_data['Version'] ) {
-            $visibloc_version = $plugin_data['Version'];
-        }
-    } else {
-        $plugin_contents = @file_get_contents( __FILE__ );
-
-        if ( false !== $plugin_contents && preg_match( '/^\s*\*\s*Version:\s*(.+)$/mi', $plugin_contents, $matches ) ) {
-            $visibloc_version = trim( $matches[1] );
-        }
-    }
-
-    define( 'VISIBLOC_JLG_VERSION', $visibloc_version );
-}
+visibloc_jlg_define_version_constant();
 
 require_once __DIR__ . '/autoload.php';
 require_once __DIR__ . '/includes/i18n-inline.php';


### PR DESCRIPTION
## Summary
- add reusable plugin metadata helper for locating the main file, directory, and version
- reuse the shared version resolver across the bootstrap, asset loader, and plugin class while hardening the asset URL fallback
- normalize the preview role cookie helper to return null for invalid values and update the integration tests accordingly

## Testing
- composer test:phpunit

------
https://chatgpt.com/codex/tasks/task_e_68e5683e8cfc832ea37a584425b0eae0