### PR TITLE
Add guided recipe wizard to admin help page

### DIFF
--- a/visi-bloc-jlg/admin-styles.css
+++ b/visi-bloc-jlg/admin-styles.css
@@ -7,6 +7,11 @@
     --visibloc-radius-pill: 999px;
     --visibloc-shadow-subtle: 0 1px 2px rgba(15, 23, 42, 0.08);
     --visibloc-shadow-elevated: 0 18px 40px -24px rgba(15, 23, 42, 0.6);
+    --visibloc-accent: #4f46e5;
+    --visibloc-accent-strong: #312e81;
+    --visibloc-text-primary: #0f172a;
+    --visibloc-text-subtle: rgba(15, 23, 42, 0.72);
+    --visibloc-focus-ring: 0 0 0 3px rgba(79, 70, 229, 0.35);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -17,6 +22,11 @@
         --visibloc-border-strong: rgba(148, 163, 184, 0.35);
         --visibloc-shadow-subtle: 0 1px 2px rgba(15, 23, 42, 0.5);
         --visibloc-shadow-elevated: 0 28px 64px -30px rgba(2, 6, 23, 0.85);
+        --visibloc-text-primary: #f8fafc;
+        --visibloc-text-subtle: rgba(226, 232, 240, 0.75);
+        --visibloc-accent: #818cf8;
+        --visibloc-accent-strong: #c7d2fe;
+        --visibloc-focus-ring: 0 0 0 3px rgba(129, 140, 248, 0.45);
     }
 }
 
