### PR TITLE
Use Playwright runner for E2E tests

### DIFF
--- a/visi-bloc-jlg/package.json
+++ b/visi-bloc-jlg/package.json
@@ -3,9 +3,10 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
+    "wp-env": "wp-env",
     "build": "wp-scripts build",
-    "test:e2e": "wp-scripts test-e2e",
-    "test:e2e:debug": "PWDEBUG=1 wp-scripts test-e2e -- --debug"
+    "test:e2e": "playwright test --config=playwright.config.js",
+    "test:e2e:debug": "PWDEBUG=1 playwright test --config=playwright.config.js --debug"
   },
   "devDependencies": {
     "@wordpress/e2e-test-utils-playwright": "^1.31.0",

--- a/visi-bloc-jlg/playwright.config.js
+++ b/visi-bloc-jlg/playwright.config.js
@@ -1,0 +1,8 @@
+const path = require( 'path' );
+const baseConfig = require( '@wordpress/scripts/config/playwright.config.js' );
+
+module.exports = {
+    ...baseConfig,
+    testDir: path.resolve( __dirname, 'tests/e2e' ),
+    testMatch: [ '**/*.spec.js' ],
+};


### PR DESCRIPTION
## Summary
- add a Playwright configuration that targets the plugin's e2e specs directory
- run e2e tests with the Playwright CLI and expose a wp-env helper script so the base config can start WordPress

## Testing
- npm run test:e2e *(fails: requires Docker for wp-env)*

------
https://chatgpt.com/codex/tasks/task_e_68e66e5a99c0832eb9fc1e426f2ab53e