### PR TITLE
Centralize plugin version access and harden role switcher cookie parsing

### DIFF
--- a/visi-bloc-jlg/includes/admin-settings.php
+++ b/visi-bloc-jlg/includes/admin-settings.php
@@ -5,6 +5,7 @@ require_once __DIR__ . '/cache-constants.php';
 
 require_once __DIR__ . '/block-utils.php';
 require_once __DIR__ . '/fallback.php';
+require_once __DIR__ . '/plugin-meta.php';
 
 /**
  * Build the onboarding checklist items displayed on the help page.
@@ -640,7 +641,7 @@ function visibloc_jlg_get_settings_snapshot() {
         'debug_mode'       => ( 'on' === $debug_mode ) ? 'on' : 'off',
         'fallback'         => visibloc_jlg_get_fallback_settings(),
         'exported_at'      => gmdate( 'c' ),
-        'version'          => defined( 'VISIBLOC_JLG_VERSION' ) ? VISIBLOC_JLG_VERSION : 'unknown',
+        'version'          => visibloc_jlg_get_plugin_version(),
     ];
 }
 
@@ -2454,7 +2455,7 @@ function visibloc_jlg_clear_caches( $unused_post_id = null ) {
 
         $mobile_bp = $mobile_bp > 0 ? $mobile_bp : $default_mobile_bp;
         $tablet_bp = $tablet_bp > 0 ? $tablet_bp : $default_tablet_bp;
-        $version   = defined( 'VISIBLOC_JLG_VERSION' ) ? VISIBLOC_JLG_VERSION : '0.0.0';
+        $version   = visibloc_jlg_get_plugin_version();
 
         $bucket_keys_to_clear = [
             sprintf( '%s:%d:%d:%d', $version, 0, (int) $mobile_bp, (int) $tablet_bp ),

--- a/visi-bloc-jlg/includes/assets.php
+++ b/visi-bloc-jlg/includes/assets.php
@@ -5,11 +5,11 @@ if ( ! defined( 'VISIBLOC_JLG_MISSING_EDITOR_ASSETS_TRANSIENT' ) ) {
     define( 'VISIBLOC_JLG_MISSING_EDITOR_ASSETS_TRANSIENT', 'visibloc_jlg_missing_editor_assets' );
 }
 
-require_once __DIR__ . '/plugin-meta.php';
 require_once __DIR__ . '/cache-constants.php';
 require_once __DIR__ . '/datetime-utils.php';
 require_once __DIR__ . '/fallback.php';
 require_once __DIR__ . '/presets.php';
+require_once __DIR__ . '/plugin-meta.php';
 
 if ( ! function_exists( 'visibloc_jlg_path_join' ) ) {
     /**
@@ -89,11 +89,9 @@ if ( ! function_exists( 'visibloc_jlg_get_asset_version' ) ) {
             return (string) $default_version;
         }
 
-        return defined( 'VISIBLOC_JLG_VERSION' ) ? VISIBLOC_JLG_VERSION : '0.0.0';
+        return visibloc_jlg_get_plugin_version();
     }
 }
-
-visibloc_jlg_define_version_constant();
 
 if ( ! defined( 'VISIBLOC_JLG_EDITOR_DATA_CACHE_GROUP' ) ) {
     define( 'VISIBLOC_JLG_EDITOR_DATA_CACHE_GROUP', 'visibloc_jlg_editor_data' );
@@ -160,7 +158,7 @@ function visibloc_jlg_get_editor_data_cache_prefix() {
         return $prefix;
     }
 
-    $version = defined( 'VISIBLOC_JLG_VERSION' ) ? VISIBLOC_JLG_VERSION : '0.0.0';
+    $version = visibloc_jlg_get_plugin_version();
     $locale  = visibloc_jlg_get_editor_data_locale();
 
     $prefix = sprintf( '%s:%s', $version, $locale );
@@ -360,7 +358,7 @@ function visibloc_jlg_enqueue_public_styles() {
     $has_custom_breakpoints = ( $mobile_bp !== $default_mobile ) || ( $tablet_bp !== $default_tablet );
     $default_handle         = 'visibloc-jlg-device-visibility';
     $dynamic_handle         = 'visibloc-jlg-device-visibility-dynamic';
-    $style_version          = defined( 'VISIBLOC_JLG_VERSION' ) ? VISIBLOC_JLG_VERSION : '1.1';
+    $style_version          = visibloc_jlg_get_plugin_version();
 
     if ( $has_custom_breakpoints ) {
         wp_dequeue_style( $default_handle );
@@ -403,7 +401,7 @@ function visibloc_jlg_enqueue_admin_styles( $hook_suffix ) {
 
     visibloc_jlg_register_visual_preset_styles();
 
-    $style_version    = defined( 'VISIBLOC_JLG_VERSION' ) ? VISIBLOC_JLG_VERSION : '1.1';
+    $style_version    = visibloc_jlg_get_plugin_version();
 
     wp_enqueue_style(
         'visibloc-jlg-admin-responsive',
@@ -420,7 +418,7 @@ function visibloc_jlg_enqueue_admin_supported_blocks_script( $hook_suffix ) {
     }
 
     $script_relative_path  = 'assets/admin-supported-blocks.js';
-    $default_script_version = defined( 'VISIBLOC_JLG_VERSION' ) ? VISIBLOC_JLG_VERSION : '1.1';
+    $default_script_version = visibloc_jlg_get_plugin_version();
     $script_version        = visibloc_jlg_get_asset_version( $script_relative_path, $default_script_version );
 
     wp_enqueue_script(
@@ -439,7 +437,7 @@ function visibloc_jlg_enqueue_admin_navigation_script( $hook_suffix ) {
     }
 
     $script_relative_path   = 'assets/admin-nav.js';
-    $default_script_version = defined( 'VISIBLOC_JLG_VERSION' ) ? VISIBLOC_JLG_VERSION : '1.1';
+    $default_script_version = visibloc_jlg_get_plugin_version();
     $script_version         = visibloc_jlg_get_asset_version( $script_relative_path, $default_script_version );
 
     wp_enqueue_script(
@@ -458,7 +456,7 @@ function visibloc_jlg_enqueue_admin_recipes_script( $hook_suffix ) {
     }
 
     $script_relative_path   = 'assets/admin-recipes.js';
-    $default_script_version = defined( 'VISIBLOC_JLG_VERSION' ) ? VISIBLOC_JLG_VERSION : '1.1';
+    $default_script_version = visibloc_jlg_get_plugin_version();
     $script_version         = visibloc_jlg_get_asset_version( $script_relative_path, $default_script_version );
 
     wp_enqueue_script(
@@ -1480,7 +1478,7 @@ function visibloc_jlg_generate_device_visibility_css( $can_preview, $mobile_bp =
 
     $cache_group = VISIBLOC_JLG_DEVICE_CSS_CACHE_GROUP;
     $cache_key   = VISIBLOC_JLG_DEVICE_CSS_CACHE_KEY;
-    $version     = defined( 'VISIBLOC_JLG_VERSION' ) ? VISIBLOC_JLG_VERSION : '0.0.0';
+    $version     = visibloc_jlg_get_plugin_version();
     $bucket_key  = sprintf(
         '%s:%d:%d:%d',
         $version,

--- a/visi-bloc-jlg/includes/plugin-meta.php
+++ b/visi-bloc-jlg/includes/plugin-meta.php
@@ -84,3 +84,18 @@ if ( ! function_exists( 'visibloc_jlg_define_version_constant' ) ) {
     }
 }
 
+if ( ! function_exists( 'visibloc_jlg_get_plugin_version' ) ) {
+    /**
+     * Retrieve the plugin version ensuring the constant is initialized.
+     *
+     * @return string
+     */
+    function visibloc_jlg_get_plugin_version() {
+        if ( defined( 'VISIBLOC_JLG_VERSION' ) ) {
+            return VISIBLOC_JLG_VERSION;
+        }
+
+        return visibloc_jlg_define_version_constant();
+    }
+}
+