@@ -27,6 +37,11 @@ body.is-dark-theme {
     --visibloc-border-strong: rgba(148, 163, 184, 0.35);
     --visibloc-shadow-subtle: 0 1px 2px rgba(15, 23, 42, 0.5);
     --visibloc-shadow-elevated: 0 28px 64px -30px rgba(2, 6, 23, 0.85);
+    --visibloc-text-primary: #f8fafc;
+    --visibloc-text-subtle: rgba(226, 232, 240, 0.75);
+    --visibloc-accent: #818cf8;
+    --visibloc-accent-strong: #c7d2fe;
+    --visibloc-focus-ring: 0 0 0 3px rgba(129, 140, 248, 0.45);
 }
 
 .visibloc-onboarding {
@@ -493,5 +508,574 @@ body.is-dark-theme .visibloc-status-badge__icon {
         margin: 0 0 10px;
         transform: none;
         box-shadow: var(--visibloc-shadow-subtle);
+    }
+}
+
+/* Guided recipes wizard */
+.visibloc-guided-recipes-box {
+    border-color: var(--visibloc-border-subtle);
+    box-shadow: var(--visibloc-shadow-subtle);
+}
+
+.visibloc-guided-recipes {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.visibloc-guided-recipes__intro {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 24px;
+    justify-content: space-between;
+    align-items: flex-start;
+}
+
+.visibloc-guided-recipes__text {
+    max-width: 680px;
+}
+
+.visibloc-guided-recipes__title {
+    margin: 0;
+    font-size: 1.4rem;
+    line-height: 1.4;
+    letter-spacing: -0.01em;
+    color: var(--visibloc-text-primary);
+}
+
+.visibloc-guided-recipes__subtitle {
+    margin: 8px 0 0;
+    color: var(--visibloc-text-subtle);
+    max-width: 60ch;
+    font-size: 0.95rem;
+}
+
+.visibloc-guided-recipes__filters {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    min-width: 220px;
+}
+
+.visibloc-guided-recipes__filter-label {
+    font-weight: 600;
+    color: var(--visibloc-text-primary);
+}
+
+.visibloc-guided-recipes__filter-select {
+    min-width: 220px;
+    padding: 10px 14px;
+    border-radius: 10px;
+    border: 1px solid var(--visibloc-border-subtle);
+    background: var(--visibloc-surface);
+    color: var(--visibloc-text-primary);
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.visibloc-guided-recipes__filter-select:focus,
+.visibloc-guided-recipes__filter-select:focus-visible {
+    outline: none;
+    border-color: var(--visibloc-accent);
+    box-shadow: var(--visibloc-focus-ring);
+}
+
+.visibloc-guided-recipes__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 20px;
+}
+
+.visibloc-guided-recipes__item[hidden] {
+    display: none !important;
+}
+
+.visibloc-recipe-card {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    height: 100%;
+    padding: 22px;
+    border-radius: var(--visibloc-radius-base);
+    border: 1px solid var(--visibloc-border-subtle);
+    background: var(--visibloc-surface);
+    box-shadow: var(--visibloc-shadow-subtle);
+    transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.visibloc-recipe-card:hover {
+    transform: translateY(-2px);
+    border-color: rgba(79, 70, 229, 0.35);
+    box-shadow: var(--visibloc-shadow-elevated);
+}
+
+.visibloc-recipe-card__header {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.visibloc-recipe-card__tag {
+    align-self: flex-start;
+    padding: 4px 10px;
+    border-radius: var(--visibloc-radius-pill);
+    background: rgba(79, 70, 229, 0.12);
+    color: var(--visibloc-accent-strong);
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+}
+
+.visibloc-recipe-card__title {
+    margin: 0;
+    font-size: 1.1rem;
+    line-height: 1.4;
+    color: var(--visibloc-text-primary);
+}
+
+.visibloc-recipe-card__description {
+    margin: 0;
+    color: var(--visibloc-text-subtle);
+    font-size: 0.95rem;
+}
+
+.visibloc-recipe-card__blocks {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.visibloc-recipe-card__blocks li {
+    padding: 6px 10px;
+    border-radius: 999px;
+    background: rgba(79, 70, 229, 0.1);
+    color: var(--visibloc-accent-strong);
+    font-size: 12px;
+    font-weight: 600;
+}
+
+.visibloc-recipe-card__meta {
+    display: grid;
+    gap: 12px;
+    margin: 0;
+}
+
+.visibloc-recipe-card__meta-item {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.visibloc-recipe-card__meta-item dt {
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--visibloc-text-subtle);
+    margin: 0;
+}
+
+.visibloc-recipe-card__meta-item dd {
+    margin: 0;
+    color: var(--visibloc-text-primary);
+    font-weight: 600;
+}
+
+.visibloc-recipe-card__footer {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.visibloc-recipe-card__kpi,
+.visibloc-recipe-card__steps {
+    margin: 0;
+    color: var(--visibloc-text-primary);
+    font-size: 0.95rem;
+}
+
+.visibloc-recipe-card__steps {
+    font-weight: 600;
+}
+
+.visibloc-recipe-card__actions {
+    display: flex;
+    align-items: center;
+}
+
+.visibloc-recipe-card__button {
+    min-height: 44px;
+    padding: 10px 18px;
+    font-weight: 600;
+}
+
+.visibloc-guided-recipes__empty {
+    margin: 0;
+    font-style: italic;
+    color: var(--visibloc-text-subtle);
+}
+
+.visibloc-guided-recipes__dialog[hidden] {
+    display: none !important;
+}
+
+.visibloc-guided-recipes__dialog {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 32px;
+    background: rgba(15, 23, 42, 0.45);
+    z-index: 100000;
+}
+
+.visibloc-guided-recipes__dialog-window {
+    background: var(--visibloc-surface);
+    color: var(--visibloc-text-primary);
+    border-radius: 18px;
+    box-shadow: var(--visibloc-shadow-elevated);
+    max-width: 760px;
+    width: min(760px, 100%);
+    max-height: calc(100vh - 64px);
+    overflow: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    padding: 28px;
+}
+
+.visibloc-guided-recipes__dialog-backdrop {
+    position: absolute;
+    inset: 0;
+}
+
+.visibloc-guided-recipes__dialog-header {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+    align-items: flex-start;
+}
+
+.visibloc-guided-recipes__dialog-title {
+    margin: 0;
+    font-size: 1.3rem;
+}
+
+.visibloc-guided-recipes__dialog-description {
+    margin: 8px 0 0;
+    color: var(--visibloc-text-subtle);
+}
+
+.visibloc-guided-recipes__dialog-close {
+    border: none;
+    background: transparent;
+    color: var(--visibloc-text-subtle);
+    font-size: 24px;
+    line-height: 1;
+    padding: 6px;
+    border-radius: 999px;
+    cursor: pointer;
+    transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.visibloc-guided-recipes__dialog-close:hover,
+.visibloc-guided-recipes__dialog-close:focus-visible {
+    background: rgba(79, 70, 229, 0.12);
+    color: var(--visibloc-accent-strong);
+    outline: none;
+    box-shadow: var(--visibloc-focus-ring);
+}
+
+.visibloc-guided-recipes__dialog-meta {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.visibloc-guided-recipes__dialog-meta-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 14px;
+    margin: 0;
+}
+
+.visibloc-guided-recipes__dialog-meta-item {
+    padding: 14px;
+    border-radius: 12px;
+    border: 1px solid var(--visibloc-border-subtle);
+    background: var(--visibloc-surface-tinted);
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.visibloc-guided-recipes__dialog-meta-item dt {
+    margin: 0;
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--visibloc-text-subtle);
+}
+
+.visibloc-guided-recipes__dialog-meta-item dd {
+    margin: 0;
+    font-weight: 600;
+}
+
+.visibloc-guided-recipes__dialog-blocks[hidden] {
+    display: none !important;
+}
+
+.visibloc-guided-recipes__dialog-blocks-title {
+    margin: 0 0 6px;
+    font-size: 0.95rem;
+    color: var(--visibloc-text-primary);
+}
+
+.visibloc-guided-recipes__dialog-blocks-list {
+    margin: 0;
+    padding-left: 18px;
+    display: grid;
+    gap: 4px;
+}
+
+.visibloc-guided-recipes__dialog-progress {
+    display: flex;
+    gap: 12px;
+    align-items: center;
+}
+
+.visibloc-guided-recipes__progress {
+    flex: 1 1 180px;
+    height: 12px;
+    border-radius: 999px;
+    overflow: hidden;
+    background: rgba(79, 70, 229, 0.15);
+    border: none;
+}
+
+.visibloc-guided-recipes__progress::-webkit-progress-bar {
+    background: rgba(79, 70, 229, 0.15);
+    border-radius: 999px;
+}
+
+.visibloc-guided-recipes__progress::-webkit-progress-value {
+    background: linear-gradient(90deg, #6366f1, #8b5cf6);
+    border-radius: 999px;
+}
+
+.visibloc-guided-recipes__progress::-moz-progress-bar {
+    background: linear-gradient(90deg, #6366f1, #8b5cf6);
+    border-radius: 999px;
+}
+
+.visibloc-guided-recipes__progress-label {
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--visibloc-text-primary);
+}
+
+.visibloc-guided-recipes__dialog-body {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.visibloc-guided-recipes__stepper-tabs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
+.visibloc-guided-recipes__stepper-tab {
+    flex: 1 1 160px;
+    min-width: 150px;
+    padding: 12px 16px;
+    border-radius: 10px;
+    border: 1px solid var(--visibloc-border-subtle);
+    background: var(--visibloc-surface-tinted);
+    color: var(--visibloc-text-primary);
+    font-weight: 600;
+    text-align: left;
+    cursor: pointer;
+    transition: border-color 0.2s ease, background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.visibloc-guided-recipes__stepper-tab[aria-selected="true"] {
+    border-color: var(--visibloc-accent);
+    background: rgba(79, 70, 229, 0.15);
+    color: var(--visibloc-accent-strong);
+    box-shadow: 0 0 0 1px rgba(79, 70, 229, 0.15);
+}
+
+.visibloc-guided-recipes__stepper-tab:focus-visible {
+    outline: none;
+    box-shadow: var(--visibloc-focus-ring);
+}
+
+.visibloc-guided-recipes__stepper-panels {
+    display: grid;
+}
+
+.visibloc-guided-recipes__stepper-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 4px 2px 0;
+}
+
+.visibloc-guided-recipes__stepper-panel[hidden] {
+    display: none !important;
+}
+
+.visibloc-guided-recipes__step-title {
+    margin: 0;
+    font-size: 1.05rem;
+}
+
+.visibloc-guided-recipes__step-intro {
+    margin: 0;
+    color: var(--visibloc-text-subtle);
+}
+
+.visibloc-recipe-step__list {
+    margin: 0;
+    padding-left: 20px;
+    display: grid;
+    gap: 6px;
+}
+
+.visibloc-recipe-step__notes {
+    padding: 12px 14px;
+    border-left: 4px solid var(--visibloc-accent);
+    background: rgba(79, 70, 229, 0.08);
+    border-radius: 10px;
+    display: grid;
+    gap: 6px;
+}
+
+.visibloc-recipe-step__notes-title {
+    margin: 0;
+    font-size: 0.95rem;
+    color: var(--visibloc-accent-strong);
+}
+
+.visibloc-recipe-step__notes ul {
+    margin: 0;
+    padding-left: 18px;
+    display: grid;
+    gap: 4px;
+}
+
+.visibloc-recipe-step__resources {
+    margin: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    align-items: center;
+    color: var(--visibloc-text-subtle);
+}
+
+.visibloc-recipe-step__resources a {
+    color: var(--visibloc-accent-strong);
+    font-weight: 600;
+    text-decoration: none;
+}
+
+.visibloc-recipe-step__resources a:hover,
+.visibloc-recipe-step__resources a:focus-visible {
+    text-decoration: underline;
+    outline: none;
+}
+
+.visibloc-recipe-step__resources-label {
+    font-weight: 600;
+}
+
+.visibloc-recipe-step__resources-separator {
+    color: var(--visibloc-text-subtle);
+}
+
+.visibloc-guided-recipes__dialog-footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 12px;
+}
+
+.visibloc-guided-recipes__dialog-next {
+    min-width: 140px;
+    min-height: 44px;
+}
+
+body.visibloc-recipes-modal-open {
+    overflow: hidden;
+}
+
+@media (max-width: 960px) {
+    .visibloc-guided-recipes__dialog-window {
+        max-height: calc(100vh - 40px);
+    }
+}
+
+@media (max-width: 782px) {
+    .visibloc-guided-recipes__intro {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .visibloc-guided-recipes__filter-select {
+        width: 100%;
+    }
+
+    .visibloc-guided-recipes__dialog {
+        padding: 16px;
+    }
+
+    .visibloc-guided-recipes__dialog-window {
+        padding: 20px;
+        border-radius: 14px;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .visibloc-recipe-card,
+    .visibloc-guided-recipes__filter-select,
+    .visibloc-guided-recipes__stepper-tab,
+    .visibloc-guided-recipes__dialog-close {
+        transition: none;
+    }
+}
+
+@media (prefers-color-scheme: dark) {
+    .visibloc-recipe-card {
+        border-color: rgba(148, 163, 184, 0.25);
+        background: rgba(30, 41, 59, 0.72);
+    }
+
+    .visibloc-recipe-card__blocks li {
+        background: rgba(129, 140, 248, 0.18);
+    }
+
+    .visibloc-guided-recipes__dialog-meta-item {
+        background: rgba(30, 41, 59, 0.72);
+        border-color: rgba(148, 163, 184, 0.25);
+    }
+
+    .visibloc-guided-recipes__dialog-window {
+        background: rgba(15, 23, 42, 0.9);
+    }
+
+    .visibloc-guided-recipes__dialog-close {
+        color: rgba(226, 232, 240, 0.8);
+    }
+
+    .visibloc-recipe-step__notes {
+        background: rgba(129, 140, 248, 0.18);
     }
 }

--- a/visi-bloc-jlg/assets/admin-recipes.js
+++ b/visi-bloc-jlg/assets/admin-recipes.js
@@ -1,0 +1,523 @@
+/* global wp */
+(function () {
+    'use strict';
+
+    var i18n = (typeof wp !== 'undefined' && wp.i18n) ? wp.i18n : null;
+    var __ = i18n && i18n.__ ? i18n.__ : function (text) { return text; };
+    var sprintf = i18n && i18n.sprintf ? i18n.sprintf : function (template) {
+        var args = Array.prototype.slice.call(arguments, 1);
+        return template.replace(/%([0-9]+)\$s/g, function (_, index) {
+            var position = parseInt(index, 10) - 1;
+            return typeof args[position] !== 'undefined' ? args[position] : '';
+        });
+    };
+
+    function getFocusableElements(container) {
+        if (!container) {
+            return [];
+        }
+
+        var selector = 'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+        var elements = Array.prototype.slice.call(container.querySelectorAll(selector));
+
+        return elements.filter(function (element) {
+            if (element.hasAttribute('disabled')) {
+                return false;
+            }
+
+            if (element.getAttribute('aria-hidden') === 'true') {
+                return false;
+            }
+
+            if (element.closest('[hidden]')) {
+                return false;
+            }
+
+            var rect = element.getBoundingClientRect();
+            return rect.width > 0 && rect.height > 0;
+        });
+    }
+
+    function parseBlocks(card) {
+        if (!card) {
+            return [];
+        }
+
+        var raw = card.getAttribute('data-recipe-blocks');
+
+        if (!raw) {
+            return [];
+        }
+
+        try {
+            var decoded = JSON.parse(raw);
+            if (Array.isArray(decoded)) {
+                return decoded.filter(function (item) {
+                    return typeof item === 'string' && item.trim() !== '';
+                });
+            }
+        } catch (error) {
+            // Ignore malformed JSON and fall back to an empty array.
+        }
+
+        return [];
+    }
+
+    function parseTemplateSteps(template) {
+        if (!template) {
+            return [];
+        }
+
+        var fragment;
+
+        if (template.content) {
+            fragment = template.content.cloneNode(true);
+        } else {
+            fragment = document.createDocumentFragment();
+            var wrapper = document.createElement('div');
+            wrapper.innerHTML = template.innerHTML;
+            while (wrapper.firstChild) {
+                fragment.appendChild(wrapper.firstChild);
+            }
+        }
+
+        return Array.prototype.slice.call(fragment.querySelectorAll('[data-visibloc-recipe-step]'));
+    }
+
+    function createPanelStructure(stepNode, panelId, tabId) {
+        var panel = document.createElement('div');
+        panel.className = 'visibloc-guided-recipes__stepper-panel';
+        panel.setAttribute('role', 'tabpanel');
+        panel.setAttribute('id', panelId);
+        panel.setAttribute('aria-labelledby', tabId);
+        panel.tabIndex = 0;
+
+        var title = stepNode.getAttribute('data-step-title') || __('Étape', 'visi-bloc-jlg');
+        var summary = stepNode.getAttribute('data-step-summary') || '';
+
+        var heading = document.createElement('h4');
+        heading.className = 'visibloc-guided-recipes__step-title';
+        heading.textContent = title;
+        panel.appendChild(heading);
+
+        if (summary) {
+            var intro = document.createElement('p');
+            intro.className = 'visibloc-guided-recipes__step-intro';
+            intro.textContent = summary;
+            panel.appendChild(intro);
+        }
+
+        while (stepNode.firstChild) {
+            panel.appendChild(stepNode.firstChild);
+        }
+
+        return {
+            panel: panel,
+            title: title
+        };
+    }
+
+    function normalizeCountMessage(count, emptyFallback) {
+        if (count === 0) {
+            return emptyFallback || '';
+        }
+
+        if (count === 1) {
+            return __('1 recette disponible', 'visi-bloc-jlg');
+        }
+
+        return sprintf(__('%d recettes disponibles', 'visi-bloc-jlg'), count);
+    }
+
+    function initialize() {
+        var container = document.querySelector('[data-visibloc-recipes]');
+
+        if (!container) {
+            return;
+        }
+
+        var cards = Array.prototype.slice.call(container.querySelectorAll('[data-visibloc-recipe-card]'));
+        var filterSelect = container.querySelector('[data-visibloc-recipes-filter]');
+        var emptyMessage = container.querySelector('[data-visibloc-recipes-empty]');
+        var liveRegion = container.querySelector('[data-visibloc-recipes-live]');
+        var dialog = container.querySelector('[data-visibloc-recipe-dialog]');
+
+        var dialogWindow = dialog ? dialog.querySelector('[data-visibloc-recipe-dialog-window]') : null;
+        var tabsContainer = dialog ? dialog.querySelector('[data-visibloc-recipe-tabs]') : null;
+        var panelsContainer = dialog ? dialog.querySelector('[data-visibloc-recipe-panels]') : null;
+        var progressElement = dialog ? dialog.querySelector('[data-visibloc-recipe-progress]') : null;
+        var progressLabel = dialog ? dialog.querySelector('[data-visibloc-recipe-progress-label]') : null;
+        var stepLiveRegion = dialog ? dialog.querySelector('[data-visibloc-recipe-step-live]') : null;
+        var prevButton = dialog ? dialog.querySelector('[data-visibloc-recipe-prev]') : null;
+        var nextButton = dialog ? dialog.querySelector('[data-visibloc-recipe-next]') : null;
+        var titleElement = dialog ? dialog.querySelector('[data-visibloc-recipe-dialog-title]') : null;
+        var descriptionElement = dialog ? dialog.querySelector('[data-visibloc-recipe-dialog-description]') : null;
+        var metaContainer = dialog ? dialog.querySelector('[data-visibloc-recipe-dialog-meta]') : null;
+        var blocksContainer = dialog ? dialog.querySelector('[data-visibloc-recipe-dialog-blocks]') : null;
+        var blocksList = dialog ? dialog.querySelector('[data-visibloc-recipe-dialog-blocks-list]') : null;
+
+        var activeTabs = [];
+        var activePanels = [];
+        var activeIndex = 0;
+        var previousFocus = null;
+        var dialogOpen = false;
+
+        function announceToLiveRegion(element, message) {
+            if (!element) {
+                return;
+            }
+
+            element.textContent = message || '';
+        }
+
+        function updateFilter(value) {
+            var normalized = (value || '').toLowerCase();
+            var visibleCount = 0;
+
+            cards.forEach(function (card) {
+                var theme = (card.getAttribute('data-theme') || '').toLowerCase();
+                var matches = !normalized || theme === normalized;
+
+                card.hidden = !matches;
+
+                if (matches) {
+                    visibleCount++;
+                }
+            });
+
+            if (emptyMessage) {
+                emptyMessage.hidden = visibleCount > 0;
+            }
+
+            announceToLiveRegion(liveRegion, normalizeCountMessage(visibleCount, emptyMessage ? emptyMessage.textContent : ''));
+        }
+
+        function closeDialog() {
+            if (!dialog || !dialogOpen) {
+                return;
+            }
+
+            dialogOpen = false;
+            dialog.setAttribute('hidden', 'hidden');
+            document.body.classList.remove('visibloc-recipes-modal-open');
+            if (tabsContainer) {
+                tabsContainer.innerHTML = '';
+            }
+
+            if (panelsContainer) {
+                panelsContainer.innerHTML = '';
+            }
+            activeTabs = [];
+            activePanels = [];
+            activeIndex = 0;
+            document.removeEventListener('keydown', handleKeydown, true);
+
+            if (previousFocus && typeof previousFocus.focus === 'function') {
+                previousFocus.focus();
+            }
+
+            previousFocus = null;
+        }
+
+        function handleKeydown(event) {
+            if (!dialogOpen) {
+                return;
+            }
+
+            if (event.key === 'Escape') {
+                event.preventDefault();
+                closeDialog();
+                return;
+            }
+
+            if (event.key !== 'Tab') {
+                return;
+            }
+
+            var focusable = getFocusableElements(dialogWindow || dialog);
+
+            if (focusable.length === 0) {
+                event.preventDefault();
+                return;
+            }
+
+            var currentIndex = focusable.indexOf(document.activeElement);
+
+            if (event.shiftKey) {
+                if (currentIndex <= 0) {
+                    event.preventDefault();
+                    focusable[focusable.length - 1].focus();
+                }
+            } else {
+                if (currentIndex === -1 || currentIndex === focusable.length - 1) {
+                    event.preventDefault();
+                    focusable[0].focus();
+                }
+            }
+        }
+
+        function setMetaValue(slug, value) {
+            if (!metaContainer) {
+                return;
+            }
+
+            var target = metaContainer.querySelector('[data-visibloc-recipe-meta="' + slug + '"]');
+
+            if (target) {
+                target.textContent = value || '—';
+            }
+        }
+
+        function updateBlocksList(blocks) {
+            if (!blocksContainer || !blocksList) {
+                return;
+            }
+
+            blocksList.innerHTML = '';
+
+            if (!blocks || !blocks.length) {
+                blocksContainer.hidden = true;
+                return;
+            }
+
+            blocks.forEach(function (block) {
+                var item = document.createElement('li');
+                item.textContent = block;
+                blocksList.appendChild(item);
+            });
+
+            blocksContainer.hidden = false;
+        }
+
+        function setActiveStep(index, focusTab) {
+            if (index < 0 || index >= activeTabs.length) {
+                return;
+            }
+
+            activeIndex = index;
+
+            activeTabs.forEach(function (tab, tabIndex) {
+                var isSelected = tabIndex === index;
+                tab.setAttribute('aria-selected', isSelected ? 'true' : 'false');
+                tab.setAttribute('tabindex', isSelected ? '0' : '-1');
+
+                if (isSelected && focusTab) {
+                    tab.focus();
+                }
+            });
+
+            activePanels.forEach(function (panel, panelIndex) {
+                panel.hidden = panelIndex !== index;
+            });
+
+            if (progressElement) {
+                progressElement.max = Math.max(activeTabs.length, 1);
+                progressElement.value = index + 1;
+            }
+
+            if (progressLabel) {
+                var template = progressLabel.getAttribute('data-visibloc-progress-template') || '';
+                if (template && template.indexOf('%1$s') !== -1) {
+                    progressLabel.textContent = sprintf(template, index + 1, activeTabs.length);
+                } else if (template) {
+                    progressLabel.textContent = template;
+                } else {
+                    progressLabel.textContent = (index + 1) + ' / ' + activeTabs.length;
+                }
+            }
+
+            if (prevButton) {
+                prevButton.disabled = index === 0;
+            }
+
+            if (nextButton) {
+                var isLastStep = index === activeTabs.length - 1;
+                var nextLabel = nextButton.getAttribute('data-visibloc-label-next') || __('Étape suivante', 'visi-bloc-jlg');
+                var finishLabel = nextButton.getAttribute('data-visibloc-label-finish') || __('Terminer', 'visi-bloc-jlg');
+                nextButton.textContent = isLastStep ? finishLabel : nextLabel;
+                nextButton.setAttribute('aria-label', nextButton.textContent);
+                nextButton.dataset.visiblocRecipeNextIsFinish = isLastStep ? 'true' : 'false';
+            }
+
+            if (stepLiveRegion && activeTabs[index]) {
+                stepLiveRegion.textContent = activeTabs[index].textContent;
+            }
+        }
+
+        function focusTabByOffset(currentIndex, offset) {
+            if (!activeTabs.length) {
+                return;
+            }
+
+            var nextIndex = (currentIndex + offset + activeTabs.length) % activeTabs.length;
+            setActiveStep(nextIndex, true);
+        }
+
+        function handleTabKeydown(event) {
+            var tab = event.currentTarget;
+            var index = parseInt(tab.getAttribute('data-index'), 10);
+
+            if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+                event.preventDefault();
+                focusTabByOffset(index, 1);
+            } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+                event.preventDefault();
+                focusTabByOffset(index, -1);
+            } else if (event.key === 'Home') {
+                event.preventDefault();
+                setActiveStep(0, true);
+            } else if (event.key === 'End') {
+                event.preventDefault();
+                setActiveStep(activeTabs.length - 1, true);
+            }
+        }
+
+        function openRecipe(card) {
+            if (!dialog || !tabsContainer || !panelsContainer) {
+                return;
+            }
+
+            var templateId = card.getAttribute('data-recipe-template');
+            var template = templateId ? document.getElementById(templateId) : null;
+
+            if (!template) {
+                template = card.querySelector('[data-visibloc-recipe-template]');
+            }
+
+            if (!template) {
+                return;
+            }
+
+            var steps = parseTemplateSteps(template);
+
+            if (!steps.length) {
+                return;
+            }
+
+            tabsContainer.innerHTML = '';
+            panelsContainer.innerHTML = '';
+            activeTabs = [];
+            activePanels = [];
+
+            var recipeId = card.getAttribute('data-recipe-id') || 'recipe';
+
+            steps.forEach(function (stepNode, index) {
+                var tabId = 'visibloc-recipe-tab-' + recipeId + '-' + index;
+                var panelId = 'visibloc-recipe-panel-' + recipeId + '-' + index;
+
+                var tab = document.createElement('button');
+                tab.type = 'button';
+                tab.className = 'visibloc-guided-recipes__stepper-tab';
+                tab.setAttribute('role', 'tab');
+                tab.setAttribute('id', tabId);
+                tab.setAttribute('aria-controls', panelId);
+                tab.setAttribute('aria-selected', index === 0 ? 'true' : 'false');
+                tab.setAttribute('tabindex', index === 0 ? '0' : '-1');
+                tab.setAttribute('data-index', String(index));
+
+                var title = stepNode.getAttribute('data-step-title') || __('Étape', 'visi-bloc-jlg');
+                tab.textContent = (index + 1) + '. ' + title;
+
+                tab.addEventListener('click', function () {
+                    setActiveStep(index, true);
+                });
+                tab.addEventListener('keydown', handleTabKeydown);
+
+                tabsContainer.appendChild(tab);
+                activeTabs.push(tab);
+
+                var structure = createPanelStructure(stepNode, panelId, tabId);
+                if (structure.panel) {
+                    structure.panel.hidden = index !== 0;
+                    panelsContainer.appendChild(structure.panel);
+                    activePanels.push(structure.panel);
+                }
+            });
+
+            if (titleElement) {
+                titleElement.textContent = card.getAttribute('data-recipe-title') || '';
+            }
+
+            if (descriptionElement) {
+                descriptionElement.textContent = card.getAttribute('data-recipe-description') || '';
+            }
+
+            setMetaValue('goal', card.getAttribute('data-recipe-goal') || '');
+            setMetaValue('audience', card.getAttribute('data-recipe-audience') || '');
+            setMetaValue('kpi', card.getAttribute('data-recipe-kpi') || '');
+            setMetaValue('time', card.getAttribute('data-recipe-time') || __('Quelques minutes', 'visi-bloc-jlg'));
+
+            updateBlocksList(parseBlocks(card));
+
+            previousFocus = document.activeElement;
+            dialog.removeAttribute('hidden');
+            dialogOpen = true;
+            document.body.classList.add('visibloc-recipes-modal-open');
+            document.addEventListener('keydown', handleKeydown, true);
+
+            setActiveStep(0, true);
+        }
+
+        if (filterSelect) {
+            filterSelect.addEventListener('change', function () {
+                updateFilter(filterSelect.value || '');
+            });
+        }
+
+        container.addEventListener('click', function (event) {
+            var target = event.target;
+
+            if (target.matches('[data-visibloc-recipe-start]')) {
+                event.preventDefault();
+                var card = target.closest('[data-visibloc-recipe-card]');
+                if (card) {
+                    openRecipe(card);
+                }
+            }
+
+            if (target.hasAttribute('data-visibloc-recipe-close')) {
+                event.preventDefault();
+                closeDialog();
+            }
+        });
+
+        if (prevButton) {
+            prevButton.addEventListener('click', function () {
+                if (!dialogOpen) {
+                    return;
+                }
+
+                var newIndex = Math.max(activeIndex - 1, 0);
+                setActiveStep(newIndex, true);
+            });
+        }
+
+        if (nextButton) {
+            nextButton.addEventListener('click', function () {
+                if (!dialogOpen) {
+                    return;
+                }
+
+                if (nextButton.dataset.visiblocRecipeNextIsFinish === 'true') {
+                    closeDialog();
+                    return;
+                }
+
+                var newIndex = Math.min(activeIndex + 1, activeTabs.length - 1);
+                setActiveStep(newIndex, true);
+            });
+        }
+
+        updateFilter(filterSelect ? filterSelect.value || '' : '');
+    }
+
+    if (typeof wp !== 'undefined' && wp.domReady) {
+        wp.domReady(initialize);
+    } else {
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', initialize);
+        } else {
+            initialize();
+        }
+    }
+})();

--- a/visi-bloc-jlg/docs/visual-debug.html
+++ b/visi-bloc-jlg/docs/visual-debug.html
@@ -76,6 +76,258 @@
         </div>
     </section>
 
+    <section class="preview" id="guided-recipes-preview">
+        <h2>Assistant guidé (aperçu statique)</h2>
+        <div class="postbox visibloc-guided-recipes-box">
+            <div class="inside">
+                <section class="visibloc-guided-recipes" data-visibloc-recipes>
+                    <header class="visibloc-guided-recipes__intro">
+                        <div class="visibloc-guided-recipes__text">
+                            <h3 class="visibloc-guided-recipes__title">Lancez une recette en quatre étapes</h3>
+                            <p class="visibloc-guided-recipes__subtitle">Cette démonstration reprend la structure du panneau d’aide WordPress. Elle montre deux scénarios exemples et déclenche le même assistant accessible que dans le plugin.</p>
+                        </div>
+                        <div class="visibloc-guided-recipes__filters">
+                            <label class="visibloc-guided-recipes__filter-label" for="demo-guided-filter">Filtrer par thématique</label>
+                            <select id="demo-guided-filter" class="visibloc-guided-recipes__filter-select" data-visibloc-recipes-filter aria-controls="visibloc-section-guided-recipes-list">
+                                <option value="">Toutes les thématiques</option>
+                                <option value="onboarding">Onboarding</option>
+                                <option value="conversion">Conversion</option>
+                            </select>
+                        </div>
+                    </header>
+                    <div class="screen-reader-text" data-visibloc-recipes-live aria-live="polite"></div>
+                    <ul class="visibloc-guided-recipes__list" id="visibloc-section-guided-recipes-list" role="list">
+                        <li
+                            class="visibloc-guided-recipes__item"
+                            data-visibloc-recipe-card
+                            data-theme="onboarding"
+                            data-recipe-id="demo-welcome"
+                            data-recipe-title="Bienvenue personnalisée"
+                            data-recipe-description="Déclenche un bloc de bienvenue pour les nouveaux abonnés."
+                            data-recipe-goal="Accélérer l’activation initiale"
+                            data-recipe-audience="Nouveaux inscrits connectés"
+                            data-recipe-kpi="Clic sur le CTA principal"
+                            data-recipe-time="5 minutes"
+                            data-recipe-theme-label="Onboarding"
+                            data-recipe-step-count="4"
+                            data-recipe-blocks='["Bloc Bannière","Bloc Bouton"]'
+                            data-recipe-template="visibloc-recipe-template-demo-welcome"
+                        >
+                            <article class="visibloc-recipe-card" aria-labelledby="visibloc-recipe-card-demo-welcome-title">
+                                <header class="visibloc-recipe-card__header">
+                                    <span class="visibloc-recipe-card__tag">Onboarding</span>
+                                    <h3 id="visibloc-recipe-card-demo-welcome-title" class="visibloc-recipe-card__title">Bienvenue personnalisée</h3>
+                                    <p class="visibloc-recipe-card__description">Affichez un message chaleureux aux nouveaux membres, avec un focus visible et un objectif clair.</p>
+                                </header>
+                                <ul class="visibloc-recipe-card__blocks" aria-label="Blocs recommandés">
+                                    <li>Bloc Bannière</li>
+                                    <li>Bloc Bouton</li>
+                                </ul>
+                                <dl class="visibloc-recipe-card__meta">
+                                    <div class="visibloc-recipe-card__meta-item">
+                                        <dt>Durée estimée</dt>
+                                        <dd>5 minutes</dd>
+                                    </div>
+                                    <div class="visibloc-recipe-card__meta-item">
+                                        <dt>Objectif</dt>
+                                        <dd>Accélérer l’activation initiale</dd>
+                                    </div>
+                                    <div class="visibloc-recipe-card__meta-item">
+                                        <dt>Audience</dt>
+                                        <dd>Nouveaux inscrits connectés</dd>
+                                    </div>
+                                </dl>
+                                <div class="visibloc-recipe-card__footer">
+                                    <p class="visibloc-recipe-card__kpi"><strong>Indicateur clé&nbsp;:</strong> <span>Clic sur le CTA principal</span></p>
+                                    <p class="visibloc-recipe-card__steps" aria-label="Nombre d’étapes de l’assistant">4 étapes</p>
+                                </div>
+                                <div class="visibloc-recipe-card__actions">
+                                    <button type="button" class="button button-primary visibloc-recipe-card__button" data-visibloc-recipe-start>Lancer l’assistant</button>
+                                </div>
+                            </article>
+                            <template id="visibloc-recipe-template-demo-welcome" data-visibloc-recipe-template>
+                                <div class="visibloc-recipe-step" data-visibloc-recipe-step data-step-title="Objectif" data-step-summary="Rappelez le bénéfice principal du message de bienvenue.">
+                                    <ul class="visibloc-recipe-step__list">
+                                        <li>Indiquez clairement l’action attendue dans le bloc.</li>
+                                        <li>Ajoutez un rappel interne sur le KPI suivi.</li>
+                                    </ul>
+                                </div>
+                                <div class="visibloc-recipe-step" data-visibloc-recipe-step data-step-title="Audience" data-step-summary="Ciblez uniquement les rôles autorisés et les nouveaux inscrits.">
+                                    <ul class="visibloc-recipe-step__list">
+                                        <li>Activez la condition « Statut de connexion ».</li>
+                                        <li>Limitez l’affichage aux sept premiers jours via un cookie.</li>
+                                    </ul>
+                                    <div class="visibloc-recipe-step__notes" role="note">
+                                        <strong class="visibloc-recipe-step__notes-title">Points de vigilance</strong>
+                                        <ul>
+                                            <li>Vérifiez le contraste du bouton (≥ 4.5:1).</li>
+                                        </ul>
+                                    </div>
+                                </div>
+                                <div class="visibloc-recipe-step" data-visibloc-recipe-step data-step-title="Timing" data-step-summary="Programmez une durée limitée pour éviter la fatigue visuelle.">
+                                    <ul class="visibloc-recipe-step__list">
+                                        <li>Définissez une fin automatique au bout d’une semaine.</li>
+                                        <li>Combinez avec un créneau horaire 8h-21h.</li>
+                                    </ul>
+                                </div>
+                                <div class="visibloc-recipe-step" data-visibloc-recipe-step data-step-title="Fallback" data-step-summary="Préparez une alternative accessible pour les visiteurs récurrents.">
+                                    <ul class="visibloc-recipe-step__list">
+                                        <li>Sélectionnez un bloc de repli informatif.</li>
+                                        <li>Ajoutez une classe <code>vb-desktop-only</code> si nécessaire.</li>
+                                    </ul>
+                                </div>
+                            </template>
+                        </li>
+                        <li
+                            class="visibloc-guided-recipes__item"
+                            data-visibloc-recipe-card
+                            data-theme="conversion"
+                            data-recipe-id="demo-cart"
+                            data-recipe-title="Relance panier"
+                            data-recipe-description="Relancez un panier abandonné avec un message accessible."
+                            data-recipe-goal="Relancer les paniers abandonnés"
+                            data-recipe-audience="Clients connectés avec panier actif"
+                            data-recipe-kpi="Taux de récupération du panier"
+                            data-recipe-time="8 minutes"
+                            data-recipe-theme-label="Conversion"
+                            data-recipe-step-count="4"
+                            data-recipe-blocks='["Bannière","Liste de produits"]'
+                            data-recipe-template="visibloc-recipe-template-demo-cart"
+                        >
+                            <article class="visibloc-recipe-card" aria-labelledby="visibloc-recipe-card-demo-cart-title">
+                                <header class="visibloc-recipe-card__header">
+                                    <span class="visibloc-recipe-card__tag">Conversion</span>
+                                    <h3 id="visibloc-recipe-card-demo-cart-title" class="visibloc-recipe-card__title">Relance panier</h3>
+                                    <p class="visibloc-recipe-card__description">Affichez une bannière contextualisée et respectez les critères WCAG pour favoriser la conversion.</p>
+                                </header>
+                                <ul class="visibloc-recipe-card__blocks" aria-label="Blocs recommandés">
+                                    <li>Bannière</li>
+                                    <li>Liste de produits</li>
+                                </ul>
+                                <dl class="visibloc-recipe-card__meta">
+                                    <div class="visibloc-recipe-card__meta-item">
+                                        <dt>Durée estimée</dt>
+                                        <dd>8 minutes</dd>
+                                    </div>
+                                    <div class="visibloc-recipe-card__meta-item">
+                                        <dt>Objectif</dt>
+                                        <dd>Relancer les paniers abandonnés</dd>
+                                    </div>
+                                    <div class="visibloc-recipe-card__meta-item">
+                                        <dt>Audience</dt>
+                                        <dd>Clients connectés avec panier actif</dd>
+                                    </div>
+                                </dl>
+                                <div class="visibloc-recipe-card__footer">
+                                    <p class="visibloc-recipe-card__kpi"><strong>Indicateur clé&nbsp;:</strong> <span>Taux de récupération</span></p>
+                                    <p class="visibloc-recipe-card__steps" aria-label="Nombre d’étapes de l’assistant">4 étapes</p>
+                                </div>
+                                <div class="visibloc-recipe-card__actions">
+                                    <button type="button" class="button button-primary visibloc-recipe-card__button" data-visibloc-recipe-start>Lancer l’assistant</button>
+                                </div>
+                            </article>
+                            <template id="visibloc-recipe-template-demo-cart" data-visibloc-recipe-template>
+                                <div class="visibloc-recipe-step" data-visibloc-recipe-step data-step-title="Objectif" data-step-summary="Rappelez la valeur du message de relance.">
+                                    <ul class="visibloc-recipe-step__list">
+                                        <li>Choisissez un avantage pertinent (livraison offerte, assistance).</li>
+                                        <li>Définissez un libellé de bouton explicite.</li>
+                                    </ul>
+                                </div>
+                                <div class="visibloc-recipe-step" data-visibloc-recipe-step data-step-title="Audience" data-step-summary="Filtrez les clients connectés disposant d’un panier.">
+                                    <ul class="visibloc-recipe-step__list">
+                                        <li>Ajoutez la condition WooCommerce « Panier non vide ».</li>
+                                        <li>Excluez les segments déjà relancés par email.</li>
+                                    </ul>
+                                    <div class="visibloc-recipe-step__notes" role="note">
+                                        <strong class="visibloc-recipe-step__notes-title">Points de vigilance</strong>
+                                        <ul>
+                                            <li>Contrôlez la navigation clavier sur chaque bouton.</li>
+                                        </ul>
+                                    </div>
+                                </div>
+                                <div class="visibloc-recipe-step" data-visibloc-recipe-step data-step-title="Timing" data-step-summary="Limitez la fréquence d’affichage.">
+                                    <ul class="visibloc-recipe-step__list">
+                                        <li>Ajoutez un cookie de fréquence pour éviter plus de trois affichages par jour.</li>
+                                        <li>Planifiez l’expiration du message après 72 heures.</li>
+                                    </ul>
+                                </div>
+                                <div class="visibloc-recipe-step" data-visibloc-recipe-step data-step-title="Fallback" data-step-summary="Fournissez une alternative claire.">
+                                    <ul class="visibloc-recipe-step__list">
+                                        <li>Affichez un lien vers les catégories principales si le panier est vide.</li>
+                                        <li>Ajoutez un bouton secondaire vers le support.</li>
+                                    </ul>
+                                </div>
+                            </template>
+                        </li>
+                    </ul>
+                    <p class="visibloc-guided-recipes__empty" data-visibloc-recipes-empty hidden>Aucune recette ne correspond au filtre sélectionné.</p>
+                    <div class="visibloc-guided-recipes__dialog" data-visibloc-recipe-dialog hidden>
+                        <div class="visibloc-guided-recipes__dialog-backdrop" data-visibloc-recipe-close></div>
+                        <div
+                            class="visibloc-guided-recipes__dialog-window"
+                            role="dialog"
+                            aria-modal="true"
+                            aria-labelledby="demo-guided-title"
+                            aria-describedby="demo-guided-description"
+                            data-visibloc-recipe-dialog-window
+                        >
+                            <header class="visibloc-guided-recipes__dialog-header">
+                                <div class="visibloc-guided-recipes__dialog-heading">
+                                    <h3 id="demo-guided-title" class="visibloc-guided-recipes__dialog-title" data-visibloc-recipe-dialog-title></h3>
+                                    <p id="demo-guided-description" class="visibloc-guided-recipes__dialog-description" data-visibloc-recipe-dialog-description></p>
+                                </div>
+                                <button type="button" class="visibloc-guided-recipes__dialog-close" data-visibloc-recipe-close>
+                                    <span aria-hidden="true">&times;</span>
+                                    <span class="screen-reader-text">Fermer l’assistant</span>
+                                </button>
+                            </header>
+                            <div class="visibloc-guided-recipes__dialog-meta" data-visibloc-recipe-dialog-meta>
+                                <dl class="visibloc-guided-recipes__dialog-meta-grid">
+                                    <div class="visibloc-guided-recipes__dialog-meta-item">
+                                        <dt>Objectif</dt>
+                                        <dd data-visibloc-recipe-meta="goal"></dd>
+                                    </div>
+                                    <div class="visibloc-guided-recipes__dialog-meta-item">
+                                        <dt>Audience cible</dt>
+                                        <dd data-visibloc-recipe-meta="audience"></dd>
+                                    </div>
+                                    <div class="visibloc-guided-recipes__dialog-meta-item">
+                                        <dt>Indicateur clé</dt>
+                                        <dd data-visibloc-recipe-meta="kpi"></dd>
+                                    </div>
+                                    <div class="visibloc-guided-recipes__dialog-meta-item">
+                                        <dt>Durée estimée</dt>
+                                        <dd data-visibloc-recipe-meta="time"></dd>
+                                    </div>
+                                </dl>
+                                <div class="visibloc-guided-recipes__dialog-blocks" data-visibloc-recipe-dialog-blocks hidden>
+                                    <h4 class="visibloc-guided-recipes__dialog-blocks-title">Blocs recommandés</h4>
+                                    <ul class="visibloc-guided-recipes__dialog-blocks-list" data-visibloc-recipe-dialog-blocks-list></ul>
+                                </div>
+                            </div>
+                            <div class="visibloc-guided-recipes__dialog-progress" role="group" aria-label="Progression de l’assistant">
+                                <progress value="0" max="4" class="visibloc-guided-recipes__progress" data-visibloc-recipe-progress>Progression de l’assistant</progress>
+                                <span class="visibloc-guided-recipes__progress-label" data-visibloc-recipe-progress-label data-visibloc-progress-template="Étape %1$s sur %2$s"></span>
+                            </div>
+                            <div class="visibloc-guided-recipes__dialog-body">
+                                <div class="visibloc-guided-recipes__stepper" data-visibloc-recipe-stepper>
+                                    <div class="visibloc-guided-recipes__stepper-tabs" role="tablist" aria-label="Étapes de la recette" data-visibloc-recipe-tabs></div>
+                                    <div class="visibloc-guided-recipes__stepper-panels" data-visibloc-recipe-panels></div>
+                                </div>
+                            </div>
+                            <div class="screen-reader-text" aria-live="polite" data-visibloc-recipe-step-live></div>
+                            <footer class="visibloc-guided-recipes__dialog-footer">
+                                <button type="button" class="button button-secondary" data-visibloc-recipe-prev>Étape précédente</button>
+                                <button type="button" class="button button-primary visibloc-guided-recipes__dialog-next" data-visibloc-recipe-next data-visibloc-label-next="Étape suivante" data-visibloc-label-finish="Terminer">Étape suivante</button>
+                            </footer>
+                        </div>
+                    </div>
+                </section>
+            </div>
+        </div>
+    </section>
+
+    <script src="../assets/admin-recipes.js"></script>
     <script>
         const toggle = document.getElementById('dark-toggle');
         const applyDarkTheme = () => {

--- a/visi-bloc-jlg/includes/admin-settings.php
+++ b/visi-bloc-jlg/includes/admin-settings.php
@@ -108,6 +108,217 @@ function visibloc_jlg_calculate_onboarding_progress( array $items ) {
     ];
 }
 
+/**
+ * Return the curated guided recipes displayed in the onboarding wizard.
+ *
+ * @return array[]
+ */
+function visibloc_jlg_get_guided_recipes() {
+    return [
+        [
+            'id'             => 'welcome-series',
+            'title'          => __( 'Série de bienvenue personnalisée', 'visi-bloc-jlg' ),
+            'description'    => __( 'Affichez un message de bienvenue dynamique aux nouveaux inscrits pour accélérer leur activation.', 'visi-bloc-jlg' ),
+            'theme'          => 'onboarding',
+            'theme_label'    => __( 'Onboarding', 'visi-bloc-jlg' ),
+            'estimated_time' => __( '5 minutes', 'visi-bloc-jlg' ),
+            'audience'       => __( 'Visiteurs authentifiés avec un cookie d’inscription récent ou un rôle « Nouvel abonné ».', 'visi-bloc-jlg' ),
+            'goal'           => __( 'Accueillir chaleureusement chaque nouvel abonné et l’orienter vers l’action clé.', 'visi-bloc-jlg' ),
+            'kpi'            => __( 'Taux de clic sur le call-to-action de bienvenue.', 'visi-bloc-jlg' ),
+            'blocks'         => [
+                __( 'Bloc Bannière / Couverture', 'visi-bloc-jlg' ),
+                __( 'Bloc Bouton', 'visi-bloc-jlg' ),
+                __( 'Bloc Liste de contrôle', 'visi-bloc-jlg' ),
+            ],
+            'steps'          => [
+                [
+                    'title'    => __( 'Objectif', 'visi-bloc-jlg' ),
+                    'summary'  => __( 'Clarifiez ce que doit accomplir cette séquence de bienvenue pour vos nouveaux inscrits.', 'visi-bloc-jlg' ),
+                    'actions'  => [
+                        __( 'Identifiez l’action principale attendue (compléter un profil, télécharger une ressource, rejoindre une communauté).', 'visi-bloc-jlg' ),
+                        __( 'Ajoutez une note interne dans le bloc pour rappeler l’objectif à l’équipe éditoriale.', 'visi-bloc-jlg' ),
+                        __( 'Définissez le KPI associé dans votre outil d’analytics (événement de clic ou conversion).', 'visi-bloc-jlg' ),
+                    ],
+                    'notes'    => [
+                        __( 'Assurez-vous que la formulation respecte les règles de lisibilité (WCAG 2.2 – critère 3.1.5).', 'visi-bloc-jlg' ),
+                    ],
+                ],
+                [
+                    'title'    => __( 'Audience', 'visi-bloc-jlg' ),
+                    'summary'  => __( 'Ciblez uniquement les visiteurs fraîchement inscrits ou ceux disposant d’un rôle dédié.', 'visi-bloc-jlg' ),
+                    'actions'  => [
+                        __( 'Activez la condition « Statut de connexion » et sélectionnez les rôles marketing pertinents.', 'visi-bloc-jlg' ),
+                        __( 'Ajoutez un déclencheur « Segment marketing » si votre CRM expose un segment « Nouveau client ».', 'visi-bloc-jlg' ),
+                        __( 'Enregistrez un cookie `visibloc_welcome_shown` pour limiter l’affichage à la première visite.', 'visi-bloc-jlg' ),
+                    ],
+                    'notes'    => [
+                        __( 'Testez le parcours avec le commutateur de rôle pour vérifier les annonces de focus et la navigation clavier.', 'visi-bloc-jlg' ),
+                    ],
+                ],
+                [
+                    'title'    => __( 'Timing', 'visi-bloc-jlg' ),
+                    'summary'  => __( 'Planifiez la durée d’affichage afin d’éviter la surexposition du message.', 'visi-bloc-jlg' ),
+                    'actions'  => [
+                        __( 'Activez la planification et définissez une date de fin 7 jours après l’inscription.', 'visi-bloc-jlg' ),
+                        __( 'Combinez avec une règle récurrente (9h-21h) pour ne pas gêner les visiteurs nocturnes.', 'visi-bloc-jlg' ),
+                        __( 'Documentez la durée dans la description du bloc pour les relecteurs.', 'visi-bloc-jlg' ),
+                    ],
+                    'notes'    => [
+                        __( 'Vérifiez l’accessibilité du composant lors de l’activation/désactivation (critère 2.2.1).', 'visi-bloc-jlg' ),
+                    ],
+                ],
+                [
+                    'title'    => __( 'Contenu & fallback', 'visi-bloc-jlg' ),
+                    'summary'  => __( 'Préparez une alternative accessible pour les visiteurs qui ne remplissent plus les conditions.', 'visi-bloc-jlg' ),
+                    'actions'  => [
+                        __( 'Rédigez un message court expliquant pourquoi le contenu n’est plus affiché.', 'visi-bloc-jlg' ),
+                        __( 'Sélectionnez un bloc réutilisable de repli dans les réglages globaux.', 'visi-bloc-jlg' ),
+                        __( 'Ajoutez une classe `vb-desktop-only` si le message doit être limité aux écrans larges.', 'visi-bloc-jlg' ),
+                    ],
+                    'notes'    => [
+                        __( 'Contrôlez le contraste des boutons (> 4.5:1) et la taille minimale des cibles tactiles (critère 2.5.8).', 'visi-bloc-jlg' ),
+                    ],
+                    'resources' => [
+                        [
+                            'label' => __( 'Checklist accessibilité WordPress', 'visi-bloc-jlg' ),
+                            'url'   => 'https://make.wordpress.org/accessibility/handbook/best-practices/',
+                        ],
+                    ],
+                ],
+            ],
+        ],
+        [
+            'id'             => 'woocommerce-cart-recovery',
+            'title'          => __( 'Relance panier WooCommerce', 'visi-bloc-jlg' ),
+            'description'    => __( 'Affichez une bannière personnalisée aux clients ayant un panier abandonné pour finaliser leur commande.', 'visi-bloc-jlg' ),
+            'theme'          => 'conversion',
+            'theme_label'    => __( 'Conversion', 'visi-bloc-jlg' ),
+            'estimated_time' => __( '8 minutes', 'visi-bloc-jlg' ),
+            'audience'       => __( 'Clients connectés avec des articles dans le panier WooCommerce et sans commande validée.', 'visi-bloc-jlg' ),
+            'goal'           => __( 'Relancer les paniers abandonnés avec une incitation contextualisée.', 'visi-bloc-jlg' ),
+            'kpi'            => __( 'Taux de récupération des paniers sur 7 jours.', 'visi-bloc-jlg' ),
+            'blocks'         => [
+                __( 'Bloc Bannière / Notice', 'visi-bloc-jlg' ),
+                __( 'Bloc Boutons', 'visi-bloc-jlg' ),
+                __( 'Bloc Liste de produits', 'visi-bloc-jlg' ),
+            ],
+            'steps'          => [
+                [
+                    'title'   => __( 'Objectif', 'visi-bloc-jlg' ),
+                    'summary' => __( 'Cadrez la valeur ajoutée de votre relance (code promo, livraison offerte, assistance).', 'visi-bloc-jlg' ),
+                    'actions' => [
+                        __( 'Choisissez le bénéfice le plus pertinent au regard de vos marges.', 'visi-bloc-jlg' ),
+                        __( 'Définissez le message principal et un CTA clair (« Finaliser ma commande »).', 'visi-bloc-jlg' ),
+                        __( 'Synchronisez l’objectif avec vos campagnes email/SMS pour éviter les doublons.', 'visi-bloc-jlg' ),
+                    ],
+                ],
+                [
+                    'title'   => __( 'Audience', 'visi-bloc-jlg' ),
+                    'summary' => __( 'Filtrez les visiteurs ayant un panier actif mais aucune commande récente.', 'visi-bloc-jlg' ),
+                    'actions' => [
+                        __( 'Ajoutez la condition WooCommerce « Panier non vide ».', 'visi-bloc-jlg' ),
+                        __( 'Excluez les segments VIP si une campagne dédiée existe déjà.', 'visi-bloc-jlg' ),
+                        __( 'Limitez l’affichage aux rôles clients pour éviter d’exposer l’offre en navigation anonyme.', 'visi-bloc-jlg' ),
+                    ],
+                    'notes' => [
+                        __( 'Vérifiez que la navigation clavier permet d’ajouter le produit au panier sans piège (critère 2.1.2).', 'visi-bloc-jlg' ),
+                    ],
+                ],
+                [
+                    'title'   => __( 'Timing', 'visi-bloc-jlg' ),
+                    'summary' => __( 'Définissez quand déclencher la relance et combien de temps la conserver.', 'visi-bloc-jlg' ),
+                    'actions' => [
+                        __( 'Utilisez un cookie de suivi (`visibloc_cart_seen`) pour ne pas ré-afficher le message plus de 3 fois par jour.', 'visi-bloc-jlg' ),
+                        __( 'Planifiez l’affichage pendant 72 heures maximum après l’abandon du panier.', 'visi-bloc-jlg' ),
+                        __( 'Combinez avec un créneau horaire (8h-22h) pour correspondre aux disponibilités de votre support.', 'visi-bloc-jlg' ),
+                    ],
+                ],
+                [
+                    'title'   => __( 'Contenu & fallback', 'visi-bloc-jlg' ),
+                    'summary' => __( 'Proposez une alternative utile si le panier a déjà été validé ou expiré.', 'visi-bloc-jlg' ),
+                    'actions' => [
+                        __( 'Préparez un fallback avec des liens vers les catégories populaires.', 'visi-bloc-jlg' ),
+                        __( 'Ajoutez un bouton secondaire vers le support client ou le chat en direct.', 'visi-bloc-jlg' ),
+                        __( 'Assurez-vous que les codes promo sont annoncés avec un texte accessible, sans s’appuyer uniquement sur la couleur.', 'visi-bloc-jlg' ),
+                    ],
+                    'resources' => [
+                        [
+                            'label' => __( 'Bonnes pratiques WooCommerce', 'visi-bloc-jlg' ),
+                            'url'   => 'https://woocommerce.com/posts/abandoned-cart-best-practices/',
+                        ],
+                    ],
+                ],
+            ],
+        ],
+        [
+            'id'             => 'b2b-lead-nurturing',
+            'title'          => __( 'Parcours lead nurturing B2B', 'visi-bloc-jlg' ),
+            'description'    => __( 'Présentez une ressource premium lorsque le visiteur atteint un score d’engagement défini.', 'visi-bloc-jlg' ),
+            'theme'          => 'engagement',
+            'theme_label'    => __( 'Engagement', 'visi-bloc-jlg' ),
+            'estimated_time' => __( '10 minutes', 'visi-bloc-jlg' ),
+            'audience'       => __( 'Contacts identifiés par votre CRM (segment « MQL ») naviguant sur des pages produits clés.', 'visi-bloc-jlg' ),
+            'goal'           => __( 'Convertir les visiteurs engagés en prospects qualifiés grâce à un contenu approfondi.', 'visi-bloc-jlg' ),
+            'kpi'            => __( 'Taux de téléchargement du livre blanc ou d’inscription au webinar.', 'visi-bloc-jlg' ),
+            'blocks'         => [
+                __( 'Bloc Colonnes avec visuels', 'visi-bloc-jlg' ),
+                __( 'Bloc Formulaire (intégration Gravity Forms / WPForms)', 'visi-bloc-jlg' ),
+                __( 'Bloc Témoignage', 'visi-bloc-jlg' ),
+            ],
+            'steps'          => [
+                [
+                    'title'   => __( 'Objectif', 'visi-bloc-jlg' ),
+                    'summary' => __( 'Définissez le rôle du contenu premium dans votre funnel.', 'visi-bloc-jlg' ),
+                    'actions' => [
+                        __( 'Choisissez le contenu téléchargeable le plus pertinent (livre blanc, étude de cas).', 'visi-bloc-jlg' ),
+                        __( 'Formulez une promesse claire dans l’accroche et les métadonnées du bloc.', 'visi-bloc-jlg' ),
+                        __( 'Préparez un UTM spécifique pour mesurer l’origine des conversions.', 'visi-bloc-jlg' ),
+                    ],
+                ],
+                [
+                    'title'   => __( 'Audience', 'visi-bloc-jlg' ),
+                    'summary' => __( 'Ciblez les visiteurs identifiés comme prospects chauds par votre CRM.', 'visi-bloc-jlg' ),
+                    'actions' => [
+                        __( 'Exploitez le segment marketing `crm_mql` fourni par le filtre `visibloc_jlg_user_segments`.', 'visi-bloc-jlg' ),
+                        __( 'Ajoutez une règle basée sur la taxonomie (catégorie « Solutions » ou « Tarifs »).', 'visi-bloc-jlg' ),
+                        __( 'Excluez les rôles internes pour éviter les biais statistiques.', 'visi-bloc-jlg' ),
+                    ],
+                    'notes' => [
+                        __( 'Vérifiez que le focus revient sur le formulaire après validation (critère 3.2.2).', 'visi-bloc-jlg' ),
+                    ],
+                ],
+                [
+                    'title'   => __( 'Timing', 'visi-bloc-jlg' ),
+                    'summary' => __( 'Coordonnez l’affichage avec vos autres campagnes nurture.', 'visi-bloc-jlg' ),
+                    'actions' => [
+                        __( 'Définissez une fenêtre d’affichage alignée sur la campagne email (par exemple 14 jours).', 'visi-bloc-jlg' ),
+                        __( 'Ajoutez une règle de fréquence via un cookie (`visibloc_nurture_limit`) pour limiter à 1 affichage par visite.', 'visi-bloc-jlg' ),
+                        __( 'Préparez un rappel interne dans l’onglet « Notes » pour synchroniser les commerciaux.', 'visi-bloc-jlg' ),
+                    ],
+                ],
+                [
+                    'title'   => __( 'Contenu & fallback', 'visi-bloc-jlg' ),
+                    'summary' => __( 'Offrez un contenu alternatif ou un point de contact humain.', 'visi-bloc-jlg' ),
+                    'actions' => [
+                        __( 'Préparez un message secondaire orienté vers la prise de rendez-vous.', 'visi-bloc-jlg' ),
+                        __( 'Ajoutez un témoignage accessible (texte et audio avec transcription).', 'visi-bloc-jlg' ),
+                        __( 'Contrôlez la compatibilité du formulaire avec les lecteurs d’écran (libellés explicites, message d’erreur clair).', 'visi-bloc-jlg' ),
+                    ],
+                    'notes'    => [
+                        __( 'Documentez l’impact dans votre tableau de bord analytics dès la première semaine.', 'visi-bloc-jlg' ),
+                    ],
+                    'resources' => [
+                        [
+                            'label' => __( 'Guide WCAG 2.2 (W3C)', 'visi-bloc-jlg' ),
+                            'url'   => 'https://www.w3.org/TR/WCAG22/',
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ];
+}
+
 function visibloc_jlg_update_supported_blocks( $block_names ) {
     $normalized_blocks    = visibloc_jlg_normalize_block_names( $block_names );
     $current_blocks_raw   = get_option( 'visibloc_supported_blocks', [] );
@@ -643,64 +854,80 @@ function visibloc_jlg_render_help_page_content() {
     $device_posts    = visibloc_jlg_get_device_specific_posts();
     $status          = visibloc_jlg_get_sanitized_query_arg( 'status' );
 
+    $guided_recipes = visibloc_jlg_get_guided_recipes();
+
     $breakpoints_requirement_message = visibloc_jlg_get_breakpoints_requirement_message();
 
-    $sections = [
+    $sections = [];
+
+    if ( ! empty( $guided_recipes ) ) {
+        $sections[] = [
+            'id'      => 'visibloc-section-guided-recipes',
+            'label'   => __( 'Recettes guidées', 'visi-bloc-jlg' ),
+            'render'  => 'visibloc_jlg_render_guided_recipes_section',
+            'args'    => [ $guided_recipes ],
+        ];
+    }
+
+    $sections = array_merge(
+        $sections,
         [
-            'id'      => 'visibloc-section-blocks',
-            'label'   => __( 'Blocs compatibles', 'visi-bloc-jlg' ),
-            'render'  => 'visibloc_jlg_render_supported_blocks_section',
-            'args'    => [ $registered_block_types, $configured_blocks ],
-        ],
-        [
-            'id'      => 'visibloc-section-permissions',
-            'label'   => __( "Permissions d'Aperçu", 'visi-bloc-jlg' ),
-            'render'  => 'visibloc_jlg_render_permissions_section',
-            'args'    => [ $allowed_roles ],
-        ],
-        [
-            'id'      => 'visibloc-section-hidden',
-            'label'   => __( 'Tableau de bord des blocs masqués (via Œil)', 'visi-bloc-jlg' ),
-            'render'  => 'visibloc_jlg_render_hidden_blocks_section',
-            'args'    => [ $hidden_posts ],
-        ],
-        [
-            'id'      => 'visibloc-section-device',
-            'label'   => __( 'Tableau de bord des blocs avec visibilité par appareil', 'visi-bloc-jlg' ),
-            'render'  => 'visibloc_jlg_render_device_visibility_section',
-            'args'    => [ $device_posts ],
-        ],
-        [
-            'id'      => 'visibloc-section-scheduled',
-            'label'   => __( 'Tableau de bord des blocs programmés', 'visi-bloc-jlg' ),
-            'render'  => 'visibloc_jlg_render_scheduled_blocks_section',
-            'args'    => [ $scheduled_posts ],
-        ],
-        [
-            'id'      => 'visibloc-section-debug',
-            'label'   => __( 'Mode de débogage', 'visi-bloc-jlg' ),
-            'render'  => 'visibloc_jlg_render_debug_mode_section',
-            'args'    => [ $debug_status ],
-        ],
-        [
-            'id'      => 'visibloc-section-breakpoints',
-            'label'   => __( 'Réglage des points de rupture', 'visi-bloc-jlg' ),
-            'render'  => 'visibloc_jlg_render_breakpoints_section',
-            'args'    => [ $mobile_bp, $tablet_bp ],
-        ],
-        [
-            'id'      => 'visibloc-section-fallback',
-            'label'   => __( 'Contenu de repli global', 'visi-bloc-jlg' ),
-            'render'  => 'visibloc_jlg_render_fallback_section',
-            'args'    => [ $fallback_settings, $fallback_blocks ],
-        ],
-        [
-            'id'      => 'visibloc-section-backup',
-            'label'   => __( 'Export & sauvegarde', 'visi-bloc-jlg' ),
-            'render'  => 'visibloc_jlg_render_settings_backup_section',
-            'args'    => [],
-        ],
-    ];
+            [
+                'id'      => 'visibloc-section-blocks',
+                'label'   => __( 'Blocs compatibles', 'visi-bloc-jlg' ),
+                'render'  => 'visibloc_jlg_render_supported_blocks_section',
+                'args'    => [ $registered_block_types, $configured_blocks ],
+            ],
+            [
+                'id'      => 'visibloc-section-permissions',
+                'label'   => __( "Permissions d'Aperçu", 'visi-bloc-jlg' ),
+                'render'  => 'visibloc_jlg_render_permissions_section',
+                'args'    => [ $allowed_roles ],
+            ],
+            [
+                'id'      => 'visibloc-section-hidden',
+                'label'   => __( 'Tableau de bord des blocs masqués (via Œil)', 'visi-bloc-jlg' ),
+                'render'  => 'visibloc_jlg_render_hidden_blocks_section',
+                'args'    => [ $hidden_posts ],
+            ],
+            [
+                'id'      => 'visibloc-section-device',
+                'label'   => __( 'Tableau de bord des blocs avec visibilité par appareil', 'visi-bloc-jlg' ),
+                'render'  => 'visibloc_jlg_render_device_visibility_section',
+                'args'    => [ $device_posts ],
+            ],
+            [
+                'id'      => 'visibloc-section-scheduled',
+                'label'   => __( 'Tableau de bord des blocs programmés', 'visi-bloc-jlg' ),
+                'render'  => 'visibloc_jlg_render_scheduled_blocks_section',
+                'args'    => [ $scheduled_posts ],
+            ],
+            [
+                'id'      => 'visibloc-section-debug',
+                'label'   => __( 'Mode de débogage', 'visi-bloc-jlg' ),
+                'render'  => 'visibloc_jlg_render_debug_mode_section',
+                'args'    => [ $debug_status ],
+            ],
+            [
+                'id'      => 'visibloc-section-breakpoints',
+                'label'   => __( 'Réglage des points de rupture', 'visi-bloc-jlg' ),
+                'render'  => 'visibloc_jlg_render_breakpoints_section',
+                'args'    => [ $mobile_bp, $tablet_bp ],
+            ],
+            [
+                'id'      => 'visibloc-section-fallback',
+                'label'   => __( 'Contenu de repli global', 'visi-bloc-jlg' ),
+                'render'  => 'visibloc_jlg_render_fallback_section',
+                'args'    => [ $fallback_settings, $fallback_blocks ],
+            ],
+            [
+                'id'      => 'visibloc-section-backup',
+                'label'   => __( 'Export & sauvegarde', 'visi-bloc-jlg' ),
+                'render'  => 'visibloc_jlg_render_settings_backup_section',
+                'args'    => [],
+            ],
+        ]
+    );
 
     $onboarding_items    = visibloc_jlg_build_onboarding_checklist_items(
         [
@@ -864,6 +1091,347 @@ function visibloc_jlg_render_help_page_content() {
                     call_user_func_array( $callback, $args );
                 endforeach; ?>
             </div>
+        </div>
+    </div>
+    <?php
+}
+
+function visibloc_jlg_render_guided_recipes_section( $recipes ) {
+    $recipes = is_array( $recipes ) ? array_values( array_filter( $recipes ) ) : [];
+    $section_id = 'visibloc-section-guided-recipes';
+
+    $filter_select_id      = $section_id . '-filter';
+    $empty_message_id      = $section_id . '-empty';
+    $live_region_id        = $section_id . '-live';
+    $dialog_title_id       = $section_id . '-dialog-title';
+    $dialog_description_id = $section_id . '-dialog-description';
+
+    $themes = [];
+
+    foreach ( $recipes as $recipe ) {
+        $theme_slug = isset( $recipe['theme'] ) ? sanitize_html_class( $recipe['theme'] ) : '';
+
+        if ( '' === $theme_slug ) {
+            $theme_slug = 'general';
+        }
+
+        $theme_label = isset( $recipe['theme_label'] ) ? (string) $recipe['theme_label'] : '';
+
+        if ( '' === $theme_label ) {
+            $theme_label = ucfirst( str_replace( '-', ' ', $theme_slug ) );
+        }
+
+        $themes[ $theme_slug ] = $theme_label;
+    }
+
+    if ( ! empty( $themes ) ) {
+        ksort( $themes );
+    }
+
+    ?>
+    <div
+        id="<?php echo esc_attr( $section_id ); ?>"
+        class="postbox visibloc-guided-recipes-box"
+        data-visibloc-section="<?php echo esc_attr( $section_id ); ?>"
+    >
+        <h2 class="hndle"><span><?php esc_html_e( 'Recettes guidées', 'visi-bloc-jlg' ); ?></span></h2>
+        <div class="inside">
+            <section class="visibloc-guided-recipes" data-visibloc-recipes>
+                <header class="visibloc-guided-recipes__intro">
+                    <div class="visibloc-guided-recipes__text">
+                        <h3 class="visibloc-guided-recipes__title">
+                            <?php esc_html_e( 'Accélérez vos scénarios avec un assistant pas-à-pas', 'visi-bloc-jlg' ); ?>
+                        </h3>
+                        <p class="visibloc-guided-recipes__subtitle">
+                            <?php esc_html_e( 'Choisissez une recette pour lancer l’assistant en quatre étapes. Chaque étape rappelle les exigences WCAG 2.2 et les réglages clés à valider avant publication.', 'visi-bloc-jlg' ); ?>
+                        </p>
+                    </div>
+                    <?php if ( ! empty( $themes ) ) : ?>
+                        <div class="visibloc-guided-recipes__filters">
+                            <label class="visibloc-guided-recipes__filter-label" for="<?php echo esc_attr( $filter_select_id ); ?>">
+                                <?php esc_html_e( 'Filtrer par thématique', 'visi-bloc-jlg' ); ?>
+                            </label>
+                            <select
+                                id="<?php echo esc_attr( $filter_select_id ); ?>"
+                                class="visibloc-guided-recipes__filter-select"
+                                data-visibloc-recipes-filter
+                                aria-controls="<?php echo esc_attr( $section_id ); ?>-list"
+                            >
+                                <option value="">
+                                    <?php esc_html_e( 'Toutes les thématiques', 'visi-bloc-jlg' ); ?>
+                                </option>
+                                <?php foreach ( $themes as $theme_slug => $theme_label ) : ?>
+                                    <option value="<?php echo esc_attr( $theme_slug ); ?>">
+                                        <?php echo esc_html( $theme_label ); ?>
+                                    </option>
+                                <?php endforeach; ?>
+                            </select>
+                        </div>
+                    <?php endif; ?>
+                </header>
+                <?php if ( empty( $recipes ) ) : ?>
+                    <p><em><?php esc_html_e( 'Aucune recette n’est disponible pour le moment.', 'visi-bloc-jlg' ); ?></em></p>
+                <?php else : ?>
+                    <div class="screen-reader-text" id="<?php echo esc_attr( $live_region_id ); ?>" aria-live="polite" data-visibloc-recipes-live></div>
+                    <ul class="visibloc-guided-recipes__list" id="<?php echo esc_attr( $section_id ); ?>-list" role="list">
+                        <?php foreach ( $recipes as $index => $recipe ) :
+                            $recipe_id = isset( $recipe['id'] ) ? sanitize_key( $recipe['id'] ) : '';
+
+                            if ( '' === $recipe_id ) {
+                                $recipe_id = 'recipe-' . $index;
+                            }
+
+                            $card_id     = 'visibloc-recipe-card-' . $recipe_id;
+                            $template_id = 'visibloc-recipe-template-' . $recipe_id;
+
+                            $theme_slug = isset( $recipe['theme'] ) ? sanitize_html_class( $recipe['theme'] ) : '';
+
+                            if ( '' === $theme_slug ) {
+                                $theme_slug = 'general';
+                            }
+
+                            $theme_label = isset( $recipe['theme_label'] ) ? (string) $recipe['theme_label'] : '';
+                            $title       = isset( $recipe['title'] ) ? (string) $recipe['title'] : '';
+                            $description = isset( $recipe['description'] ) ? (string) $recipe['description'] : '';
+                            $estimated   = isset( $recipe['estimated_time'] ) ? (string) $recipe['estimated_time'] : '';
+                            $audience    = isset( $recipe['audience'] ) ? (string) $recipe['audience'] : '';
+                            $goal        = isset( $recipe['goal'] ) ? (string) $recipe['goal'] : '';
+                            $kpi         = isset( $recipe['kpi'] ) ? (string) $recipe['kpi'] : '';
+
+                            $blocks = isset( $recipe['blocks'] ) && is_array( $recipe['blocks'] )
+                                ? array_values( array_filter( array_map( 'strval', $recipe['blocks'] ) ) )
+                                : [];
+                            $steps = isset( $recipe['steps'] ) && is_array( $recipe['steps'] )
+                                ? array_values( array_filter( $recipe['steps'] ) )
+                                : [];
+
+                            $step_count      = count( $steps );
+                            $step_count_text = sprintf( _n( '%d étape', '%d étapes', $step_count, 'visi-bloc-jlg' ), $step_count );
+                            $blocks_json     = ! empty( $blocks ) ? wp_json_encode( $blocks ) : '[]';
+
+                            if ( false === $blocks_json ) {
+                                $blocks_json = '[]';
+                            }
+                            ?>
+                            <li
+                                class="visibloc-guided-recipes__item"
+                                data-visibloc-recipe-card
+                                data-theme="<?php echo esc_attr( $theme_slug ); ?>"
+                                data-recipe-id="<?php echo esc_attr( $recipe_id ); ?>"
+                                data-recipe-title="<?php echo esc_attr( $title ); ?>"
+                                data-recipe-description="<?php echo esc_attr( $description ); ?>"
+                                data-recipe-goal="<?php echo esc_attr( $goal ); ?>"
+                                data-recipe-audience="<?php echo esc_attr( $audience ); ?>"
+                                data-recipe-kpi="<?php echo esc_attr( $kpi ); ?>"
+                                data-recipe-time="<?php echo esc_attr( $estimated ); ?>"
+                                data-recipe-theme-label="<?php echo esc_attr( $theme_label ); ?>"
+                                data-recipe-step-count="<?php echo esc_attr( $step_count ); ?>"
+                                data-recipe-blocks="<?php echo esc_attr( $blocks_json ); ?>"
+                            >
+                                <article class="visibloc-recipe-card" aria-labelledby="<?php echo esc_attr( $card_id ); ?>-title">
+                                    <header class="visibloc-recipe-card__header">
+                                        <?php if ( '' !== $theme_label ) : ?>
+                                            <span class="visibloc-recipe-card__tag"><?php echo esc_html( $theme_label ); ?></span>
+                                        <?php endif; ?>
+                                        <h3 id="<?php echo esc_attr( $card_id ); ?>-title" class="visibloc-recipe-card__title">
+                                            <?php echo esc_html( $title ); ?>
+                                        </h3>
+                                        <?php if ( '' !== $description ) : ?>
+                                            <p class="visibloc-recipe-card__description"><?php echo esc_html( $description ); ?></p>
+                                        <?php endif; ?>
+                                    </header>
+                                    <?php if ( ! empty( $blocks ) ) : ?>
+                                        <ul class="visibloc-recipe-card__blocks" aria-label="<?php esc_attr_e( 'Blocs recommandés', 'visi-bloc-jlg' ); ?>">
+                                            <?php foreach ( $blocks as $block_label ) : ?>
+                                                <li><?php echo esc_html( $block_label ); ?></li>
+                                            <?php endforeach; ?>
+                                        </ul>
+                                    <?php endif; ?>
+                                    <dl class="visibloc-recipe-card__meta">
+                                        <div class="visibloc-recipe-card__meta-item">
+                                            <dt><?php esc_html_e( 'Durée estimée', 'visi-bloc-jlg' ); ?></dt>
+                                            <dd><?php echo esc_html( '' !== $estimated ? $estimated : __( 'Quelques minutes', 'visi-bloc-jlg' ) ); ?></dd>
+                                        </div>
+                                        <div class="visibloc-recipe-card__meta-item">
+                                            <dt><?php esc_html_e( 'Objectif', 'visi-bloc-jlg' ); ?></dt>
+                                            <dd><?php echo esc_html( $goal ); ?></dd>
+                                        </div>
+                                        <div class="visibloc-recipe-card__meta-item">
+                                            <dt><?php esc_html_e( 'Audience', 'visi-bloc-jlg' ); ?></dt>
+                                            <dd><?php echo esc_html( $audience ); ?></dd>
+                                        </div>
+                                    </dl>
+                                    <div class="visibloc-recipe-card__footer">
+                                        <p class="visibloc-recipe-card__kpi">
+                                            <strong><?php esc_html_e( 'Indicateur clé', 'visi-bloc-jlg' ); ?>:</strong>
+                                            <span><?php echo esc_html( $kpi ); ?></span>
+                                        </p>
+                                        <p class="visibloc-recipe-card__steps" aria-label="<?php esc_attr_e( 'Nombre d’étapes de l’assistant', 'visi-bloc-jlg' ); ?>">
+                                            <?php echo esc_html( $step_count_text ); ?>
+                                        </p>
+                                    </div>
+                                    <div class="visibloc-recipe-card__actions">
+                                        <button
+                                            type="button"
+                                            class="button button-primary visibloc-recipe-card__button"
+                                            data-visibloc-recipe-start
+                                            data-recipe-template="<?php echo esc_attr( $template_id ); ?>"
+                                        >
+                                            <?php esc_html_e( 'Lancer l’assistant', 'visi-bloc-jlg' ); ?>
+                                        </button>
+                                    </div>
+                                </article>
+                                <template id="<?php echo esc_attr( $template_id ); ?>" data-visibloc-recipe-template>
+                                    <?php foreach ( $steps as $step ) :
+                                        $step_title     = isset( $step['title'] ) ? (string) $step['title'] : '';
+                                        $step_summary   = isset( $step['summary'] ) ? (string) $step['summary'] : '';
+                                        $step_actions   = isset( $step['actions'] ) && is_array( $step['actions'] ) ? array_values( array_filter( $step['actions'] ) ) : [];
+                                        $step_notes     = isset( $step['notes'] ) && is_array( $step['notes'] ) ? array_values( array_filter( $step['notes'] ) ) : [];
+                                        $step_resources = isset( $step['resources'] ) && is_array( $step['resources'] ) ? array_values( array_filter( $step['resources'] ) ) : [];
+                                        ?>
+                                        <div
+                                            class="visibloc-recipe-step"
+                                            data-visibloc-recipe-step
+                                            data-step-title="<?php echo esc_attr( $step_title ); ?>"
+                                            data-step-summary="<?php echo esc_attr( $step_summary ); ?>"
+                                        >
+                                            <?php if ( '' !== $step_summary ) : ?>
+                                                <p class="visibloc-recipe-step__summary"><?php echo esc_html( $step_summary ); ?></p>
+                                            <?php endif; ?>
+                                            <?php if ( ! empty( $step_actions ) ) : ?>
+                                                <ul class="visibloc-recipe-step__list">
+                                                    <?php foreach ( $step_actions as $action ) : ?>
+                                                        <li><?php echo esc_html( $action ); ?></li>
+                                                    <?php endforeach; ?>
+                                                </ul>
+                                            <?php endif; ?>
+                                            <?php if ( ! empty( $step_notes ) ) : ?>
+                                                <div class="visibloc-recipe-step__notes" role="note">
+                                                    <strong class="visibloc-recipe-step__notes-title"><?php esc_html_e( 'Points de vigilance', 'visi-bloc-jlg' ); ?></strong>
+                                                    <ul>
+                                                        <?php foreach ( $step_notes as $note ) : ?>
+                                                            <li><?php echo esc_html( $note ); ?></li>
+                                                        <?php endforeach; ?>
+                                                    </ul>
+                                                </div>
+                                            <?php endif; ?>
+                                            <?php if ( ! empty( $step_resources ) ) : ?>
+                                                <p class="visibloc-recipe-step__resources">
+                                                    <span class="visibloc-recipe-step__resources-label"><?php esc_html_e( 'Ressources utiles :', 'visi-bloc-jlg' ); ?></span>
+                                                    <?php
+                                                    $resource_index = 0;
+                                                    foreach ( $step_resources as $resource ) :
+                                                        $resource_label = isset( $resource['label'] ) ? (string) $resource['label'] : '';
+                                                        $resource_url   = isset( $resource['url'] ) ? (string) $resource['url'] : '';
+
+                                                        if ( '' === $resource_label || '' === $resource_url ) {
+                                                            continue;
+                                                        }
+
+                                                        if ( $resource_index > 0 ) {
+                                                            echo '<span class="visibloc-recipe-step__resources-separator"> · </span>';
+                                                        }
+
+                                                        printf(
+                                                            '<a href="%1$s" target="_blank" rel="noopener noreferrer">%2$s</a>',
+                                                            esc_url( $resource_url ),
+                                                            esc_html( $resource_label )
+                                                        );
+
+                                                        $resource_index++;
+                                                    endforeach;
+                                                    ?>
+                                                </p>
+                                            <?php endif; ?>
+                                        </div>
+                                    <?php endforeach; ?>
+                                </template>
+                            </li>
+                        <?php endforeach; ?>
+                    </ul>
+                    <p
+                        id="<?php echo esc_attr( $empty_message_id ); ?>"
+                        class="visibloc-guided-recipes__empty"
+                        data-visibloc-recipes-empty
+                        hidden
+                    >
+                        <?php esc_html_e( 'Aucune recette ne correspond au filtre sélectionné.', 'visi-bloc-jlg' ); ?>
+                    </p>
+                    <div class="visibloc-guided-recipes__dialog" data-visibloc-recipe-dialog hidden>
+                        <div class="visibloc-guided-recipes__dialog-backdrop" data-visibloc-recipe-close></div>
+                        <div
+                            class="visibloc-guided-recipes__dialog-window"
+                            role="dialog"
+                            aria-modal="true"
+                            aria-labelledby="<?php echo esc_attr( $dialog_title_id ); ?>"
+                            aria-describedby="<?php echo esc_attr( $dialog_description_id ); ?>"
+                            data-visibloc-recipe-dialog-window
+                        >
+                            <header class="visibloc-guided-recipes__dialog-header">
+                                <div class="visibloc-guided-recipes__dialog-heading">
+                                    <h3 id="<?php echo esc_attr( $dialog_title_id ); ?>" class="visibloc-guided-recipes__dialog-title" data-visibloc-recipe-dialog-title></h3>
+                                    <p id="<?php echo esc_attr( $dialog_description_id ); ?>" class="visibloc-guided-recipes__dialog-description" data-visibloc-recipe-dialog-description></p>
+                                </div>
+                                <button type="button" class="visibloc-guided-recipes__dialog-close" data-visibloc-recipe-close>
+                                    <span aria-hidden="true">&times;</span>
+                                    <span class="screen-reader-text"><?php esc_html_e( 'Fermer l’assistant', 'visi-bloc-jlg' ); ?></span>
+                                </button>
+                            </header>
+                            <div class="visibloc-guided-recipes__dialog-meta" data-visibloc-recipe-dialog-meta>
+                                <dl class="visibloc-guided-recipes__dialog-meta-grid">
+                                    <div class="visibloc-guided-recipes__dialog-meta-item">
+                                        <dt><?php esc_html_e( 'Objectif', 'visi-bloc-jlg' ); ?></dt>
+                                        <dd data-visibloc-recipe-meta="goal"></dd>
+                                    </div>
+                                    <div class="visibloc-guided-recipes__dialog-meta-item">
+                                        <dt><?php esc_html_e( 'Audience cible', 'visi-bloc-jlg' ); ?></dt>
+                                        <dd data-visibloc-recipe-meta="audience"></dd>
+                                    </div>
+                                    <div class="visibloc-guided-recipes__dialog-meta-item">
+                                        <dt><?php esc_html_e( 'Indicateur clé', 'visi-bloc-jlg' ); ?></dt>
+                                        <dd data-visibloc-recipe-meta="kpi"></dd>
+                                    </div>
+                                    <div class="visibloc-guided-recipes__dialog-meta-item">
+                                        <dt><?php esc_html_e( 'Durée estimée', 'visi-bloc-jlg' ); ?></dt>
+                                        <dd data-visibloc-recipe-meta="time"></dd>
+                                    </div>
+                                </dl>
+                                <div class="visibloc-guided-recipes__dialog-blocks" data-visibloc-recipe-dialog-blocks hidden>
+                                    <h4 class="visibloc-guided-recipes__dialog-blocks-title"><?php esc_html_e( 'Blocs recommandés', 'visi-bloc-jlg' ); ?></h4>
+                                    <ul class="visibloc-guided-recipes__dialog-blocks-list" data-visibloc-recipe-dialog-blocks-list></ul>
+                                </div>
+                            </div>
+                            <div class="visibloc-guided-recipes__dialog-progress" role="group" aria-label="<?php esc_attr_e( 'Progression de l’assistant', 'visi-bloc-jlg' ); ?>">
+                                <progress value="0" max="4" class="visibloc-guided-recipes__progress" data-visibloc-recipe-progress>
+                                    <?php esc_html_e( 'Progression de l’assistant', 'visi-bloc-jlg' ); ?>
+                                </progress>
+                                <span class="visibloc-guided-recipes__progress-label" data-visibloc-recipe-progress-label data-visibloc-progress-template="<?php echo esc_attr__( 'Étape %1$s sur %2$s', 'visi-bloc-jlg' ); ?>"></span>
+                            </div>
+                            <div class="visibloc-guided-recipes__dialog-body">
+                                <div class="visibloc-guided-recipes__stepper" data-visibloc-recipe-stepper>
+                                    <div class="visibloc-guided-recipes__stepper-tabs" role="tablist" aria-label="<?php esc_attr_e( 'Étapes de la recette', 'visi-bloc-jlg' ); ?>" data-visibloc-recipe-tabs></div>
+                                    <div class="visibloc-guided-recipes__stepper-panels" data-visibloc-recipe-panels></div>
+                                </div>
+                            </div>
+                            <div class="screen-reader-text" aria-live="polite" data-visibloc-recipe-step-live></div>
+                            <footer class="visibloc-guided-recipes__dialog-footer">
+                                <button type="button" class="button button-secondary" data-visibloc-recipe-prev>
+                                    <?php esc_html_e( 'Étape précédente', 'visi-bloc-jlg' ); ?>
+                                </button>
+                                <button
+                                    type="button"
+                                    class="button button-primary visibloc-guided-recipes__dialog-next"
+                                    data-visibloc-recipe-next
+                                    data-visibloc-label-next="<?php echo esc_attr__( 'Étape suivante', 'visi-bloc-jlg' ); ?>"
+                                    data-visibloc-label-finish="<?php echo esc_attr__( 'Terminer', 'visi-bloc-jlg' ); ?>"
+                                >
+                                    <?php esc_html_e( 'Étape suivante', 'visi-bloc-jlg' ); ?>
+                                </button>
+                            </footer>
+                        </div>
+                    </div>
+                <?php endif; ?>
+            </section>
         </div>
     </div>
     <?php

--- a/visi-bloc-jlg/includes/assets.php
+++ b/visi-bloc-jlg/includes/assets.php
@@ -447,6 +447,29 @@ function visibloc_jlg_enqueue_admin_navigation_script( $hook_suffix ) {
     );
 }
 
+add_action( 'admin_enqueue_scripts', 'visibloc_jlg_enqueue_admin_recipes_script' );
+function visibloc_jlg_enqueue_admin_recipes_script( $hook_suffix ) {
+    if ( 'toplevel_page_visi-bloc-jlg-help' !== $hook_suffix ) {
+        return;
+    }
+
+    $script_relative_path   = 'assets/admin-recipes.js';
+    $default_script_version = defined( 'VISIBLOC_JLG_VERSION' ) ? VISIBLOC_JLG_VERSION : '1.1';
+    $script_version         = visibloc_jlg_get_asset_version( $script_relative_path, $default_script_version );
+
+    wp_enqueue_script(
+        'visibloc-jlg-admin-recipes',
+        visibloc_jlg_get_asset_url( $script_relative_path ),
+        [ 'wp-dom-ready', 'wp-i18n' ],
+        $script_version,
+        true
+    );
+
+    if ( function_exists( 'wp_set_script_translations' ) ) {
+        wp_set_script_translations( 'visibloc-jlg-admin-recipes', 'visi-bloc-jlg' );
+    }
+}
+
 add_action( 'enqueue_block_editor_assets', 'visibloc_jlg_enqueue_editor_assets' );
 function visibloc_jlg_enqueue_editor_assets() {
     $asset_file_path = visibloc_jlg_get_asset_path( 'build/index.asset.php' );


### PR DESCRIPTION
## Summary
- add a guided recipe section with an accessible four-step assistant on the help page following the roadmap
- enqueue the new admin-recipes script and extend admin styles for the guided recipe components
- update the visual debug document with a static preview of the wizard for design reviews

## Testing
- php -l visi-bloc-jlg/includes/admin-settings.php

------
https://chatgpt.com/codex/tasks/task_e_68e579152630832ea0ec7c20aac76a11