### PR TITLE
Add caching for supported block lookups

### DIFF
--- a/visi-bloc-jlg/includes/admin-settings.php
+++ b/visi-bloc-jlg/includes/admin-settings.php
@@ -334,6 +334,10 @@ function visibloc_jlg_update_supported_blocks( $block_names ) {
 
     update_option( 'visibloc_supported_blocks', $normalized_blocks );
 
+    if ( function_exists( 'visibloc_jlg_invalidate_supported_blocks_cache' ) ) {
+        visibloc_jlg_invalidate_supported_blocks_cache();
+    }
+
     if ( $has_list_changed ) {
         visibloc_jlg_rebuild_group_block_summary_index();
     }
@@ -2419,6 +2423,10 @@ function visibloc_jlg_clear_caches( $unused_post_id = null ) {
 
     if ( function_exists( 'visibloc_jlg_clear_editor_data_cache' ) ) {
         visibloc_jlg_clear_editor_data_cache();
+    }
+
+    if ( function_exists( 'visibloc_jlg_invalidate_supported_blocks_cache' ) ) {
+        visibloc_jlg_invalidate_supported_blocks_cache();
     }
 
     delete_transient( 'visibloc_hidden_posts' );

--- a/visi-bloc-jlg/tests/phpunit/bootstrap.php
+++ b/visi-bloc-jlg/tests/phpunit/bootstrap.php
@@ -1094,12 +1094,20 @@ function get_edit_post_link( $post_id ) {
 function update_option( $name, $value, $autoload = null ) {
     $GLOBALS['visibloc_test_options'][ $name ] = $value;
 
+    if ( 'visibloc_supported_blocks' === $name && function_exists( 'visibloc_jlg_invalidate_supported_blocks_cache' ) ) {
+        visibloc_jlg_invalidate_supported_blocks_cache();
+    }
+
     return true;
 }
 
 function delete_option( $name ) {
     if ( isset( $GLOBALS['visibloc_test_options'][ $name ] ) ) {
         unset( $GLOBALS['visibloc_test_options'][ $name ] );
+    }
+
+    if ( 'visibloc_supported_blocks' === $name && function_exists( 'visibloc_jlg_invalidate_supported_blocks_cache' ) ) {
+        visibloc_jlg_invalidate_supported_blocks_cache();
     }
 
     return true;


### PR DESCRIPTION
## Summary
- add runtime and object cache helpers for the supported blocks list with automatic invalidation hooks
- ensure admin helpers clear the supported blocks cache when options or caches change
- update the PHPUnit bootstrap and integration tests to cover cache refresh scenarios

## Testing
- composer test:phpunit

------
https://chatgpt.com/codex/tasks/task_e_68e67043fd9c832e8a98c73a4c25efe6