--- a/visi-bloc-jlg/includes/presets.php
+++ b/visi-bloc-jlg/includes/presets.php
@@ -1,6 +1,8 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) exit;
 
+require_once __DIR__ . '/plugin-meta.php';
+
 if ( ! function_exists( 'visibloc_jlg_get_visual_presets_definitions' ) ) {
     /**
      * Return the curated list of visual presets available for the UI.
@@ -14,7 +16,7 @@ if ( ! function_exists( 'visibloc_jlg_get_visual_presets_definitions' ) ) {
             return $presets;
         }
 
-        $default_version = defined( 'VISIBLOC_JLG_VERSION' ) ? VISIBLOC_JLG_VERSION : '1.1';
+        $default_version = visibloc_jlg_get_plugin_version();
         $base_dir        = 'assets/presets';
 
         $definitions = [

--- a/visi-bloc-jlg/includes/role-switcher.php
+++ b/visi-bloc-jlg/includes/role-switcher.php
@@ -6,6 +6,18 @@ if ( ! isset( $visibloc_jlg_real_user_id ) ) {
     $visibloc_jlg_real_user_id = null;
 }
 
+if ( ! function_exists( 'visibloc_jlg_get_plugin_version' ) ) {
+    $plugin_meta_path = __DIR__ . '/plugin-meta.php';
+
+    if ( ! file_exists( $plugin_meta_path ) ) {
+        $plugin_meta_path = dirname( __DIR__, 2 ) . '/includes/plugin-meta.php';
+    }
+
+    if ( file_exists( $plugin_meta_path ) ) {
+        require_once $plugin_meta_path;
+    }
+}
+
 if ( ! function_exists( 'visibloc_jlg_get_preview_role_from_cookie' ) ) {
     function visibloc_jlg_get_preview_role_from_cookie() {
         $cookie_name = 'visibloc_preview_role';
@@ -20,7 +32,13 @@ if ( ! function_exists( 'visibloc_jlg_get_preview_role_from_cookie' ) ) {
             return null;
         }
 
-        return sanitize_key( wp_unslash( $cookie_value ) );
+        $sanitized_value = sanitize_key( wp_unslash( $cookie_value ) );
+
+        if ( '' === $sanitized_value ) {
+            return null;
+        }
+
+        return $sanitized_value;
     }
 }
 
@@ -1048,7 +1066,7 @@ function visibloc_jlg_enqueue_role_switcher_frontend_assets() {
     }
 
     $plugin_main_file = __DIR__ . '/../visi-bloc-jlg.php';
-    $version          = defined( 'VISIBLOC_JLG_VERSION' ) ? VISIBLOC_JLG_VERSION : '1.0.0';
+    $version          = visibloc_jlg_get_plugin_version();
 
     wp_enqueue_style(
         'visibloc-jlg-role-switcher',

--- a/visi-bloc-jlg/visi-bloc-jlg.php
+++ b/visi-bloc-jlg/visi-bloc-jlg.php
@@ -44,7 +44,7 @@ if ( ! defined( 'VISIBLOC_JLG_PLUGIN_URL' ) ) {
 
 require_once __DIR__ . '/includes/plugin-meta.php';
 
-visibloc_jlg_define_version_constant();
+visibloc_jlg_get_plugin_version();
 
 require_once __DIR__ . '/autoload.php';
 require_once __DIR__ . '/includes/i18n-inline.php';


### PR DESCRIPTION
## Summary
- centralize plugin version retrieval through a shared helper and use it across bootstrap, assets, presets, and admin utilities to avoid version drift
- guard the role switcher loader when fetching plugin metadata and normalize the preview cookie to null when its contents are invalid
- refresh asset and cache version references to rely on the helper for consistent cache-busting

## Testing
- composer test:phpunit

------
https://chatgpt.com/codex/tasks/task_e_68e63a11556c832ea0b8d53037781e38