### PR TITLE
Fix schedule timezone parsing and audit log null handling

### DIFF
--- a/visi-bloc-jlg/includes/admin-settings.php
+++ b/visi-bloc-jlg/includes/admin-settings.php
@@ -9,6 +9,7 @@ require_once __DIR__ . '/fallback.php';
 require_once __DIR__ . '/utils.php';
 require_once __DIR__ . '/plugin-meta.php';
 require_once __DIR__ . '/insights.php';
+require_once __DIR__ . '/datetime-utils.php';
 
 visibloc_jlg_define_default_supported_blocks();
 
@@ -131,9 +132,9 @@ function visibloc_jlg_normalize_schedule_timestamp( $value ) {
         return $timestamp > 0 ? $timestamp : null;
     }
 
-    $timestamp = strtotime( (string) $value );
+    $timestamp = visibloc_jlg_parse_schedule_datetime( (string) $value, 'site' );
 
-    return false !== $timestamp ? $timestamp : null;
+    return null !== $timestamp ? $timestamp : null;
 }
 
 // Notifications logic replaced below.

--- a/visi-bloc-jlg/includes/audit-log.php
+++ b/visi-bloc-jlg/includes/audit-log.php
@@ -177,24 +177,37 @@ function visibloc_jlg_record_audit_event( $event_type, array $payload = [] ) {
 
     $created_at = function_exists( 'current_time' ) ? current_time( 'mysql' ) : gmdate( 'Y-m-d H:i:s' );
 
+    $data = [
+        'event_type' => $normalized_event,
+        'message'    => $message,
+        'created_at' => $created_at,
+    ];
+
+    $formats = [
+        '%s',
+        '%s',
+        '%s',
+    ];
+
+    if ( null !== $context_json ) {
+        $data['context'] = $context_json;
+        $formats[]       = '%s';
+    }
+
+    if ( $user_id > 0 ) {
+        $data['user_id'] = $user_id;
+        $formats[]       = '%d';
+    }
+
+    if ( $post_id > 0 ) {
+        $data['post_id'] = $post_id;
+        $formats[]       = '%d';
+    }
+
     $inserted = $wpdb->insert(
         visibloc_jlg_get_audit_log_table_name(),
-        [
-            'event_type' => $normalized_event,
-            'message'    => $message,
-            'context'    => $context_json,
-            'user_id'    => $user_id > 0 ? $user_id : null,
-            'post_id'    => $post_id > 0 ? $post_id : null,
-            'created_at' => $created_at,
-        ],
-        [
-            '%s',
-            '%s',
-            '%s',
-            '%d',
-            '%d',
-            '%s',
-        ]
+        $data,
+        $formats
     );
 
     return false !== $inserted;


### PR DESCRIPTION
## Summary
- ensure schedule timestamps parsed with the site timezone by reusing existing datetime helpers
- prevent audit log inserts from coercing missing user/post IDs to zero by building insert data dynamically

## Testing
- `composer run test:phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68f4d681d344832ea20ee89553638958