### PR TITLE
Implement codified visual presets

### DIFF
--- a/visi-bloc-jlg/admin-styles.css
+++ b/visi-bloc-jlg/admin-styles.css
@@ -7,6 +7,7 @@
     --visibloc-radius-pill: 999px;
     --visibloc-shadow-subtle: 0 1px 2px rgba(15, 23, 42, 0.08);
     --visibloc-shadow-elevated: 0 18px 40px -24px rgba(15, 23, 42, 0.6);
+    --visibloc-font-family: var(--wp-admin-font-family, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
     --visibloc-accent: #4f46e5;
     --visibloc-accent-strong: #312e81;
     --visibloc-text-primary: #0f172a;
@@ -22,6 +23,7 @@
         --visibloc-border-strong: rgba(148, 163, 184, 0.35);
         --visibloc-shadow-subtle: 0 1px 2px rgba(15, 23, 42, 0.5);
         --visibloc-shadow-elevated: 0 28px 64px -30px rgba(2, 6, 23, 0.85);
+        --visibloc-font-family: var(--wp-admin-font-family, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
         --visibloc-text-primary: #f8fafc;
         --visibloc-text-subtle: rgba(226, 232, 240, 0.75);
         --visibloc-accent: #818cf8;
@@ -37,6 +39,7 @@ body.is-dark-theme {
     --visibloc-border-strong: rgba(148, 163, 184, 0.35);
     --visibloc-shadow-subtle: 0 1px 2px rgba(15, 23, 42, 0.5);
     --visibloc-shadow-elevated: 0 28px 64px -30px rgba(2, 6, 23, 0.85);
+    --visibloc-font-family: var(--wp-admin-font-family, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
     --visibloc-text-primary: #f8fafc;
     --visibloc-text-subtle: rgba(226, 232, 240, 0.75);
     --visibloc-accent: #818cf8;
@@ -303,7 +306,7 @@ body.is-dark-theme {
     background-clip: padding-box;
     color: var(--visibloc-badge-foreground);
     font-size: 12px;
-    font-family: var(--wp-admin-font-family, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
+    font-family: var(--visibloc-font-family, var(--wp-admin-font-family, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif));
     font-weight: 600;
     letter-spacing: 0.01em;
     line-height: 1.45;

--- a/visi-bloc-jlg/assets/presets/anime-kinetic.css
+++ b/visi-bloc-jlg/assets/presets/anime-kinetic.css
@@ -1,0 +1,118 @@
+/*!
+ * Anime Kinetic preset for Visi-Bloc – JLG
+ * Motion-forward preset inspired by Anime.js patterns.
+ */
+:root[data-visibloc-preset="anime-kinetic"],
+body[data-visibloc-preset="anime-kinetic"],
+.visibloc-preset--anime-kinetic {
+    --visibloc-font-family: "Plus Jakarta Sans", "Inter", system-ui, sans-serif;
+    --visibloc-surface: #0f172a;
+    --visibloc-surface-subtle: rgba(15, 23, 42, 0.94);
+    --visibloc-surface-tinted: rgba(30, 41, 59, 0.85);
+    --visibloc-border-subtle: rgba(56, 189, 248, 0.32);
+    --visibloc-border-strong: rgba(14, 165, 233, 0.48);
+    --visibloc-shadow-subtle: 0 18px 60px -50px rgba(14, 165, 233, 0.6);
+    --visibloc-shadow-elevated: 0 68px 160px -90px rgba(79, 70, 229, 0.65);
+    --visibloc-accent: #f97316;
+    --visibloc-accent-strong: #22d3ee;
+    --visibloc-focus-ring: 0 0 0 4px rgba(34, 211, 238, 0.5);
+    --visibloc-radius-base: 14px;
+    --visibloc-radius-pill: 999px;
+    --visibloc-text-primary: #f8fafc;
+    --visibloc-text-subtle: rgba(248, 250, 252, 0.7);
+    color-scheme: dark;
+}
+
+:root[data-visibloc-preset="anime-kinetic"].is-light-theme,
+body[data-visibloc-preset="anime-kinetic"].is-light-theme,
+.visibloc-preset--anime-kinetic.is-light-theme {
+    --visibloc-surface: #0f172a;
+}
+
+[data-visibloc-preset="anime-kinetic"] .visibloc-status-badge,
+.visibloc-preset--anime-kinetic .visibloc-status-badge {
+    border-radius: calc(var(--visibloc-radius-base) + 6px);
+    font-family: var(--visibloc-font-family);
+    background: linear-gradient(135deg, rgba(249, 115, 22, 0.9), rgba(59, 130, 246, 0.9));
+    color: #0b1120;
+    box-shadow: 0 22px 80px -52px rgba(15, 118, 110, 0.55);
+    animation: vbAnimePulse 3.6s ease-in-out infinite;
+}
+
+[data-visibloc-preset="anime-kinetic"] .visibloc-onboarding,
+.visibloc-preset--anime-kinetic .visibloc-onboarding {
+    background: radial-gradient(circle at 20% 20%, rgba(34, 211, 238, 0.18), transparent 55%),
+        radial-gradient(circle at 80% 0%, rgba(249, 115, 22, 0.18), transparent 50%),
+        rgba(15, 23, 42, 0.95);
+    border: 1px solid rgba(59, 130, 246, 0.28);
+    backdrop-filter: blur(16px);
+    overflow: hidden;
+    position: relative;
+}
+
+[data-visibloc-preset="anime-kinetic"] .visibloc-onboarding::after,
+.visibloc-preset--anime-kinetic .visibloc-onboarding::after {
+    content: "";
+    position: absolute;
+    inset: -40% -30% auto;
+    height: 200px;
+    background: linear-gradient(120deg, rgba(34, 211, 238, 0.45), rgba(129, 140, 248, 0.3));
+    filter: blur(40px);
+    opacity: 0.6;
+    animation: vbAnimeComet 6s ease-in-out infinite;
+    pointer-events: none;
+}
+
+[data-visibloc-preset="anime-kinetic"] .components-button.is-primary,
+.visibloc-preset--anime-kinetic .components-button.is-primary {
+    border-radius: var(--visibloc-radius-pill);
+    padding-inline: clamp(1.25rem, 2.2vw, 2.5rem);
+    min-height: 46px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    background-image: linear-gradient(135deg, #f97316, #22d3ee);
+    box-shadow: 0 28px 80px -48px rgba(15, 118, 110, 0.6);
+    transition: transform 150ms ease, box-shadow 150ms ease;
+}
+
+[data-visibloc-preset="anime-kinetic"] .components-button.is-primary:hover,
+.visibloc-preset--anime-kinetic .components-button.is-primary:hover {
+    transform: translateY(-2px) scale(1.01);
+    box-shadow: 0 32px 88px -46px rgba(14, 165, 233, 0.65);
+}
+
+[data-visibloc-preset="anime-kinetic"] .components-button.is-tertiary,
+.visibloc-preset--anime-kinetic .components-button.is-tertiary {
+    color: rgba(244, 114, 182, 0.92);
+}
+
+@keyframes vbAnimePulse {
+    0% {
+        transform: translateY(0) scale(1);
+        filter: saturate(0.9);
+    }
+    45% {
+        transform: translateY(-2px) scale(1.015);
+        filter: saturate(1.15);
+    }
+    100% {
+        transform: translateY(0) scale(1);
+        filter: saturate(0.9);
+    }
+}
+
+@keyframes vbAnimeComet {
+    0% {
+        transform: translate(-10%, -10%) rotate(0deg);
+        opacity: 0.5;
+    }
+    50% {
+        transform: translate(10%, 0) rotate(3deg);
+        opacity: 0.85;
+    }
+    100% {
+        transform: translate(-12%, -6%) rotate(-2deg);
+        opacity: 0.5;
+    }
+}

--- a/visi-bloc-jlg/assets/presets/bootstrap-express.css
+++ b/visi-bloc-jlg/assets/presets/bootstrap-express.css
@@ -1,0 +1,77 @@
+/*!
+ * Bootstrap Express preset for Visi-Bloc – JLG
+ * Classic Bootstrap-inspired colors and rounded controls.
+ */
+:root[data-visibloc-preset="bootstrap-express"],
+body[data-visibloc-preset="bootstrap-express"],
+.visibloc-preset--bootstrap-express {
+    --visibloc-font-family: "Helvetica Neue", Arial, sans-serif;
+    --visibloc-surface: #ffffff;
+    --visibloc-surface-subtle: #f8f9fa;
+    --visibloc-surface-tinted: #eef2ff;
+    --visibloc-border-subtle: rgba(13, 110, 253, 0.12);
+    --visibloc-border-strong: rgba(13, 110, 253, 0.28);
+    --visibloc-shadow-subtle: 0 10px 30px -22px rgba(13, 110, 253, 0.4);
+    --visibloc-shadow-elevated: 0 38px 90px -60px rgba(13, 110, 253, 0.35);
+    --visibloc-accent: #0d6efd;
+    --visibloc-accent-strong: #0b5ed7;
+    --visibloc-focus-ring: 0 0 0 4px rgba(13, 110, 253, 0.32);
+    --visibloc-radius-base: 12px;
+    --visibloc-radius-pill: 50rem;
+    --visibloc-text-primary: #052c65;
+    --visibloc-text-subtle: rgba(5, 44, 101, 0.72);
+}
+
+:root[data-visibloc-preset="bootstrap-express"].is-dark-theme,
+body.is-dark-theme[data-visibloc-preset="bootstrap-express"],
+.visibloc-preset--bootstrap-express.is-dark-theme {
+    --visibloc-surface: rgba(18, 25, 42, 0.9);
+    --visibloc-surface-subtle: rgba(22, 31, 51, 0.82);
+    --visibloc-border-subtle: rgba(96, 165, 250, 0.22);
+    --visibloc-border-strong: rgba(96, 165, 250, 0.32);
+    --visibloc-shadow-subtle: 0 14px 36px -28px rgba(2, 6, 23, 0.68);
+    --visibloc-shadow-elevated: 0 52px 130px -70px rgba(2, 6, 23, 0.75);
+    --visibloc-accent: #4ea8ff;
+    --visibloc-accent-strong: #7cc1ff;
+    --visibloc-focus-ring: 0 0 0 4px rgba(78, 168, 255, 0.35);
+    --visibloc-text-primary: #f8f9fa;
+    --visibloc-text-subtle: rgba(226, 232, 240, 0.72);
+}
+
+[data-visibloc-preset="bootstrap-express"] .visibloc-onboarding,
+.visibloc-preset--bootstrap-express .visibloc-onboarding {
+    border: 1px solid rgba(13, 110, 253, 0.18);
+    border-radius: calc(var(--visibloc-radius-base) + 4px);
+    box-shadow: 0 24px 70px -52px rgba(13, 110, 253, 0.45);
+}
+
+[data-visibloc-preset="bootstrap-express"] .components-button.is-primary,
+.visibloc-preset--bootstrap-express .components-button.is-primary {
+    border-radius: var(--visibloc-radius-pill);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    padding-inline: 22px;
+    min-height: 44px;
+    box-shadow: 0 16px 36px -24px rgba(13, 110, 253, 0.45);
+}
+
+[data-visibloc-preset="bootstrap-express"] .components-button.is-secondary,
+.visibloc-preset--bootstrap-express .components-button.is-secondary {
+    border-radius: var(--visibloc-radius-pill);
+    border-width: 2px;
+}
+
+[data-visibloc-preset="bootstrap-express"] .visibloc-status-badge,
+.visibloc-preset--bootstrap-express .visibloc-status-badge {
+    border-radius: calc(var(--visibloc-radius-base) + 4px);
+    font-family: var(--visibloc-font-family);
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.95), rgba(13, 110, 253, 0.14));
+    box-shadow: 0 18px 60px -45px rgba(13, 110, 253, 0.55);
+}
+
+[data-visibloc-preset="bootstrap-express"] .components-panel,
+.visibloc-preset--bootstrap-express .components-panel {
+    border-radius: var(--visibloc-radius-base);
+    overflow: hidden;
+}

--- a/visi-bloc-jlg/assets/presets/headless-fluent.css
+++ b/visi-bloc-jlg/assets/presets/headless-fluent.css
@@ -1,0 +1,83 @@
+/*!
+ * Headless Fluent preset for Visi-Bloc – JLG
+ * Inspired by Headless UI design tokens.
+ */
+:root[data-visibloc-preset="headless-fluent"],
+body[data-visibloc-preset="headless-fluent"],
+.visibloc-preset--headless-fluent {
+    --visibloc-font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    --visibloc-surface: #ffffff;
+    --visibloc-surface-subtle: #f1f5f9;
+    --visibloc-surface-tinted: #f8fafc;
+    --visibloc-border-subtle: rgba(15, 23, 42, 0.06);
+    --visibloc-border-strong: rgba(15, 23, 42, 0.16);
+    --visibloc-shadow-subtle: 0 10px 24px -22px rgba(15, 23, 42, 0.45);
+    --visibloc-shadow-elevated: 0 40px 80px -48px rgba(15, 23, 42, 0.35);
+    --visibloc-accent: #2563eb;
+    --visibloc-accent-strong: #1d4ed8;
+    --visibloc-focus-ring: 0 0 0 3px rgba(37, 99, 235, 0.28);
+    --visibloc-radius-base: 8px;
+    --visibloc-radius-pill: 999px;
+    --visibloc-text-primary: #0f172a;
+    --visibloc-text-subtle: rgba(15, 23, 42, 0.65);
+}
+
+:root[data-visibloc-preset="headless-fluent"].is-dark-theme,
+body.is-dark-theme[data-visibloc-preset="headless-fluent"],
+.visibloc-preset--headless-fluent.is-dark-theme {
+    --visibloc-surface: rgba(15, 23, 42, 0.8);
+    --visibloc-surface-subtle: rgba(30, 41, 59, 0.72);
+    --visibloc-border-subtle: rgba(148, 163, 184, 0.2);
+    --visibloc-border-strong: rgba(148, 163, 184, 0.3);
+    --visibloc-shadow-subtle: 0 12px 28px -20px rgba(2, 6, 23, 0.65);
+    --visibloc-shadow-elevated: 0 48px 120px -60px rgba(2, 6, 23, 0.75);
+    --visibloc-text-primary: #f8fafc;
+    --visibloc-text-subtle: rgba(226, 232, 240, 0.78);
+    --visibloc-accent: #60a5fa;
+    --visibloc-accent-strong: #bfdbfe;
+    --visibloc-focus-ring: 0 0 0 3px rgba(96, 165, 250, 0.32);
+}
+
+[data-visibloc-preset="headless-fluent"] .visibloc-status-badge,
+.visibloc-preset--headless-fluent .visibloc-status-badge {
+    border-radius: calc(var(--visibloc-radius-base) + 2px);
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(241, 245, 249, 0.8));
+    box-shadow: 0 8px 26px -18px rgba(37, 99, 235, 0.35);
+    font-family: var(--visibloc-font-family);
+    transition: transform 150ms ease, box-shadow 150ms ease;
+}
+
+[data-visibloc-preset="headless-fluent"] .visibloc-status-badge:hover,
+.visibloc-preset--headless-fluent .visibloc-status-badge:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 18px 36px -20px rgba(37, 99, 235, 0.35);
+}
+
+[data-visibloc-preset="headless-fluent"] .visibloc-onboarding,
+.visibloc-preset--headless-fluent .visibloc-onboarding {
+    backdrop-filter: blur(12px);
+    transition: box-shadow 180ms ease;
+}
+
+[data-visibloc-preset="headless-fluent"] .visibloc-onboarding:hover,
+.visibloc-preset--headless-fluent .visibloc-onboarding:hover {
+    box-shadow: 0 35px 80px -60px rgba(15, 23, 42, 0.42);
+}
+
+[data-visibloc-preset="headless-fluent"] .components-button.is-primary,
+.visibloc-preset--headless-fluent .components-button.is-primary {
+    border-radius: calc(var(--visibloc-radius-base) + 4px);
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    transition: background-color 140ms ease, transform 140ms ease, box-shadow 140ms ease;
+}
+
+[data-visibloc-preset="headless-fluent"] .components-button.is-primary:focus-visible,
+.visibloc-preset--headless-fluent .components-button.is-primary:focus-visible {
+    box-shadow: var(--visibloc-focus-ring);
+}
+
+[data-visibloc-preset="headless-fluent"] .components-button.is-primary:hover,
+.visibloc-preset--headless-fluent .components-button.is-primary:hover {
+    transform: translateY(-1px);
+}

--- a/visi-bloc-jlg/assets/presets/radix-structured.css
+++ b/visi-bloc-jlg/assets/presets/radix-structured.css
@@ -1,0 +1,86 @@
+/*!
+ * Radix Structured preset for Visi-Bloc – JLG
+ * Inspired by Radix UI primitives with clear elevations.
+ */
+:root[data-visibloc-preset="radix-structured"],
+body[data-visibloc-preset="radix-structured"],
+.visibloc-preset--radix-structured {
+    --visibloc-font-family: "IBM Plex Sans", "Inter", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+    --visibloc-surface: #f9f8ff;
+    --visibloc-surface-subtle: #f4f1ff;
+    --visibloc-surface-tinted: #edebff;
+    --visibloc-border-subtle: rgba(76, 29, 149, 0.12);
+    --visibloc-border-strong: rgba(76, 29, 149, 0.28);
+    --visibloc-shadow-subtle: 0 18px 46px -38px rgba(58, 27, 126, 0.45);
+    --visibloc-shadow-elevated: 0 42px 120px -64px rgba(58, 27, 126, 0.5);
+    --visibloc-accent: #6d28d9;
+    --visibloc-accent-strong: #4c1d95;
+    --visibloc-focus-ring: 0 0 0 3px rgba(109, 40, 217, 0.35);
+    --visibloc-radius-tight: 4px;
+    --visibloc-radius-base: 10px;
+    --visibloc-radius-loose: 16px;
+    --visibloc-radius-pill: 999px;
+    --visibloc-text-primary: #1e1b4b;
+    --visibloc-text-subtle: rgba(30, 27, 75, 0.68);
+}
+
+:root[data-visibloc-preset="radix-structured"].is-dark-theme,
+body.is-dark-theme[data-visibloc-preset="radix-structured"],
+.visibloc-preset--radix-structured.is-dark-theme {
+    --visibloc-surface: rgba(26, 24, 60, 0.92);
+    --visibloc-surface-subtle: rgba(36, 30, 80, 0.86);
+    --visibloc-border-subtle: rgba(196, 181, 253, 0.22);
+    --visibloc-border-strong: rgba(196, 181, 253, 0.32);
+    --visibloc-shadow-subtle: 0 20px 48px -36px rgba(13, 9, 40, 0.7);
+    --visibloc-shadow-elevated: 0 58px 140px -70px rgba(13, 9, 40, 0.78);
+    --visibloc-accent: #c4b5fd;
+    --visibloc-accent-strong: #a78bfa;
+    --visibloc-focus-ring: 0 0 0 3px rgba(167, 139, 250, 0.35);
+    --visibloc-text-primary: #f3f4ff;
+    --visibloc-text-subtle: rgba(226, 232, 240, 0.74);
+}
+
+[data-visibloc-preset="radix-structured"] .visibloc-guided-recipes__card,
+.visibloc-preset--radix-structured .visibloc-guided-recipes__card {
+    border-radius: var(--visibloc-radius-loose);
+    border: 1px solid var(--visibloc-border-subtle);
+    box-shadow: 0 20px 60px -50px rgba(109, 40, 217, 0.5);
+    transition: border-color 120ms ease, box-shadow 160ms ease;
+}
+
+[data-visibloc-preset="radix-structured"] .visibloc-guided-recipes__card:focus-within,
+.visibloc-preset--radix-structured .visibloc-guided-recipes__card:focus-within {
+    border-color: rgba(109, 40, 217, 0.55);
+    box-shadow: 0 30px 80px -60px rgba(109, 40, 217, 0.45);
+}
+
+[data-visibloc-preset="radix-structured"] .visibloc-status-badge,
+.visibloc-preset--radix-structured .visibloc-status-badge {
+    border-radius: var(--visibloc-radius-loose);
+    font-family: var(--visibloc-font-family);
+    text-transform: none;
+    letter-spacing: 0.01em;
+    box-shadow: 0 14px 40px -32px rgba(109, 40, 217, 0.32);
+}
+
+[data-visibloc-preset="radix-structured"] .components-toggle-group-control,
+.visibloc-preset--radix-structured .components-toggle-group-control {
+    border-radius: var(--visibloc-radius-base);
+    padding: 6px;
+    gap: 4px;
+    background: rgba(109, 40, 217, 0.08);
+}
+
+[data-visibloc-preset="radix-structured"] .components-button.is-primary,
+.visibloc-preset--radix-structured .components-button.is-primary {
+    border-radius: var(--visibloc-radius-pill);
+    padding-inline: 22px;
+    min-height: 42px;
+    font-weight: 600;
+    box-shadow: 0 16px 40px -28px rgba(109, 40, 217, 0.55);
+}
+
+[data-visibloc-preset="radix-structured"] .components-button.is-primary:hover,
+.visibloc-preset--radix-structured .components-button.is-primary:hover {
+    box-shadow: 0 28px 70px -36px rgba(109, 40, 217, 0.55);
+}

--- a/visi-bloc-jlg/assets/presets/semantic-harmony.css
+++ b/visi-bloc-jlg/assets/presets/semantic-harmony.css
@@ -1,0 +1,71 @@
+/*!
+ * Semantic Harmony preset for Visi-Bloc – JLG
+ * Expressive palette inspired by Semantic UI.
+ */
+:root[data-visibloc-preset="semantic-harmony"],
+body[data-visibloc-preset="semantic-harmony"],
+.visibloc-preset--semantic-harmony {
+    --visibloc-font-family: "Lato", "Helvetica Neue", Arial, sans-serif;
+    --visibloc-surface: hsl(0 0% 100%);
+    --visibloc-surface-subtle: hsl(210 40% 96%);
+    --visibloc-surface-tinted: hsl(205 78% 96%);
+    --visibloc-border-subtle: hsla(205, 60%, 40%, 0.18);
+    --visibloc-border-strong: hsla(205, 70%, 38%, 0.32);
+    --visibloc-shadow-subtle: 0 18px 52px -44px hsla(205, 70%, 32%, 0.55);
+    --visibloc-shadow-elevated: 0 54px 140px -72px hsla(205, 70%, 32%, 0.5);
+    --visibloc-accent: hsl(205 80% 45%);
+    --visibloc-accent-strong: hsl(205 85% 34%);
+    --visibloc-focus-ring: 0 0 0 3px hsla(205, 80%, 45%, 0.4);
+    --visibloc-radius-base: 10px;
+    --visibloc-radius-pill: 999px;
+    --visibloc-text-primary: hsl(215 34% 21%);
+    --visibloc-text-subtle: hsla(215, 32%, 21%, 0.7);
+}
+
+:root[data-visibloc-preset="semantic-harmony"].is-dark-theme,
+body.is-dark-theme[data-visibloc-preset="semantic-harmony"],
+.visibloc-preset--semantic-harmony.is-dark-theme {
+    --visibloc-surface: hsla(212, 32%, 18%, 0.9);
+    --visibloc-surface-subtle: hsla(210, 38%, 22%, 0.82);
+    --visibloc-border-subtle: hsla(205, 68%, 72%, 0.28);
+    --visibloc-border-strong: hsla(205, 70%, 62%, 0.35);
+    --visibloc-shadow-subtle: 0 20px 60px -52px hsla(205, 80%, 30%, 0.6);
+    --visibloc-shadow-elevated: 0 58px 150px -80px hsla(205, 80%, 30%, 0.58);
+    --visibloc-accent: hsla(205, 88%, 68%, 0.95);
+    --visibloc-accent-strong: hsla(205, 86%, 60%, 0.95);
+    --visibloc-focus-ring: 0 0 0 3px hsla(205, 85%, 66%, 0.5);
+    --visibloc-text-primary: hsl(210 40% 96%);
+    --visibloc-text-subtle: hsla(210, 38%, 80%, 0.8);
+}
+
+[data-visibloc-preset="semantic-harmony"] .visibloc-status-badge,
+.visibloc-preset--semantic-harmony .visibloc-status-badge {
+    border-radius: calc(var(--visibloc-radius-base) + 6px);
+    font-family: var(--visibloc-font-family);
+    background: linear-gradient(180deg, hsla(205, 80%, 94%, 0.95), hsla(205, 78%, 88%, 0.85));
+    box-shadow: 0 18px 58px -48px hsla(205, 76%, 35%, 0.55);
+}
+
+[data-visibloc-preset="semantic-harmony"] .visibloc-guided-recipes__card,
+.visibloc-preset--semantic-harmony .visibloc-guided-recipes__card {
+    border-radius: calc(var(--visibloc-radius-base) + 8px);
+    border: 1px solid hsla(205, 72%, 45%, 0.28);
+    background: radial-gradient(circle at top left, hsla(205, 90%, 97%, 0.9), hsla(210, 38%, 96%, 0.85));
+    box-shadow: 0 40px 120px -70px hsla(205, 78%, 35%, 0.45);
+}
+
+[data-visibloc-preset="semantic-harmony"] .visibloc-guided-recipes__badge,
+.visibloc-preset--semantic-harmony .visibloc-guided-recipes__badge {
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    font-weight: 700;
+}
+
+[data-visibloc-preset="semantic-harmony"] .components-button.is-primary,
+.visibloc-preset--semantic-harmony .components-button.is-primary {
+    border-radius: calc(var(--visibloc-radius-base) + 4px);
+    padding-inline: 20px;
+    min-height: 44px;
+    font-weight: 700;
+    box-shadow: 0 18px 60px -42px hsla(205, 80%, 35%, 0.55);
+}

--- a/visi-bloc-jlg/assets/presets/shadcn-minimal.css
+++ b/visi-bloc-jlg/assets/presets/shadcn-minimal.css
@@ -1,0 +1,96 @@
+/*!
+ * Shadcn Minimal preset for Visi-Bloc – JLG
+ * Inspired by shadcn/ui typography and restrained surfaces.
+ */
+:root[data-visibloc-preset="shadcn-minimal"],
+body[data-visibloc-preset="shadcn-minimal"],
+.visibloc-preset--shadcn-minimal {
+    --visibloc-font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+    --visibloc-surface: #ffffff;
+    --visibloc-surface-subtle: #f9fafb;
+    --visibloc-surface-tinted: #f4f4f5;
+    --visibloc-border-subtle: rgba(17, 24, 39, 0.08);
+    --visibloc-border-strong: rgba(17, 24, 39, 0.16);
+    --visibloc-shadow-subtle: 0 12px 26px -24px rgba(17, 24, 39, 0.35);
+    --visibloc-shadow-elevated: 0 30px 70px -45px rgba(17, 24, 39, 0.4);
+    --visibloc-accent: #111827;
+    --visibloc-accent-strong: #0b1120;
+    --visibloc-focus-ring: 0 0 0 3px rgba(17, 24, 39, 0.45);
+    --visibloc-radius-base: 10px;
+    --visibloc-radius-pill: 999px;
+    --visibloc-text-primary: #111827;
+    --visibloc-text-subtle: rgba(17, 24, 39, 0.66);
+}
+
+:root[data-visibloc-preset="shadcn-minimal"].is-dark-theme,
+body.is-dark-theme[data-visibloc-preset="shadcn-minimal"],
+.visibloc-preset--shadcn-minimal.is-dark-theme {
+    --visibloc-surface: rgba(15, 23, 42, 0.85);
+    --visibloc-surface-subtle: rgba(31, 41, 55, 0.78);
+    --visibloc-border-subtle: rgba(148, 163, 184, 0.25);
+    --visibloc-border-strong: rgba(148, 163, 184, 0.35);
+    --visibloc-shadow-subtle: 0 14px 36px -26px rgba(2, 6, 23, 0.72);
+    --visibloc-shadow-elevated: 0 50px 110px -60px rgba(2, 6, 23, 0.82);
+    --visibloc-accent: #f8fafc;
+    --visibloc-accent-strong: #cbd5f5;
+    --visibloc-focus-ring: 0 0 0 3px rgba(226, 232, 240, 0.4);
+    --visibloc-text-primary: #f8fafc;
+    --visibloc-text-subtle: rgba(226, 232, 240, 0.7);
+}
+
+[data-visibloc-preset="shadcn-minimal"] .visibloc-onboarding,
+.visibloc-preset--shadcn-minimal .visibloc-onboarding {
+    border-width: 2px;
+    border-style: solid;
+    border-color: var(--visibloc-border-subtle);
+    padding: 28px;
+    gap: 18px;
+    font-family: var(--visibloc-font-family);
+}
+
+[data-visibloc-preset="shadcn-minimal"] .visibloc-onboarding__title,
+.visibloc-preset--shadcn-minimal .visibloc-onboarding__title {
+    font-weight: 600;
+    letter-spacing: -0.015em;
+}
+
+[data-visibloc-preset="shadcn-minimal"] .visibloc-guided-recipes__card,
+.visibloc-preset--shadcn-minimal .visibloc-guided-recipes__card {
+    border-radius: calc(var(--visibloc-radius-base) + 6px);
+    border: 1px solid rgba(17, 24, 39, 0.08);
+    box-shadow: 0 18px 46px -42px rgba(17, 24, 39, 0.65);
+    transition: transform 180ms ease, box-shadow 180ms ease;
+}
+
+[data-visibloc-preset="shadcn-minimal"] .visibloc-guided-recipes__card:hover,
+.visibloc-preset--shadcn-minimal .visibloc-guided-recipes__card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 48px 120px -80px rgba(17, 24, 39, 0.6);
+}
+
+[data-visibloc-preset="shadcn-minimal"] .components-badge,
+.visibloc-preset--shadcn-minimal .components-badge {
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    font-weight: 500;
+}
+
+[data-visibloc-preset="shadcn-minimal"] .components-button.is-primary,
+.visibloc-preset--shadcn-minimal .components-button.is-primary {
+    border-radius: calc(var(--visibloc-radius-base) + 2px);
+    padding-inline: 18px;
+    min-height: 40px;
+    box-shadow: none;
+    transition: background-color 120ms ease, color 120ms ease, opacity 120ms ease;
+}
+
+[data-visibloc-preset="shadcn-minimal"] .components-button.is-secondary,
+.visibloc-preset--shadcn-minimal .components-button.is-secondary {
+    border-radius: calc(var(--visibloc-radius-base) + 2px);
+}
+
+[data-visibloc-preset="shadcn-minimal"] .components-input-control__input,
+.visibloc-preset--shadcn-minimal .components-input-control__input {
+    border-radius: calc(var(--visibloc-radius-base) + 4px);
+    font-variant-numeric: tabular-nums;
+}

--- a/visi-bloc-jlg/docs/presets-graphiques.md
+++ b/visi-bloc-jlg/docs/presets-graphiques.md
@@ -1,0 +1,54 @@
+# Presets graphiques proposés pour Visibloc
+
+Ce document présente plusieurs presets graphiques prêts à l'emploi pour accélérer la conception d'interfaces autour du plugin Visi-Bloc – JLG. Chaque preset dispose désormais d’un fichier CSS chargeable à la demande dans `assets/presets/`. Les styles sont exposés via des attributs `data-visibloc-preset` et des classes utilitaires (`visibloc-preset--slug`) utilisables sur l’interface Gutenberg et dans l’administration.
+
+Chaque preset reprend les codes visuels et les interactions de bibliothèques populaires comme Headless UI, shadcn/ui, Radix UI, Bootstrap, Semantic UI et Anime.js, tout en indiquant comment décliner ces inspirations dans l'écosystème WordPress/Gutenberg.
+
+## 1. Preset « Headless Fluent » (inspiré de Headless UI)
+- **Philosophie** : composants sans styles imposés, basés sur l'accessibilité, personnalisables via Tailwind ou tokens internes.
+- **Tokens suggérés** : palette neutre (`slate-50` à `slate-900`), accent principal `#2563EB`, radius `8px`, ombres légères (`shadow-md`).
+- **Composants clés** : Dialog, Popover, Tabs et Combobox s'appuyant sur les hooks d'état WordPress (`@wordpress/data`).
+- **Interactions** : transitions discrètes (`transition ease-out duration-150`), focus states visibles (`outline-2 outline-offset-2`).
+- **Intégration Gutenberg** : utiliser `@wordpress/components` pour les primitives (Button, TextControl) en surcouchant les classes Tailwind injectées via `postcss-preset-env`.
+
+## 2. Preset « Shadcn Minimal » (inspiré de shadcn/ui)
+- **Philosophie** : design system minimaliste basé sur Radix primitives + Tailwind, avec une hiérarchie typographique affirmée.
+- **Tokens suggérés** : typographie `"Inter"`, scale `--font-size-xs` à `--font-size-4xl`, couleurs `--primary: #111827`, `--primary-foreground: #F9FAFB`, `--muted: #E5E7EB`.
+- **Composants clés** : Command Palette (`Cmd+K`), Sheet latéral pour les paramètres avancés, Badge de statut pour les règles.
+- **Interactions** : micro-animations sur hover (`scale-102`, `bg-muted/60`), skeleton loaders pour les panneaux lourds.
+- **Intégration Gutenberg** : générer les classes utilitaires dans `assets/scss/_tokens.scss` et fournir un preset de couleurs dans `theme.json` pour harmoniser l'éditeur.
+
+## 3. Preset « Radix Structured » (inspiré de Radix UI)
+- **Philosophie** : composants modulaires, orientés accessibilité, avec un focus sur les états contrôlés/non contrôlés.
+- **Tokens suggérés** : palette `Radix Gray` + `Radix Violet`, radius progressifs (`4px`, `6px`, `8px`), spacing basé sur l'échelle 4 (`4px`, `8px`, `12px`, `16px`).
+- **Composants clés** : Slider pour les fenêtres temporelles, Collapsible pour les règles avancées, Toast de feedback système.
+- **Interactions** : animations `@radix-ui/react-toast` adaptées en CSS via `@keyframes slideIn`, `fadeOut`.
+- **Intégration Gutenberg** : encapsuler les primitives dans des composants React (`packages/components`) et distribuer une feuille CSS générée via CSS Modules pour éviter les collisions.
+
+## 4. Preset « Bootstrap Express »
+- **Philosophie** : adoption rapide, repères visuels classiques, forte lisibilité sur bureau et mobile.
+- **Tokens suggérés** : palette `Primary #0D6EFD`, `Success #198754`, `Warning #FFC107`, `Danger #DC3545`; typographie `"Helvetica Neue", Arial, sans-serif`; radius `0.375rem`.
+- **Composants clés** : Navbar secondaire pour les onglets d'options, Accordions pour les groupes de règles, Alerts pour les conflits détectés.
+- **Interactions** : transitions CSS standard (`transition: all .2s ease-in-out`), `box-shadow` accentué sur les modals.
+- **Intégration Gutenberg** : importer uniquement les modules SCSS nécessaires (`buttons`, `forms`, `utilities`) via `sass-loader` afin de limiter le poids, et mapper les variables Bootstrap avec celles du Customizer.
+
+## 5. Preset « Semantic Harmony » (inspiré de Semantic UI)
+- **Philosophie** : interface expressive, labels descriptifs, thèmes déclinables via variables CSS.
+- **Tokens suggérés** : `--brand-hue: 205`, `--brand-saturation: 80%`, `--brand-lightness: 45%`; typographie `"Lato"`; `border-radius: 0.28571429rem`.
+- **Composants clés** : Steps pour l'onboarding, Cards empilées pour visualiser les scénarios, Dropdown multi-sélection pour les segments.
+- **Interactions** : `box-shadow` dynamique (`0 2px 8px rgba(34,36,38,0.12)`), animations `slide down` sur les menus contextuels.
+- **Intégration Gutenberg** : définir des mixins Sass pour générer les variations (positive, negative, info) et exposer un JSON de thème chargeable depuis l'administration.
+
+## 6. Preset « Anime Kinetic » (inspiré d'Anime.js)
+- **Philosophie** : expérience dynamique axée sur les transitions et animations scénarisées.
+- **Tokens suggérés** : couleurs saturées (`#F97316`, `#10B981`, `#3B82F6`), gradients linéaires, usage de `clamp()` pour la typographie responsive.
+- **Composants clés** : Timeline visuelle des règles programmées, indicateurs pulsés pour les alertes, loaders illustrés.
+- **Interactions** : animations orchestrées via Anime.js (`targets: '.vb-rule-card'`, `translateY`, `opacity`, `stagger`), déclenchement conditionnel lors de l'apparition (`IntersectionObserver`).
+- **Intégration Gutenberg** : charger Anime.js uniquement sur les écrans d'administration concernés, fournir des hooks React (`useAnimeTimeline`) et documenter les préférences de réduction de mouvement (`prefers-reduced-motion`).
+
+## Recommandations transverses
+- **Accessibilité** : chaque preset doit conserver un contraste AA/AAA, gérer les focus states, respecter les rôles ARIA et offrir un mode réduit de mouvement.
+- **Thématisation** : exposer les tokens via des variables CSS (`:root { --vb-color-primary: ... }`) et permettre leur surcharge depuis le Customizer ou `theme.json`.
+- **Performance** : livrer les CSS via `assets/build/presets/{preset}.css` chargés à la demande et regrouper les scripts optionnels (Anime.js) sous forme de chunks dynamiques.
+- **Documentation** : ajouter une section par preset dans le guide d'onboarding, avec captures d'écran, exemples de blocs et snippets de configuration.
+

--- a/visi-bloc-jlg/includes/assets.php
+++ b/visi-bloc-jlg/includes/assets.php
@@ -9,6 +9,7 @@ require_once __DIR__ . '/plugin-meta.php';
 require_once __DIR__ . '/cache-constants.php';
 require_once __DIR__ . '/datetime-utils.php';
 require_once __DIR__ . '/fallback.php';
+require_once __DIR__ . '/presets.php';
 
 if ( ! function_exists( 'visibloc_jlg_path_join' ) ) {
     /**
@@ -348,6 +349,7 @@ function visibloc_jlg_clear_editor_data_cache( $slugs = null ) {
 
 add_action( 'wp_enqueue_scripts', 'visibloc_jlg_enqueue_public_styles' );
 function visibloc_jlg_enqueue_public_styles() {
+    visibloc_jlg_register_visual_preset_styles();
     $can_preview    = visibloc_jlg_can_user_preview();
     $default_mobile = 781;
     $default_tablet = 1024;
@@ -398,6 +400,8 @@ function visibloc_jlg_enqueue_admin_styles( $hook_suffix ) {
     if ( 'toplevel_page_visi-bloc-jlg-help' !== $hook_suffix ) {
         return;
     }
+
+    visibloc_jlg_register_visual_preset_styles();
 
     $style_version    = defined( 'VISIBLOC_JLG_VERSION' ) ? VISIBLOC_JLG_VERSION : '1.1';
 
@@ -480,6 +484,7 @@ function visibloc_jlg_enqueue_editor_assets() {
     }
 
     visibloc_jlg_clear_missing_editor_assets_flag();
+    visibloc_jlg_register_visual_preset_styles();
     $asset_file = include( $asset_file_path );
     wp_enqueue_script(
         'visibloc-jlg-editor-script',
@@ -518,6 +523,7 @@ function visibloc_jlg_enqueue_editor_assets() {
             'commonCookies'     => visibloc_jlg_get_editor_common_cookies(),
             'fallbackSettings' => visibloc_jlg_get_editor_fallback_settings(),
             'fallbackBlocks'   => visibloc_jlg_get_editor_fallback_blocks(),
+            'visualPresets'    => visibloc_jlg_get_editor_visual_presets(),
         ]
     );
 }

--- a/visi-bloc-jlg/includes/presets.php
+++ b/visi-bloc-jlg/includes/presets.php
@@ -1,0 +1,286 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+if ( ! function_exists( 'visibloc_jlg_get_visual_presets_definitions' ) ) {
+    /**
+     * Return the curated list of visual presets available for the UI.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    function visibloc_jlg_get_visual_presets_definitions() {
+        static $presets = null;
+
+        if ( null !== $presets ) {
+            return $presets;
+        }
+
+        $default_version = defined( 'VISIBLOC_JLG_VERSION' ) ? VISIBLOC_JLG_VERSION : '1.1';
+        $base_dir        = 'assets/presets';
+
+        $definitions = [
+            'headless-fluent' => [
+                'label'        => __( 'Headless Fluent', 'visi-bloc-jlg' ),
+                'description'  => __( 'Composants fluides et accessibles inspirés de Headless UI avec un accent bleu électrique.', 'visi-bloc-jlg' ),
+                'inspiration'  => 'Headless UI',
+                'components'   => [
+                    __( 'Dialogues et popovers discrets', 'visi-bloc-jlg' ),
+                    __( 'Panneaux contextuels à transitions courtes', 'visi-bloc-jlg' ),
+                    __( 'Boutons primaires très contrastés', 'visi-bloc-jlg' ),
+                ],
+                'interactions' => [
+                    __( 'Animations ease-out rapides (150 ms)', 'visi-bloc-jlg' ),
+                    __( 'Focus visible renforcé', 'visi-bloc-jlg' ),
+                ],
+                'tokens'       => [
+                    'surface'        => '#ffffff',
+                    'surfaceSubtle'  => '#f1f5f9',
+                    'borderSubtle'   => 'rgba(15, 23, 42, 0.06)',
+                    'borderStrong'   => 'rgba(15, 23, 42, 0.16)',
+                    'accent'         => '#2563eb',
+                    'accentStrong'   => '#1d4ed8',
+                    'shadowSubtle'   => '0 10px 24px -22px rgba(15, 23, 42, 0.45)',
+                    'shadowElevated' => '0 40px 80px -48px rgba(15, 23, 42, 0.35)',
+                    'radiusBase'     => '8px',
+                    'fontFamily'     => 'Inter',
+                ],
+                'class_name'   => 'visibloc-preset--headless-fluent',
+                'file'         => 'headless-fluent.css',
+            ],
+            'shadcn-minimal' => [
+                'label'        => __( 'Shadcn Minimal', 'visi-bloc-jlg' ),
+                'description'  => __( 'Preset typographique minimaliste inspiré de shadcn/ui, idéal pour les réglages sobrement hiérarchisés.', 'visi-bloc-jlg' ),
+                'inspiration'  => 'shadcn/ui',
+                'components'   => [
+                    __( 'Cartes avec bordure double', 'visi-bloc-jlg' ),
+                    __( 'Boutons minimalistes à coins doux', 'visi-bloc-jlg' ),
+                    __( 'Champs de formulaire tabulaires', 'visi-bloc-jlg' ),
+                ],
+                'interactions' => [
+                    __( 'Ombrages doux et progressifs', 'visi-bloc-jlg' ),
+                    __( 'Hover subtil sur les cartes', 'visi-bloc-jlg' ),
+                ],
+                'tokens'       => [
+                    'surface'        => '#ffffff',
+                    'surfaceSubtle'  => '#f9fafb',
+                    'borderSubtle'   => 'rgba(17, 24, 39, 0.08)',
+                    'borderStrong'   => 'rgba(17, 24, 39, 0.16)',
+                    'accent'         => '#111827',
+                    'accentStrong'   => '#0b1120',
+                    'shadowSubtle'   => '0 12px 26px -24px rgba(17, 24, 39, 0.35)',
+                    'shadowElevated' => '0 30px 70px -45px rgba(17, 24, 39, 0.4)',
+                    'radiusBase'     => '10px',
+                    'fontFamily'     => 'Inter',
+                ],
+                'class_name'   => 'visibloc-preset--shadcn-minimal',
+                'file'         => 'shadcn-minimal.css',
+            ],
+            'radix-structured' => [
+                'label'        => __( 'Radix Structured', 'visi-bloc-jlg' ),
+                'description'  => __( 'Palette violette structurée pour mettre en avant sliders, toggles et cartes empilées.', 'visi-bloc-jlg' ),
+                'inspiration'  => 'Radix UI',
+                'components'   => [
+                    __( 'Cartes à rayons progressifs', 'visi-bloc-jlg' ),
+                    __( 'Groupes de boutons segmentés', 'visi-bloc-jlg' ),
+                    __( 'Badges informatifs sans capitalisation', 'visi-bloc-jlg' ),
+                ],
+                'interactions' => [
+                    __( 'Focus ring violet soutenu', 'visi-bloc-jlg' ),
+                    __( 'Transitions sur les hover de cartes et sliders', 'visi-bloc-jlg' ),
+                ],
+                'tokens'       => [
+                    'surface'        => '#f9f8ff',
+                    'surfaceSubtle'  => '#f4f1ff',
+                    'borderSubtle'   => 'rgba(76, 29, 149, 0.12)',
+                    'borderStrong'   => 'rgba(76, 29, 149, 0.28)',
+                    'accent'         => '#6d28d9',
+                    'accentStrong'   => '#4c1d95',
+                    'shadowSubtle'   => '0 18px 46px -38px rgba(58, 27, 126, 0.45)',
+                    'shadowElevated' => '0 42px 120px -64px rgba(58, 27, 126, 0.5)',
+                    'radiusBase'     => '10px',
+                    'fontFamily'     => 'IBM Plex Sans',
+                ],
+                'class_name'   => 'visibloc-preset--radix-structured',
+                'file'         => 'radix-structured.css',
+            ],
+            'bootstrap-express' => [
+                'label'        => __( 'Bootstrap Express', 'visi-bloc-jlg' ),
+                'description'  => __( 'Réinterprétation moderne des codes Bootstrap pour une prise en main rapide.', 'visi-bloc-jlg' ),
+                'inspiration'  => 'Bootstrap',
+                'components'   => [
+                    __( 'Boutons pilules contrastés', 'visi-bloc-jlg' ),
+                    __( 'Cartes avec bordure bleutée', 'visi-bloc-jlg' ),
+                    __( 'Panneaux aux coins arrondis', 'visi-bloc-jlg' ),
+                ],
+                'interactions' => [
+                    __( 'Focus ring accentué de 4px', 'visi-bloc-jlg' ),
+                    __( 'Majuscules légères sur les boutons principaux', 'visi-bloc-jlg' ),
+                ],
+                'tokens'       => [
+                    'surface'        => '#ffffff',
+                    'surfaceSubtle'  => '#f8f9fa',
+                    'borderSubtle'   => 'rgba(13, 110, 253, 0.12)',
+                    'borderStrong'   => 'rgba(13, 110, 253, 0.28)',
+                    'accent'         => '#0d6efd',
+                    'accentStrong'   => '#0b5ed7',
+                    'shadowSubtle'   => '0 10px 30px -22px rgba(13, 110, 253, 0.4)',
+                    'shadowElevated' => '0 38px 90px -60px rgba(13, 110, 253, 0.35)',
+                    'radiusBase'     => '12px',
+                    'fontFamily'     => 'Helvetica Neue',
+                ],
+                'class_name'   => 'visibloc-preset--bootstrap-express',
+                'file'         => 'bootstrap-express.css',
+            ],
+            'semantic-harmony' => [
+                'label'        => __( 'Semantic Harmony', 'visi-bloc-jlg' ),
+                'description'  => __( 'Palette expressive aux accents bleu lagon reprenant les codes Semantic UI.', 'visi-bloc-jlg' ),
+                'inspiration'  => 'Semantic UI',
+                'components'   => [
+                    __( 'Badges et steps en capitales espacées', 'visi-bloc-jlg' ),
+                    __( 'Cartes aux dégradés radiaux', 'visi-bloc-jlg' ),
+                    __( 'Boutons massifs à ombres diffuses', 'visi-bloc-jlg' ),
+                ],
+                'interactions' => [
+                    __( 'Transitions douces sur les cartes', 'visi-bloc-jlg' ),
+                    __( 'Focus bleu cyan lumineux', 'visi-bloc-jlg' ),
+                ],
+                'tokens'       => [
+                    'surface'        => 'hsl(0 0% 100%)',
+                    'surfaceSubtle'  => 'hsl(210 40% 96%)',
+                    'borderSubtle'   => 'hsla(205, 60%, 40%, 0.18)',
+                    'borderStrong'   => 'hsla(205, 70%, 38%, 0.32)',
+                    'accent'         => 'hsl(205 80% 45%)',
+                    'accentStrong'   => 'hsl(205 85% 34%)',
+                    'shadowSubtle'   => '0 18px 52px -44px hsla(205, 70%, 32%, 0.55)',
+                    'shadowElevated' => '0 54px 140px -72px hsla(205, 70%, 32%, 0.5)',
+                    'radiusBase'     => '10px',
+                    'fontFamily'     => 'Lato',
+                ],
+                'class_name'   => 'visibloc-preset--semantic-harmony',
+                'file'         => 'semantic-harmony.css',
+            ],
+            'anime-kinetic' => [
+                'label'        => __( 'Anime Kinetic', 'visi-bloc-jlg' ),
+                'description'  => __( 'Preset vibrant avec dégradés et micro-animations inspirés d’Anime.js.', 'visi-bloc-jlg' ),
+                'inspiration'  => 'Anime.js',
+                'components'   => [
+                    __( 'Badges pulsés et lumineux', 'visi-bloc-jlg' ),
+                    __( 'Panneaux à fond animé', 'visi-bloc-jlg' ),
+                    __( 'Boutons CTA à gradient dynamique', 'visi-bloc-jlg' ),
+                ],
+                'interactions' => [
+                    __( 'Animations pulsées et comètes', 'visi-bloc-jlg' ),
+                    __( 'Gradients animés sur les boutons', 'visi-bloc-jlg' ),
+                ],
+                'tokens'       => [
+                    'surface'        => '#0f172a',
+                    'surfaceSubtle'  => 'rgba(15, 23, 42, 0.94)',
+                    'borderSubtle'   => 'rgba(56, 189, 248, 0.32)',
+                    'borderStrong'   => 'rgba(14, 165, 233, 0.48)',
+                    'accent'         => '#f97316',
+                    'accentStrong'   => '#22d3ee',
+                    'shadowSubtle'   => '0 18px 60px -50px rgba(14, 165, 233, 0.6)',
+                    'shadowElevated' => '0 68px 160px -90px rgba(79, 70, 229, 0.65)',
+                    'radiusBase'     => '14px',
+                    'fontFamily'     => 'Plus Jakarta Sans',
+                ],
+                'class_name'   => 'visibloc-preset--anime-kinetic',
+                'file'         => 'anime-kinetic.css',
+            ],
+        ];
+
+        $presets = [];
+
+        foreach ( $definitions as $slug => $data ) {
+            if ( ! is_string( $slug ) || '' === $slug ) {
+                continue;
+            }
+
+            $file = isset( $data['file'] ) ? (string) $data['file'] : '';
+            $file = ltrim( $file, '/' );
+
+            if ( '' === $file ) {
+                continue;
+            }
+
+            $relative_path = $base_dir . '/' . $file;
+            $handle        = 'visibloc-jlg-preset-' . str_replace( '_', '-', sanitize_key( $slug ) );
+            $stylesheet    = function_exists( 'visibloc_jlg_get_asset_url' )
+                ? visibloc_jlg_get_asset_url( $relative_path )
+                : '';
+            $version       = function_exists( 'visibloc_jlg_get_asset_version' )
+                ? visibloc_jlg_get_asset_version( $relative_path, $default_version )
+                : $default_version;
+
+            $presets[] = [
+                'slug'            => $slug,
+                'name'            => isset( $data['label'] ) ? (string) $data['label'] : $slug,
+                'description'     => isset( $data['description'] ) ? (string) $data['description'] : '',
+                'inspiration'     => isset( $data['inspiration'] ) ? (string) $data['inspiration'] : '',
+                'features'        => [
+                    'components'   => isset( $data['components'] ) && is_array( $data['components'] ) ? array_values( $data['components'] ) : [],
+                    'interactions' => isset( $data['interactions'] ) && is_array( $data['interactions'] ) ? array_values( $data['interactions'] ) : [],
+                ],
+                'tokens'          => isset( $data['tokens'] ) && is_array( $data['tokens'] ) ? $data['tokens'] : [],
+                'handle'          => $handle,
+                'className'       => isset( $data['class_name'] ) ? (string) $data['class_name'] : '',
+                'stylesheet'      => $stylesheet,
+                'stylesheet_path' => $relative_path,
+                'version'         => $version,
+            ];
+        }
+
+        return $presets;
+    }
+}
+
+if ( ! function_exists( 'visibloc_jlg_register_visual_preset_styles' ) ) {
+    /**
+     * Register the preset stylesheets so they can be enqueued on demand.
+     *
+     * @return void
+     */
+    function visibloc_jlg_register_visual_preset_styles() {
+        if ( ! function_exists( 'wp_register_style' ) ) {
+            return;
+        }
+
+        foreach ( visibloc_jlg_get_visual_presets_definitions() as $preset ) {
+            $handle    = isset( $preset['handle'] ) ? (string) $preset['handle'] : '';
+            $stylesheet = isset( $preset['stylesheet'] ) ? (string) $preset['stylesheet'] : '';
+            $version    = isset( $preset['version'] ) ? (string) $preset['version'] : '';
+
+            if ( '' === $handle || '' === $stylesheet ) {
+                continue;
+            }
+
+            wp_register_style( $handle, $stylesheet, [], $version );
+        }
+    }
+}
+
+if ( ! function_exists( 'visibloc_jlg_get_editor_visual_presets' ) ) {
+    /**
+     * Sanitize preset definitions for editor consumption.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    function visibloc_jlg_get_editor_visual_presets() {
+        $presets = [];
+
+        foreach ( visibloc_jlg_get_visual_presets_definitions() as $preset ) {
+            $presets[] = [
+                'slug'        => (string) ( $preset['slug'] ?? '' ),
+                'name'        => (string) ( $preset['name'] ?? '' ),
+                'description' => (string) ( $preset['description'] ?? '' ),
+                'inspiration' => (string) ( $preset['inspiration'] ?? '' ),
+                'features'    => isset( $preset['features'] ) && is_array( $preset['features'] ) ? $preset['features'] : [ 'components' => [], 'interactions' => [] ],
+                'tokens'      => isset( $preset['tokens'] ) && is_array( $preset['tokens'] ) ? $preset['tokens'] : [],
+                'handle'      => (string) ( $preset['handle'] ?? '' ),
+                'className'   => (string) ( $preset['className'] ?? '' ),
+                'stylesheet'  => (string) ( $preset['stylesheet'] ?? '' ),
+            ];
+        }
+
+        return $presets;
+    }
+}

--- a/visi-bloc-jlg/src/editor-styles.css
+++ b/visi-bloc-jlg/src/editor-styles.css
@@ -8,6 +8,7 @@
     --visibloc-radius-pill: 999px;
     --visibloc-shadow-subtle: 0 1px 2px rgba(15, 23, 42, 0.08);
     --visibloc-shadow-strong: 0 14px 30px -20px rgba(15, 23, 42, 0.55);
+    --visibloc-font-family: var(--wp-admin-font-family, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -18,6 +19,7 @@
         --visibloc-border-strong: rgba(148, 163, 184, 0.28);
         --visibloc-shadow-subtle: 0 1px 2px rgba(15, 23, 42, 0.6);
         --visibloc-shadow-strong: 0 18px 38px -18px rgba(15, 23, 42, 0.85);
+        --visibloc-font-family: var(--wp-admin-font-family, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
     }
 }
 
@@ -77,7 +79,7 @@
         var(--visibloc-badge-bg)
     );
     background-clip: padding-box;
-    font-family: var(--wp-admin-font-family, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
+    font-family: var(--visibloc-font-family, var(--wp-admin-font-family, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif));
     color: var(--visibloc-badge-foreground);
     box-shadow: 0 1px 0 rgba(15, 23, 42, 0.08), var(--visibloc-badge-shadow);
     max-width: 320px;

--- a/visi-bloc-jlg/tests/phpunit/integration/EditorAssetsTest.php
+++ b/visi-bloc-jlg/tests/phpunit/integration/EditorAssetsTest.php
@@ -165,6 +165,35 @@ class EditorAssetsTest extends TestCase {
         $this->assertSame( 1, $visibloc_test_counters['get_terms'] ?? 0 );
     }
 
+    public function test_visual_presets_definitions_are_available(): void {
+        $presets = visibloc_jlg_get_visual_presets_definitions();
+
+        $this->assertCount( 6, $presets );
+
+        foreach ( $presets as $preset ) {
+            $this->assertIsArray( $preset );
+            $this->assertArrayHasKey( 'slug', $preset );
+            $this->assertArrayHasKey( 'name', $preset );
+            $this->assertArrayHasKey( 'handle', $preset );
+            $this->assertArrayHasKey( 'stylesheet_path', $preset );
+            $this->assertNotSame( '', $preset['slug'] );
+            $this->assertNotSame( '', $preset['handle'] );
+            $this->assertStringEndsWith( '.css', $preset['stylesheet_path'] );
+        }
+
+        $editor = visibloc_jlg_get_editor_visual_presets();
+
+        $this->assertCount( 6, $editor );
+        foreach ( $editor as $preset ) {
+            $this->assertArrayHasKey( 'slug', $preset );
+            $this->assertArrayHasKey( 'name', $preset );
+            $this->assertArrayHasKey( 'tokens', $preset );
+            $this->assertArrayHasKey( 'features', $preset );
+            $this->assertIsArray( $preset['tokens'] );
+            $this->assertIsArray( $preset['features'] );
+        }
+    }
+
     public function test_editor_cache_can_be_cleared_explicitly(): void {
         global $visibloc_test_post_types, $visibloc_test_counters;
 


### PR DESCRIPTION
## Summary
- add themed CSS presets for the six documented design inspirations and tune shared typography variables
- expose preset metadata and stylesheet handles to WordPress via a new presets helper and updated asset bootstrap
- document the new preset assets and cover them with integration tests

## Testing
- composer test:phpunit

------
https://chatgpt.com/codex/tasks/task_e_68e62fdeea38832e80d60138e338946d