### PR TITLE
Refactor asset helpers and defaults

### DIFF
--- a/visi-bloc-jlg/includes/admin-settings.php
+++ b/visi-bloc-jlg/includes/admin-settings.php
@@ -7,6 +7,8 @@ require_once __DIR__ . '/block-utils.php';
 require_once __DIR__ . '/fallback.php';
 require_once __DIR__ . '/plugin-meta.php';
 
+visibloc_jlg_define_default_supported_blocks();
+
 /**
  * Build the onboarding checklist items displayed on the help page.
  *

--- a/visi-bloc-jlg/includes/block-utils.php
+++ b/visi-bloc-jlg/includes/block-utils.php
@@ -3,9 +3,9 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-if ( ! defined( 'VISIBLOC_JLG_DEFAULT_SUPPORTED_BLOCKS' ) ) {
-    define( 'VISIBLOC_JLG_DEFAULT_SUPPORTED_BLOCKS', [ 'core/group' ] );
-}
+require_once __DIR__ . '/plugin-meta.php';
+
+visibloc_jlg_define_default_supported_blocks();
 
 if ( ! function_exists( 'visibloc_jlg_normalize_block_names' ) ) {
     /**

--- a/visi-bloc-jlg/includes/plugin-meta.php
+++ b/visi-bloc-jlg/includes/plugin-meta.php
@@ -99,3 +99,29 @@ if ( ! function_exists( 'visibloc_jlg_get_plugin_version' ) ) {
     }
 }
 
+if ( ! function_exists( 'visibloc_jlg_define_default_supported_blocks' ) ) {
+    /**
+     * Ensure the default supported blocks constant is declared.
+     *
+     * @return array The list of default block slugs.
+     */
+    function visibloc_jlg_define_default_supported_blocks() {
+        if ( ! defined( 'VISIBLOC_JLG_DEFAULT_SUPPORTED_BLOCKS' ) ) {
+            define( 'VISIBLOC_JLG_DEFAULT_SUPPORTED_BLOCKS', [ 'core/group' ] );
+        }
+
+        return (array) VISIBLOC_JLG_DEFAULT_SUPPORTED_BLOCKS;
+    }
+}
+
+if ( ! function_exists( 'visibloc_jlg_get_default_supported_blocks' ) ) {
+    /**
+     * Retrieve the default supported blocks list.
+     *
+     * @return array
+     */
+    function visibloc_jlg_get_default_supported_blocks() {
+        return visibloc_jlg_define_default_supported_blocks();
+    }
+}
+

--- a/visi-bloc-jlg/includes/visibility-logic.php
+++ b/visi-bloc-jlg/includes/visibility-logic.php
@@ -3,6 +3,9 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 
 require_once __DIR__ . '/datetime-utils.php';
 require_once __DIR__ . '/fallback.php';
+require_once __DIR__ . '/plugin-meta.php';
+
+visibloc_jlg_define_default_supported_blocks();
 
 final class Visibloc_Jlg_Visibility_Decision {
     public $is_visible;

--- a/visi-bloc-jlg/package-lock.json
+++ b/visi-bloc-jlg/package-lock.json
@@ -10,9 +10,7 @@
       "devDependencies": {
         "@wordpress/e2e-test-utils-playwright": "^1.31.0",
         "@wordpress/env": "^9.2.0",
-        "@wordpress/scripts": "^26.0.0",
-        "hasown": "2.0.2",
-        "p-try": "3.0.0"
+        "@wordpress/scripts": "^26.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -16733,19 +16731,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/p-try": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-3.0.0.tgz",
-      "integrity": "sha512-nD1xrH3cV2epQsO8pv6p28i/TdrzJQ5g73c41a+fu+3uhABdf7xujY58ebIuSrOQYxNb8WqNDpX6HjYl8P0KfQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/pac-proxy-agent": {

--- a/visi-bloc-jlg/package.json
+++ b/visi-bloc-jlg/package.json
@@ -10,8 +10,6 @@
   "devDependencies": {
     "@wordpress/e2e-test-utils-playwright": "^1.31.0",
     "@wordpress/env": "^9.2.0",
-    "@wordpress/scripts": "^26.0.0",
-    "hasown": "2.0.2",
-    "p-try": "3.0.0"
+    "@wordpress/scripts": "^26.0.0"
   }
 }

--- a/visi-bloc-jlg/src/Plugin.php
+++ b/visi-bloc-jlg/src/Plugin.php
@@ -231,8 +231,8 @@ class Plugin {
      * Ensure the default supported blocks constant is declared.
      */
     protected function define_default_supported_blocks() {
-        if ( ! defined( 'VISIBLOC_JLG_DEFAULT_SUPPORTED_BLOCKS' ) ) {
-            define( 'VISIBLOC_JLG_DEFAULT_SUPPORTED_BLOCKS', [ 'core/group' ] );
-        }
+        require_once $this->plugin_dir . '/includes/plugin-meta.php';
+
+        visibloc_jlg_define_default_supported_blocks();
     }
 }


### PR DESCRIPTION
## Summary
- centralize the default supported blocks definition through plugin-meta helpers
- replace the custom asset path joiner with WordPress helpers and expose URL fallbacks
- drop unused frontend devDependencies from the build configuration

## Testing
- composer test:phpunit

------
https://chatgpt.com/codex/tasks/task_e_68e66b86cac4832eb59c80a2132d9e16