### PR TITLE
Fix fallback country input state sync

### DIFF
--- a/visi-bloc-jlg/src/index.js
+++ b/visi-bloc-jlg/src/index.js
@@ -1511,20 +1511,23 @@ const parseCountryTokensFromString = (input) => {
 };
 
 const CountryTokensTextControl = ({ value, onChange, label, placeholder }) => {
-    const sanitizedTokens = useMemo(() => {
+    const sanitizedTokensString = useMemo(() => {
         if (!Array.isArray(value)) {
-            return [];
+            return '';
         }
 
         return value
             .map((token) => normalizeCountryCode(token))
-            .filter(Boolean);
+            .filter(Boolean)
+            .join(', ');
     }, [value]);
-    const [inputValue, setInputValue] = useState(sanitizedTokens.join(', '));
+    const [inputValue, setInputValue] = useState(sanitizedTokensString);
 
     useEffect(() => {
-        setInputValue(sanitizedTokens.join(', '));
-    }, [sanitizedTokens]);
+        setInputValue((currentValue) =>
+            currentValue === sanitizedTokensString ? currentValue : sanitizedTokensString,
+        );
+    }, [sanitizedTokensString]);
 
     const handleChange = useCallback(
         (nextValue) => {


### PR DESCRIPTION
## Summary
- stop the fallback country input from reseting its value during typing
- only resync the local input state when the sanitized value string actually changes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f261ef00e4832ebf5ee76b3fdf3b55